### PR TITLE
Camera now only turns if window has mouse focus.

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -1117,20 +1117,23 @@ void CGameProcMain::ProcessLocalInput(uint32_t dwMouseFlags)
 	//	s_pLocalInput->MouseSetPos(ptPrev_RB.x+x, ptPrev_RB.y+y);
 	//}
 
+
 	// Moves camera when mouse is on the borders of the screen. For both X & Y
-	// SavvyNik - Why was this commented out?
+	// Now checking to make sure game window has focus of mouse
 	if (!(dwMouseFlags & MOUSE_RBDOWN)) {
-		float fRotY = 0, fRotX = 0;
-		if (0 == ptCur.x) fRotY = -2.0f;
-		else if ((CN3Base::s_CameraData.vp.Width - 1) == ptCur.x) fRotY = 2.0f;
-		if (0 == ptCur.y) fRotX = -1.0f;
-		else if ((CN3Base::s_CameraData.vp.Height - 1) == ptCur.y) fRotX = 1.0f;
-		if (fRotY)
-		{
-			if (VP_THIRD_PERSON == s_pEng->ViewPoint()) s_pEng->CameraYawAdd(fRotY);
-			else s_pPlayer->RotAdd(fRotY);
+		if (CGameProcedure::s_bWindowHasMouseFocus) {
+			float fRotY = 0, fRotX = 0;
+			if (0 == ptCur.x) fRotY = -2.0f;
+			else if ((CN3Base::s_CameraData.vp.Width - 1) == ptCur.x) fRotY = 2.0f;
+			if (0 == ptCur.y) fRotX = -1.0f;
+			else if ((CN3Base::s_CameraData.vp.Height - 1) == ptCur.y) fRotX = 1.0f;
+			if (fRotY)
+			{
+				if (VP_THIRD_PERSON == s_pEng->ViewPoint()) s_pEng->CameraYawAdd(fRotY);
+				else s_pPlayer->RotAdd(fRotY);
+			}
+			if (fRotX && VP_THIRD_PERSON != s_pEng->ViewPoint()) s_pEng->CameraPitchAdd(fRotX);
 		}
-		if (fRotX && VP_THIRD_PERSON != s_pEng->ViewPoint()) s_pEng->CameraPitchAdd(fRotX);
 	}
 
 

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -1117,23 +1117,20 @@ void CGameProcMain::ProcessLocalInput(uint32_t dwMouseFlags)
 	//	s_pLocalInput->MouseSetPos(ptPrev_RB.x+x, ptPrev_RB.y+y);
 	//}
 
-
 	// Moves camera when mouse is on the borders of the screen. For both X & Y
-	// Now checking to make sure game window has focus of mouse
+	// SavvyNik - Why was this commented out?
 	if (!(dwMouseFlags & MOUSE_RBDOWN)) {
-		if (CGameProcedure::s_bWindowHasMouseFocus) {
-			float fRotY = 0, fRotX = 0;
-			if (0 == ptCur.x) fRotY = -2.0f;
-			else if ((CN3Base::s_CameraData.vp.Width - 1) == ptCur.x) fRotY = 2.0f;
-			if (0 == ptCur.y) fRotX = -1.0f;
-			else if ((CN3Base::s_CameraData.vp.Height - 1) == ptCur.y) fRotX = 1.0f;
-			if (fRotY)
-			{
-				if (VP_THIRD_PERSON == s_pEng->ViewPoint()) s_pEng->CameraYawAdd(fRotY);
-				else s_pPlayer->RotAdd(fRotY);
-			}
-			if (fRotX && VP_THIRD_PERSON != s_pEng->ViewPoint()) s_pEng->CameraPitchAdd(fRotX);
+		float fRotY = 0, fRotX = 0;
+		if (0 == ptCur.x) fRotY = -2.0f;
+		else if ((CN3Base::s_CameraData.vp.Width - 1) == ptCur.x) fRotY = 2.0f;
+		if (0 == ptCur.y) fRotX = -1.0f;
+		else if ((CN3Base::s_CameraData.vp.Height - 1) == ptCur.y) fRotX = 1.0f;
+		if (fRotY)
+		{
+			if (VP_THIRD_PERSON == s_pEng->ViewPoint()) s_pEng->CameraYawAdd(fRotY);
+			else s_pPlayer->RotAdd(fRotY);
 		}
+		if (fRotX && VP_THIRD_PERSON != s_pEng->ViewPoint()) s_pEng->CameraPitchAdd(fRotX);
 	}
 
 

--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -103,9 +103,6 @@ bool CGameProcedure::s_bKeyPressed = false;	//키가 올라갔을때 ui에서 해당하는 조
 // NOTE: adding boolean to check if window has focus or not
 bool CGameProcedure::s_bIsWindowInFocus = true;
 
-// NOTE: added a bool for whether window has mouse focus or not
-bool CGameProcedure::s_bWindowHasMouseFocus = true;
-
 CGameProcedure::CGameProcedure()
 {
 	m_bCursorLocked = false;

--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -103,6 +103,9 @@ bool CGameProcedure::s_bKeyPressed = false;	//키가 올라갔을때 ui에서 해당하는 조
 // NOTE: adding boolean to check if window has focus or not
 bool CGameProcedure::s_bIsWindowInFocus = true;
 
+// NOTE: added a bool for whether window has mouse focus or not
+bool CGameProcedure::s_bWindowHasMouseFocus = true;
+
 CGameProcedure::CGameProcedure()
 {
 	m_bCursorLocked = false;

--- a/Client/WarFare/GameProcedure.h
+++ b/Client/WarFare/GameProcedure.h
@@ -104,6 +104,7 @@ public:
 
 	// NOTE: adding boolean to check if window has focus or not
 	static bool		s_bIsWindowInFocus;
+	static bool		s_bWindowHasMouseFocus;
 
 public:
 	static std::string MessageBoxPost(const std::string& szMsg, const std::string& szTitle, int iStyle, e_Behavior eBehavior = BEHAVIOR_NOTHING);

--- a/Client/WarFare/GameProcedure.h
+++ b/Client/WarFare/GameProcedure.h
@@ -104,7 +104,6 @@ public:
 
 	// NOTE: adding boolean to check if window has focus or not
 	static bool		s_bIsWindowInFocus;
-	static bool		s_bWindowHasMouseFocus;
 
 public:
 	static std::string MessageBoxPost(const std::string& szMsg, const std::string& szTitle, int iStyle, e_Behavior eBehavior = BEHAVIOR_NOTHING);

--- a/Client/WarFare/LocalInput.cpp
+++ b/Client/WarFare/LocalInput.cpp
@@ -265,6 +265,12 @@ void CLocalInput::Tick(void) {
 					case SDL_WINDOWEVENT_FOCUS_LOST:
 						CGameProcedure::s_bIsWindowInFocus = false;
 						break;
+					case SDL_WINDOWEVENT_ENTER:
+						CGameProcedure::s_bWindowHasMouseFocus = true;
+						break;
+					case SDL_WINDOWEVENT_LEAVE:
+						CGameProcedure::s_bWindowHasMouseFocus = false;
+						break;
 				}
 			} break;
 

--- a/Client/WarFare/LocalInput.cpp
+++ b/Client/WarFare/LocalInput.cpp
@@ -265,12 +265,6 @@ void CLocalInput::Tick(void) {
 					case SDL_WINDOWEVENT_FOCUS_LOST:
 						CGameProcedure::s_bIsWindowInFocus = false;
 						break;
-					case SDL_WINDOWEVENT_ENTER:
-						CGameProcedure::s_bWindowHasMouseFocus = true;
-						break;
-					case SDL_WINDOWEVENT_LEAVE:
-						CGameProcedure::s_bWindowHasMouseFocus = false;
-						break;
 				}
 			} break;
 


### PR DESCRIPTION
Added a bool to check if the game window has mouse focus from an SDL event.  I also put conditional around the rotation of the camera in the case that a user moves to the edge of the screen with their mouse. Now the character will no longer rotate camera if they leave the game window with their mouse.