### PR TITLE
Account logout fix

### DIFF
--- a/Server/GameServer/DBAgent.cpp
+++ b/Server/GameServer/DBAgent.cpp
@@ -1482,16 +1482,19 @@ void CDBAgent::AccountLogout(
 	if (dbCommand.get() == nullptr)
 		return;
 
+
 	int iCode = 0;
-	uint8_t bRet = 0;
+	uint8_t bRet1 = 0;
+	uint8_t bRet2 = 0;
 
-	dbCommand->AddParameter(SQL_PARAM_INPUT, strAccountID.c_str(), strAccountID.length());
-	dbCommand->AddParameter(SQL_PARAM_OUTPUT, &bRet);
+	dbCommand->AddParameter(SQL_PARAM_INPUT, strAccountID.c_str(), strAccountID.length()); // @AccountID
+	dbCommand->AddParameter(SQL_PARAM_INPUT, &iCode);                                      // @LogoutCode
+	dbCommand->AddParameter(SQL_PARAM_OUTPUT, &bRet1);                                     // @nRet
+	dbCommand->AddParameter(SQL_PARAM_OUTPUT, &bRet2);                                     // @nRet2
 
-	if (!dbCommand->Execute(string_format(
-		_T("{CALL ACCOUNT_LOGOUT(?, %d, ?)}"),
-		iCode)))
+	if (!dbCommand->Execute(_T("{CALL ACCOUNT_LOGOUT(?, ?, ?, ?)}")))
 		ReportSQLError(m_AccountDB->GetError());
+
 }
 
 void CDBAgent::UpdateConCurrentUserCount(


### PR DESCRIPTION
issue : cannot login same account after logging out the game because DB call does not work as intended. sp_help checking table in database shows it expects 4 parameters instead of 3. This commit aiming the solve the problem, now logged out accounts can login back without closing and reopening server.