### PR TITLE
Resolves issue #102

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -5795,8 +5795,11 @@ void CGameProcMain::ParseChattingCommand(const std::string& szCmd)
 		break;
 
 		default:
-			break;
+		break;
 	} // end of switch(eCmd)
+
+	// Clears out the strings from the szCmds so we won't re-send same values on the next command execution.
+	memset(szCmds, 0, sizeof(szCmds));
 }
 
 void CGameProcMain::UpdateUI_PartyOrForceButtons()


### PR DESCRIPTION
Simply clears out the old values of the string array for each time command is executed so it won't re-send the same values.