### PR TITLE
WIZ_TIMENOTIFY disconnect in Release mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Makefile
 *.o
 *.dSYM
 *.exp
+Server/shared/Debug/shared.lib

--- a/Client/WarFare/UILogin.cpp
+++ b/Client/WarFare/UILogin.cpp
@@ -149,6 +149,16 @@ bool CUILogIn::Load(HANDLE hFile)
 		m_pGroup_ServerList->SetVisible(false);
 	}
 
+
+#ifdef _DEBUG
+	/*
+		@Demircivi
+		Laziness. I don't want to type userName and password every time :D.
+	*/
+
+	m_pEdit_id->SetString("demircivi");
+	m_pEdit_pw->SetString("test");
+#endif
 	return true;
 }
 

--- a/Server/GameServer/User.cpp
+++ b/Server/GameServer/User.cpp
@@ -287,6 +287,8 @@ bool CUser::HandlePacket(Packet & pkt)
 	case WIZ_GAMESTART:
 		GameStart(pkt);
 		break;
+	case WIZ_TIMENOTIFY: // @Demircivi: added this case in order to fix disconnecting because of ping packets which are sent by the Client.
+		break;
 	case WIZ_SERVER_INDEX:
 		SendServerIndex();
 		break;


### PR DESCRIPTION
Server doesn't allow user to send unhandled packets in Release mode,
since the Client sends WIZ_TIMENOTIFY packet periodically, we have to
allow it in Server side.