### PR TITLE
Skill icons which not available

### DIFF
--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1363,7 +1363,7 @@ stop:
 	spSkill->pUIIcon->SetTex(spSkill->szIconFN);
 	spSkill->pUIIcon->SetUVRect(0,0,1,1);
 	spSkill->pUIIcon->SetUIType(UI_TYPE_ICON);
-	spSkill->pUIIcon->SetStyle(UISTYLE_DISABLE_SKILL);
+	spSkill->pUIIcon->SetStyle(UISTYLE_ICON_SKILL);
 
 	CN3UIArea* pArea = NULL;
 	pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_TREE, j);

--- a/Client/WarFare/UISkillTreeDlg.h
+++ b/Client/WarFare/UISkillTreeDlg.h
@@ -56,7 +56,7 @@ protected:
 	void				AllClearImageByName(const std::string& szFN, bool bTrueOrNot);
 	RECT				GetSampleRect();
 	void				PageButtonInitialize();
-
+	bool				CheckSkillCanBeUse(__TABLE_UPC_SKILL* pUSkill);
 public:
 	void SetVisible(bool bVisible);
 	CUISkillTreeDlg();
@@ -78,7 +78,7 @@ public:
 	__IconItemSkill*	GetHighlightIconItem(CN3UIIcon* pUIIcon);
 	int					GetSkilliOrder(__IconItemSkill* spSkill);
 
-	void				AddSkillToPage(__TABLE_UPC_SKILL* pUSkill, int iOffset = 0);
+	void				AddSkillToPage(__TABLE_UPC_SKILL* pUSkill, int iOffset = 0, bool bHasLevelToUse = true);
 
 	void				SetPageInIconRegion(int iKindOf, int iPageNum);		// 아이콘 역역에서 현재 페이지 설정..
 	void				SetPageInCharRegion();								// 문자 역역에서 현재 페이지 설정..


### PR DESCRIPTION
About Skill Icons which are not available
In skill tree dialog, there are no icons for skills which not available on our level
I try to implement it, also i create new function for checking the skill if its available on our current level, when fires right click on icon (for put it hot key dialog).
I dont know this is the right and easiest way.