### PR TITLE
Remove deprecated std::binary_function and minor cleanup in __FriendsInfo and __GameServerInfo structs

### DIFF
--- a/Client/WarFare/UILogin.h
+++ b/Client/WarFare/UILogin.h
@@ -14,20 +14,30 @@
 
 #include "N3UIBase.h"
 
-struct __GameServerInfo : public std::binary_function<__GameServerInfo, __GameServerInfo, bool>
+struct __GameServerInfo
 {
-	std::string szName;
-	std::string szIP;
-	int	iConcurrentUserCount;
+	std::string	szName;
+	std::string	szIP;
+	int			iConcurrentUserCount;
 
-	void Init() { szName.clear(); szIP.clear(); iConcurrentUserCount = 0; }
-	bool operator () (const __GameServerInfo& x, const __GameServerInfo& y) const 
+	void Init()
+	{
+		szName.clear();
+		szIP.clear();
+		iConcurrentUserCount = 0;
+	}
+
+	bool operator () (const __GameServerInfo& x, const __GameServerInfo& y) const
 	{
 		return (x.iConcurrentUserCount >= y.iConcurrentUserCount);
 	}
 
-	__GameServerInfo() { this->Init(); };
-	__GameServerInfo(const std::string szName2, const std::string szIP2, int iConcurrentUserCount2)
+	__GameServerInfo()
+	{
+		Init();
+	}
+
+	__GameServerInfo(const std::string& szName2, const std::string& szIP2, int iConcurrentUserCount2)
 	{
 		szName = szName2;
 		szIP = szIP2;

--- a/Client/WarFare/UIVarious.h
+++ b/Client/WarFare/UIVarious.h
@@ -189,20 +189,30 @@ public:
 	//void	MsgSend_DutyAppoint(e_KnightsDuty eDuty);
 };
 
-struct __FriendsInfo : public std::binary_function<__FriendsInfo, __FriendsInfo, bool>// 기사 단원 정보..
+struct __FriendsInfo // 기사 단원 정보..
 {
-	std::string		szName;
-	int				iID; // ID
-	bool			bOnLine; // 접속했나?
-	bool			bIsParty; // 파티 플레이중인가?
+	std::string	szName;
+	int			iID; // ID
+	bool		bOnLine; // 접속했나?
+	bool		bIsParty; // 파티 플레이중인가?
 
-	void Init() { szName = ""; iID = -1; bOnLine = false; bIsParty = false; }
-	bool operator () (const __FriendsInfo& x, const __FriendsInfo& y) const 
+	void Init()
+	{
+		szName = "";
+		iID = -1;
+		bOnLine = false;
+		bIsParty = false;
+	}
+
+	bool operator () (const __FriendsInfo& x, const __FriendsInfo& y) const
 	{
 		return (x.szName >= y.szName);
 	}
 
-	__FriendsInfo() { this->Init(); }
+	__FriendsInfo()
+	{
+		Init();
+	}
 };
 
 typedef std::map<std::string, __FriendsInfo>::iterator it_FI;


### PR DESCRIPTION
Remove deprecated std::binary_function and minor cleanup in __FriendsInfo and __GameServerInfo structs

 * Resolves compilation error with VS2022 toolset (v143) due to removal of std::binary_function