### PR TITLE
implements minimap-zoom, cleaned up blinking magic, adds Quest/PUS-buttons

### DIFF
--- a/Client/WarFare/UIStateBar.h
+++ b/Client/WarFare/UIStateBar.h
@@ -47,6 +47,8 @@ protected:
 	CN3UIImage*		m_pImage_Map; // 이 이미지에 미니맵 텍스처를 적용시킨다..
 	CN3UIButton*	m_pBtn_ZoomIn;
 	CN3UIButton*	m_pBtn_ZoomOut;
+	CN3UIButton*	m_pBtn_Quest;
+	CN3UIButton*	m_pBtn_Power;
 
 	// NOTE(srmeier): new components
 	CN3UIString*	m_pText_FPS;
@@ -56,6 +58,7 @@ protected:
 	float			m_fMapSizeZ;
 	float			m_fYawPlayer;
 	__Vector3		m_vPosPlayer;
+	__Vector3		m_vViewPos;
 
 	__VertexTransformedColor	m_vArrows[6]; // 플레이어 위치 화살표..
 	std::list<__PositionInfo>	m_Positions;


### PR DESCRIPTION
- implemented the zoom buttons
- added minimap-clamping (no info outside the map, no looking outside the map)
- added basic code for future handling of the QuestHelper/PowerupStore-Buttons
- cleaned up the blinking code for expiring magic

Zoomlevels and steps can be kept as is or modified to match the official values if someone finds out.
Could not check as minimap-zooming is broken/not implemented in the binary client either.