### PR TITLE
There is an error when you open sundries, page 2 and mouse hover Guar…

### DIFF
--- a/Client/WarFare/UIImageTooltipDlg.cpp
+++ b/Client/WarFare/UIImageTooltipDlg.cpp
@@ -903,7 +903,7 @@ int	CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill* spItem, bo
 				m_pStr[iIndex]->SetColor(m_CWhite);
 			else
 				m_pStr[iIndex]->SetColor(m_CRed);
-			sprintf(szBuff, szStr.c_str(), spItem->pItemBasic->byNeedTitle+spItem->pItemExt->siNeedTitle);
+			sprintf(szBuff, szStr.c_str(), std::to_string(spItem->pItemBasic->byNeedTitle+spItem->pItemExt->siNeedTitle).c_str());
 			m_pstdstr[iIndex] = szBuff;
 			iIndex++;
 		}


### PR DESCRIPTION
…dian Items then unhandled exception happens.

I try to fix it;
When client try to show tooltips of items icons which has attribute 'need title', IDS_TOOLTIP_NEEDTITLE loads format of string that has '%s' as input parameter.
This change confirms parameter need to be string. But i dont know that the output string is correct.