### PR TITLE
fix for skill drag drop from skill tree to hotkey bar

### DIFF
--- a/Client/WarFare/UIHotKeyDlg.cpp
+++ b/Client/WarFare/UIHotKeyDlg.cpp
@@ -557,28 +557,22 @@ int	CUIHotKeyDlg::GetAreaiOrder()
 
 bool CUIHotKeyDlg::IsSelectedSkillInRealIconArea()
 {
-	// search for area first.
-	CN3UIArea* pArea;
-	bool bFound = false;
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
-	int index = 1;
-	for( int i = 0; i < MAX_SKILL_IN_HOTKEY; i++ )
+	for (int i = 0; i < MAX_SKILL_IN_HOTKEY; i++)
 	{
-		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_HOTKEY, i);
-		if (pArea && pArea->IsIn(ptCur.x, ptCur.y))
-		{
-			bFound = true;
-			index = i;
-			break;
-		}
+		CN3UIArea* pArea = GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_HOTKEY, i);
+		if (pArea == nullptr
+			|| !pArea->IsIn(ptCur.x, ptCur.y))
+			continue;
+
+		if (m_sSkillSelectInfo.pSkillDoneInfo == nullptr)
+			return false;
+
+		SetReceiveSelectedSkill(i);
+		return true;
 	}
 
-	if (!bFound) return false;
-	if (!CN3UIWndBase::m_sSkillSelectInfo.pSkillDoneInfo) return false;
-	
-	SetReceiveSelectedSkill(index);
-
-	return bFound;
+	return false;
 }
 
 bool CUIHotKeyDlg::GetEmptySlotIndex(int &iIndex)

--- a/Client/WarFare/UIHotKeyDlg.cpp
+++ b/Client/WarFare/UIHotKeyDlg.cpp
@@ -557,24 +557,26 @@ int	CUIHotKeyDlg::GetAreaiOrder()
 
 bool CUIHotKeyDlg::IsSelectedSkillInRealIconArea()
 {
-	// 먼저 Area를 검색한다..
+	// search for area first.
 	CN3UIArea* pArea;
 	bool bFound = false;
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
-
+	int index = 1;
 	for( int i = 0; i < MAX_SKILL_IN_HOTKEY; i++ )
 	{
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_HOTKEY, i);
 		if (pArea && pArea->IsIn(ptCur.x, ptCur.y))
 		{
 			bFound = true;
+			index = i;
 			break;
 		}
 	}
 
 	if (!bFound) return false;
 	if (!CN3UIWndBase::m_sSkillSelectInfo.pSkillDoneInfo) return false;
-	//SetReceiveSelectedSkill(i);
+	
+	SetReceiveSelectedSkill(index);
 
 	return bFound;
 }


### PR DESCRIPTION
Probably for testing purposes some part of the code is commented out and that causes drag / drop feature to not work from skilltree to hotkey. Re adding those solved the presenting issue.