### PR TITLE
Error on using skill points to assasin on rogue and passion on warrior.

### DIFF
--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -573,7 +573,8 @@ void CUISkillTreeDlg::PointPushUpButton(int iValue)
 				break;
 		}
 	}
-
+	// WHY ROGUES CANT POINT TO ASSASIN - WHY WARRIORS CANT POINT TO PASSION ?
+	/*
 	if (iValue == 7)
 	{
 		switch ( CGameBase::s_pPlayer->m_InfoBase.eNation )
@@ -641,6 +642,7 @@ void CUISkillTreeDlg::PointPushUpButton(int iValue)
 				break;
 		}
 	}
+	*/
 
 	switch(iValue)	
 	{


### PR DESCRIPTION
Using skill points to assasin on rogue and passion on warrior