### PR TITLE
Wiz warp list fix game crash

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -4279,19 +4279,23 @@ void CGameProcMain::MsgSend_Warp() // 워프 - 존이동이 될수도 있다..
 
 	uint8_t byBuff[8];
 	int iOffset = 0;
-	
+
+	m_szWarpDestination = WI.szName;
+
+	if (s_pPlayer->m_InfoExt.iGold < WI.iGold)
+	{
+		std::string szFmt;
+		char szMsg[256] = {};
+
+		_LoadStringFromResource(IDS_TELEPORT_TO_X_NEED_Y_COINS, szFmt);
+		snprintf(szMsg, sizeof(szMsg), szFmt.c_str(), WI.szName.c_str(), WI.iGold);
+		MsgOutput(szMsg, 0xFFFF3B3B);
+		return;
+	}
+
 	CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_WARP_LIST);
-	CAPISocket::MP_AddShort(byBuff, iOffset, WI.iID); // 워프 아이디 보내기...
+	CAPISocket::MP_AddShort(byBuff, iOffset, (int16_t) WI.iID); // 워프 아이디 보내기...
 	s_pSocket->Send(byBuff, iOffset);
-
-	/*
-	__Vector3 vec3;
-	vec3.x = 361.278503f;
-	vec3.y = 2.822370f;
-	vec3.z = 137.339859f;
-
-	InitZone(WI.iZone, vec3);
-	*/
 }
 
 void CGameProcMain::DoCommercialTransaction(int iTradeID)
@@ -6667,7 +6671,7 @@ void CGameProcMain::MsgRecv_WarpList_Error(Packet& pkt)
 	{
 		case WARP_LIST_ERROR_SUCCESS:
 			::_LoadStringFromResource(IDS_WARP_ARRIVED_AT, szFmt);
-			snprintf(szMsg, sizeof(szMsg), szFmt.c_str(), "<warp name here>");
+			snprintf(szMsg, sizeof(szMsg), szFmt.c_str(), m_szWarpDestination.c_str());
 			MsgOutput(szMsg, 0xFFFFFF00);
 			break;
 

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -6614,49 +6614,17 @@ void CGameProcMain::MsgRecv_NoahChange(Packet& pkt)		// 노아 변경..
 
 void CGameProcMain::MsgRecv_WarpList(Packet& pkt)		// 워프 리스트 - 존 체인지가 될 수도 있다..
 {
-	m_pUIWarp->Reset();
-
-	int result = pkt.read<uint8_t>();
-
-
-	if (result == 0)
+	uint8_t opcode = pkt.read<uint8_t>();
+	if (opcode == 2)
 	{
-		
-		int errorReason = pkt.read<uint8_t>();
-		std::string szFmt; char szBuff[128] = "";
-
-		if (errorReason == 2) //level requirement is not met
-		{
-			int requiredLevel = pkt.read<uint8_t>();
-
-			::_LoadStringFromResource(6610, szFmt);
-			sprintf(szBuff, szFmt.c_str(), requiredLevel);
-			this->MsgOutput(szBuff, 0xffff0000);
-		}
-		else if (errorReason == 3) //user cannot enter during CSW
-		{
-			::_LoadStringFromResource(6612, szFmt);
-			this->MsgOutput(szFmt, 0xffff0000);
-		}
-		else if (errorReason == 4) //cannot enter during war
-		{
-			::_LoadStringFromResource(6611, szFmt);
-			this->MsgOutput(szFmt, 0xffff0000);
-		}
-		else if (errorReason == 5) //cannot enter with zero National Points
-		{
-			::_LoadStringFromResource(6613, szFmt);
-			this->MsgOutput(szFmt, 0xffff0000);
-		}
-		//this is not present in Texts_us.tbl, 60+ tries to enter Ardream
-		else if (errorReason == 7) //user do not qualify to enter zone, level is higher
-		{
-
-		}
-		
-
+		MsgRecv_WarpList_Error(pkt);
 		return;
 	}
+
+	if (opcode != 1)
+		return;
+
+	m_pUIWarp->Reset();
 
 	int iListCount = pkt.read<int16_t>();
 
@@ -6670,14 +6638,14 @@ void CGameProcMain::MsgRecv_WarpList(Packet& pkt)		// 워프 리스트 - 존 체
 	{
 		__WarpInfo WI;
 		
-		WI.iID = pkt.read<int16_t>(); // 워프 ID
-		iStrLen = pkt.read<int16_t>(); // 이름 길이
-		pkt.readString(WI.szName, iStrLen); // 이름
-		iStrLen = pkt.read<int16_t>(); // 동의문 길이
-		pkt.readString(WI.szAgreement, iStrLen); // 동의문
+		WI.iID = pkt.read<int16_t>();				// 워프 ID
+		iStrLen = pkt.read<int16_t>();				// 이름 길이
+		pkt.readString(WI.szName, iStrLen);			// 이름
+		iStrLen = pkt.read<int16_t>();				// 동의문 길이
+		pkt.readString(WI.szAgreement, iStrLen);	// 동의문
 		WI.iZone = pkt.read<int16_t>();				// 존번호
 		WI.iMaxUser = pkt.read<int16_t>();			// 최대 유저 카운트.
-		WI.iGold = pkt.read<uint32_t>();				// 돈
+		WI.iGold = pkt.read<uint32_t>();			// 돈
 		WI.vPos.x = (pkt.read<int16_t>())/10.0f;	// 좌표 
 		WI.vPos.z = (pkt.read<int16_t>())/10.0f;	//
 		WI.vPos.y = (pkt.read<int16_t>())/10.0f;	// 
@@ -6689,67 +6657,56 @@ void CGameProcMain::MsgRecv_WarpList(Packet& pkt)		// 워프 리스트 - 존 체
 	m_pUIWarp->SetVisible(true);
 }
 
-/*
-void CGameProcMain::MsgRecv_ServerCheckAndRequestConcurrentUserCount(Packet& pkt)	// 서버 IP 와 포트를 받아 동접자를 체크해 본다..
+void CGameProcMain::MsgRecv_WarpList_Error(Packet& pkt)
 {
-	std::string szIP;
-	int iStrLen = pkt.read<int16_t>(); // IP..
-	pkt.readString(szIP, iStrLen);
-	uint32_t dwPort = pkt.read<int16_t>(); // Port
+	uint8_t errorCode = pkt.read<uint8_t>();
+	std::string szFmt;
+	char szMsg[128] = {};
 
-	__WarpInfo WI;
-	if(m_pUIWarp->InfoGetCur(WI) < 0) return;
-
-	bool bNeedConnectSubSocket = (szIP != s_pSocket->GetCurrentIP() || dwPort != s_pSocket->GetCurrentPort()); // 접속해야 할 IP 와 포트가 똑같은지
-
-	if(bNeedConnectSubSocket) // 서브 소켓으로 접속해야 하면..
+	switch (errorCode)
 	{
-		int iErr = s_pSocketSub->Connect(s_hWndSubSocket, szIP.c_str(), dwPort); // 서브 소켓으로 접속해서..
-		if(iErr)
+		case WARP_LIST_ERROR_SUCCESS:
+			::_LoadStringFromResource(IDS_WARP_ARRIVED_AT, szFmt);
+			snprintf(szMsg, sizeof(szMsg), szFmt.c_str(), "<warp name here>");
+			MsgOutput(szMsg, 0xFFFFFF00);
+			break;
+
+		case WARP_LIST_ERROR_MIN_LEVEL:
 		{
-			this->ReportServerConnectionFailed(WI.szName, iErr, false);
-			return;
+			int requiredLevel = pkt.read<uint8_t>();
+
+			::_LoadStringFromResource(IDS_WARP_MIN_LEVEL, szFmt);
+			snprintf(szMsg, sizeof(szMsg), szFmt.c_str(), requiredLevel);
+			MsgOutput(szMsg, 0xFFFFFF00);
 		}
-	}
+		break;
 
-	// 동접자 체크..
-	int iOffsetSend = 0;
-	uint8_t byBuff[8];
-	
-	CAPISocket::MP_AddByte(byBuff, iOffsetSend, WIZ_ZONE_CONCURRENT);
-	CAPISocket::MP_AddShort(byBuff, iOffsetSend, WI.iZone);
-	CAPISocket::MP_AddByte(byBuff, iOffsetSend, s_pPlayer->m_InfoBase.eNation); // 국가별 동접수..
+		case WARP_LIST_ERROR_NOT_DURING_CSW:
+			::_LoadStringFromResource(IDS_WARP_NOT_DURING_CSW, szFmt);
+			MsgOutput(szFmt, 0xFFFFFF00);
+			break;
 
-	if(bNeedConnectSubSocket) s_pSocketSub->Send(byBuff, iOffsetSend); // 서브 소켓으로 보내기.
-	else s_pSocket->Send(byBuff, iOffsetSend); // 본 소켓으로 보내기..
-}
+		case WARP_LIST_ERROR_NOT_DURING_WAR:
+			::_LoadStringFromResource(IDS_WARP_NOT_DURING_WAR, szFmt);
+			MsgOutput(szFmt, 0xFFFFFF00);
+			break;
 
+		case WARP_LIST_ERROR_NEED_LOYALTY:
+			::_LoadStringFromResource(IDS_WARP_NEED_LOYALTY, szFmt);
+			MsgOutput(szFmt, 0xFFFFFF00);
+			break;
 
-void CGameProcMain::MsgRecv_ConcurrentUserCountAndSendServerCheck(Packet& pkt)			// 동접자를 받고 서버에 접속하겠다는 패킷을 보낸다.
-{
-	int iConcurrentUser = pkt.read<int16_t>(); // IP..
-	if(s_pSocketSub->IsConnected()) s_pSocketSub->Disconnect();
+		case WARP_LIST_ERROR_WRONG_LEVEL_DLW:
+			::_LoadStringFromResource(IDS_WARP_LEVEL_30_TO_50, szFmt);
+			MessageBoxPost(szFmt, "", MB_OK);
+			break;
 
-	__WarpInfo WI;
-	if(m_pUIWarp->InfoGetCur(WI) < 0) return;
-
-	if(iConcurrentUser < WI.iMaxUser) // 동접 제한보다 적으면..
-	{
-		int iOffsetSend = 0;
-		uint8_t byBuff[8];
-		
-		CAPISocket::MP_AddByte(byBuff, iOffsetSend, WIZ_VIRTUAL_SERVER);
-		CAPISocket::MP_AddShort(byBuff, iOffsetSend, WI.iID);
-
-		s_pSocket->Send(byBuff, iOffsetSend);
-	}
-	else
-	{
-		std::string szMsg; ::_LoadStringFromResource(IDS_MSG_CONCURRENT_USER_OVERFLOW, szMsg); // 동시 접속 제한 초과..
-		this->MsgOutput(szMsg, 0xffff0000);
+		case WARP_LIST_ERROR_DO_NOT_QUALIFY:
+			::_LoadStringFromResource(IDS_WARP_DO_NOT_QUALIFY, szFmt);
+			MessageBoxPost(szFmt, "", MB_OK);
+			break;
 	}
 }
-*/
 
 void CGameProcMain::MsgRecv_Knights_Create(Packet& pkt)
 {

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -6614,17 +6614,57 @@ void CGameProcMain::MsgRecv_NoahChange(Packet& pkt)		// 노아 변경..
 
 void CGameProcMain::MsgRecv_WarpList(Packet& pkt)		// 워프 리스트 - 존 체인지가 될 수도 있다..
 {
-	int iByte = pkt.read<uint8_t>();
-
 	m_pUIWarp->Reset();
 
-	int iStrLen = 0;
+	int result = pkt.read<uint8_t>();
+
+
+	if (result == 0)
+	{
+		
+		int errorReason = pkt.read<uint8_t>();
+		std::string szFmt; char szBuff[128] = "";
+
+		if (errorReason == 2) //level requirement is not met
+		{
+			int requiredLevel = pkt.read<uint8_t>();
+
+			::_LoadStringFromResource(6610, szFmt);
+			sprintf(szBuff, szFmt.c_str(), requiredLevel);
+			this->MsgOutput(szBuff, 0xffff0000);
+		}
+		else if (errorReason == 3) //user cannot enter during CSW
+		{
+			::_LoadStringFromResource(6612, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		else if (errorReason == 4) //cannot enter during war
+		{
+			::_LoadStringFromResource(6611, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		else if (errorReason == 5) //cannot enter with zero National Points
+		{
+			::_LoadStringFromResource(6613, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		//this is not present in Texts_us.tbl, 60+ tries to enter Ardream
+		else if (errorReason == 7) //user do not qualify to enter zone, level is higher
+		{
+
+		}
+		
+
+		return;
+	}
 
 	int iListCount = pkt.read<int16_t>();
 
 	// if there are no warp info (if m_bZoneChangeSameZone is true) - No need to show empty list. 
 	if (iListCount == 0)
 		return;
+
+	int iStrLen = 0;
 
 	for(int i = 0; i < iListCount; i++)
 	{

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -1,13 +1,4 @@
-﻿// GameProcMain.h: interface for the CGameProcMain class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_GAMEPROCMAIN_H__E1C4F2CC_5AF3_4417_8917_A52CD5523DB3__INCLUDED_)
-#define AFX_GAMEPROCMAIN_H__E1C4F2CC_5AF3_4417_8917_A52CD5523DB3__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "GameProcedure.h"
 #include <set>
@@ -106,6 +97,8 @@ public:
 	int			m_iExitTimeRemaining; // seconds remaining until exit
 
 	float		m_fMBRotateTime;
+
+	std::string	m_szWarpDestination;
 
 protected:
 	virtual bool ProcessPacket(Packet& pkt);
@@ -327,5 +320,3 @@ public:
 	CGameProcMain();									// 생성자.
 	virtual ~CGameProcMain();							// 소멸자.
 };
-
-#endif // !defined(AFX_GAMEPROCMAIN_H__E1C4F2CC_5AF3_4417_8917_A52CD5523DB3__INCLUDED_)

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -195,7 +195,9 @@ protected:
 
 	void	MsgRecv_NoahChange(Packet& pkt);			// 노아 변경..
 	void	MsgRecv_WarpList(Packet& pkt);				// 워프 리스트..
-//	void	MsgRecv_ServerCheckAndRequestConcurrentUserCount(Packet& pkt);			// 서버 IP 와 포트를 받아 동접자를 체크해 본다..
+	void	MsgRecv_WarpList_Error(Packet& pkt);		// 워프 리스트..
+
+	//	void	MsgRecv_ServerCheckAndRequestConcurrentUserCount(Packet& pkt);			// 서버 IP 와 포트를 받아 동접자를 체크해 본다..
 //	void	MsgRecv_ConcurrentUserCountAndSendServerCheck(Packet& pkt);
 	
 	//knights...

--- a/Client/WarFare/resource.h
+++ b/Client/WarFare/resource.h
@@ -461,6 +461,8 @@
 #define IDS_WARP_NOT_DURING_CSW         6612 // You cannot enter during the Castle Siege War. 
 #define IDS_WARP_NEED_LOYALTY           6613 // You cannot enter when you have 0 national points. 
 
+#define IDS_TELEPORT_TO_X_NEED_Y_COINS  7612 // To teleport to %s, you need %d coins
+
 #define IDS_EXITING_GAME_IN_X_SECONDS	7632 // Exiting game in %d seconds.
 #define IDS_EXITING_GAME_CANCELED		7633 // Exiting game canceled.
 #define IDS_WARP_LEVEL_30_TO_50         7657 // Only characters with level 30~50 can enter.

--- a/Client/WarFare/resource.h
+++ b/Client/WarFare/resource.h
@@ -455,9 +455,16 @@
 #define IDS_WANT_PARTY_MEMBER           6123
 #define IDS_SETTING_KARUS_SCREEN        6124
 #define IDS_SETTING_ELMORAD_SCREEN      6125
+#define IDS_WARP_ARRIVED_AT             6606 // You've arrived at %s.
+#define IDS_WARP_MIN_LEVEL              6610 // You need to be at least level %d.
+#define IDS_WARP_NOT_DURING_WAR         6611 // You cannot enter during the Lunar War. 
+#define IDS_WARP_NOT_DURING_CSW         6612 // You cannot enter during the Castle Siege War. 
+#define IDS_WARP_NEED_LOYALTY           6613 // You cannot enter when you have 0 national points. 
 
 #define IDS_EXITING_GAME_IN_X_SECONDS	7632 // Exiting game in %d seconds.
 #define IDS_EXITING_GAME_CANCELED		7633 // Exiting game canceled.
+#define IDS_WARP_LEVEL_30_TO_50         7657 // Only characters with level 30~50 can enter.
+#define IDS_WARP_DO_NOT_QUALIFY         7659 // You cannot enter because you do not qualify. 
 
 #define IDS_PRIVATE_CMD_CAT				7800
 #define IDS_TRADE_CMD_CAT				7801

--- a/Server/GameServer/CharacterMovementHandler.cpp
+++ b/Server/GameServer/CharacterMovementHandler.cpp
@@ -335,13 +335,16 @@ void CUser::ZoneChange(uint16_t sNewZone, float x, float z)
 	WarpListResponse errorReason;
 	if (!CanChangeZone(pMap, errorReason))
 	{
-		Packet result(WIZ_WARP_LIST);
+		Packet result;
 
-		result << uint8_t(2) << uint8_t(errorReason);
+		result << uint8_t(WIZ_WARP_LIST); //packet header
+		result << uint8_t(false);   //packet result is false
+		result << uint8_t(errorReason);   //errorReason
 
-		if (errorReason == WarpListMinLevel)
-			result << pMap->GetMinLevelReq();
-
+		//additional required level info
+		if (errorReason == WarpListMinLevel) 
+			result << pMap->GetMinLevelReq(); 
+	
 		Send(&result);
 		return;
 	}

--- a/Server/GameServer/CharacterMovementHandler.cpp
+++ b/Server/GameServer/CharacterMovementHandler.cpp
@@ -186,25 +186,25 @@ void CUser::Rotate(Packet & pkt)
 	SendToRegion(&result, this);
 }
 
-bool CUser::CanChangeZone(C3DMap * pTargetMap, WarpListResponse & errorReason)
+bool CUser::CanChangeZone(C3DMap* pTargetMap, e_WarpListError& errorReason)
 {
 	// While unofficial, game masters should be allowed to teleport anywhere.
 	if (isGM())
 		return true;
 
 	// Generic error reason; this should only be checked when the method returns false.
-	errorReason = WarpListGenericError;
+	errorReason = WARP_LIST_ERROR_GENERIC;
 
 	if (GetLevel() < pTargetMap->GetMinLevelReq())
 	{
-		errorReason = WarpListMinLevel;
+		errorReason = WARP_LIST_ERROR_MIN_LEVEL;
 		return false;
 	}
 
 	if (GetLevel() > pTargetMap->GetMaxLevelReq()
 		/*|| !CanLevelQualify(pTargetMap->GetMaxLevelReq())*/)
 	{
-		errorReason = WarpListDoNotQualify;
+		errorReason = WARP_LIST_ERROR_DO_NOT_QUALIFY;
 		return false;
 	}
 
@@ -220,6 +220,7 @@ bool CUser::CanChangeZone(C3DMap * pTargetMap, WarpListResponse & errorReason)
 			return g_pMain->m_byKarusOpenFlag;
 		else
 			return g_pMain->m_byElmoradOpenFlag;
+
 	case ZONE_ELMORAD:
 		// Users may enter Luferson (1)/El Morad (2) if they are that nation, 
 		if (GetNation() == pTargetMap->GetID()) 
@@ -230,58 +231,68 @@ bool CUser::CanChangeZone(C3DMap * pTargetMap, WarpListResponse & errorReason)
 			return g_pMain->m_byElmoradOpenFlag;
 		else
 			return g_pMain->m_byKarusOpenFlag;
+
 	case ZONE_KARUS_ESLANT:
 		return GetNation() == pTargetMap->GetID() - 10;
+
 	case ZONE_ELMORAD_ESLANT:
 		return GetNation() == pTargetMap->GetID() - 10;
+
 	case ZONE_DELOS: // TODO: implement CSW logic.
-		if (g_pMain->m_byBattleOpen == CLAN_BATTLE && !g_pMain->m_byBattleSiegeWarTeleport)
+		if (g_pMain->m_byBattleOpen == CLAN_BATTLE
+			&& !g_pMain->m_byBattleSiegeWarTeleport)
 		{
-			errorReason = WarpListNotDuringCSW;
+			errorReason = WARP_LIST_ERROR_NOT_DURING_CSW;
 			return false;
 		}
-		else
+
 		return true;
+
 	case ZONE_BIFROST:
 		return true;
+
 	case ZONE_ARDREAM:
 		if (g_pMain->isWarOpen())
 		{
-			errorReason = WarpListNotDuringWar;
+			errorReason = WARP_LIST_ERROR_NOT_DURING_WAR;
 			return false;
 		}
 
 		if (GetLoyalty() <= 0)
 		{
-			errorReason = WarpListNeedNP;
+			errorReason = WARP_LIST_ERROR_NEED_LOYALTY;
 			return false;
 		}
 
 		return true;
+
 	case ZONE_RONARK_LAND_BASE:
-		if (g_pMain->isWarOpen() && g_pMain->m_byBattleZoneType != ZONE_ARDREAM)
+		if (g_pMain->isWarOpen()
+			&& g_pMain->m_byBattleZoneType != ZONE_ARDREAM)
 		{
-			errorReason = WarpListNotDuringWar;
+			errorReason = WARP_LIST_ERROR_NOT_DURING_WAR;
 			return false;
 		}
 
 		if (GetLoyalty() <= 0)
 		{
-			errorReason = WarpListNeedNP;
+			errorReason = WARP_LIST_ERROR_NEED_LOYALTY;
 			return false;
 		}
 
 		return false;
+
 	case ZONE_RONARK_LAND:
-		if (g_pMain->isWarOpen() && g_pMain->m_byBattleZoneType != ZONE_ARDREAM)
+		if (g_pMain->isWarOpen()
+			&& g_pMain->m_byBattleZoneType != ZONE_ARDREAM)
 		{
-			errorReason = WarpListNotDuringWar;
+			errorReason = WARP_LIST_ERROR_NOT_DURING_WAR;
 			return false;
 		}
 
 		if (GetLoyalty() <= 0)
 		{
-			errorReason = WarpListNeedNP;
+			errorReason = WARP_LIST_ERROR_NEED_LOYALTY;
 			return false;
 		}
 
@@ -291,16 +302,20 @@ bool CUser::CanChangeZone(C3DMap * pTargetMap, WarpListResponse & errorReason)
 		// War zones may only be entered if that war zone is active.
 		if (pTargetMap->isWarZone())
 		{
-			if(pTargetMap->GetID() == ZONE_SNOW_BATTLE)
+			if (pTargetMap->GetID() == ZONE_SNOW_BATTLE)
 			{
-			if ((pTargetMap->GetID() - ZONE_SNOW_BATTLE) != g_pMain->m_byBattleZone)
-				return false;
+				if ((pTargetMap->GetID() - ZONE_SNOW_BATTLE) != g_pMain->m_byBattleZone)
+					return false;
 			}
 			else if ((pTargetMap->GetID() - ZONE_BATTLE_BASE) != g_pMain->m_byBattleZone)
+			{
 				return false;
+			}
 			else if ((GetNation() == ELMORAD && g_pMain->m_byElmoradOpenFlag)
 				|| (GetNation() == KARUS && g_pMain->m_byKarusOpenFlag))
+			{
 				return false;
+			}
 		}
 	}
 
@@ -332,19 +347,16 @@ void CUser::ZoneChange(uint16_t sNewZone, float x, float z)
 	if (pMap == nullptr) 
 		return;
 
-	WarpListResponse errorReason;
+	e_WarpListError errorReason;
 	if (!CanChangeZone(pMap, errorReason))
 	{
-		Packet result;
+		Packet result(WIZ_WARP_LIST);
 
-		result << uint8_t(WIZ_WARP_LIST); //packet header
-		result << uint8_t(false);   //packet result is false
-		result << uint8_t(errorReason);   //errorReason
+		result << uint8_t(2) << uint8_t(errorReason);
 
-		//additional required level info
-		if (errorReason == WarpListMinLevel) 
-			result << pMap->GetMinLevelReq(); 
-	
+		if (errorReason == WARP_LIST_ERROR_MIN_LEVEL)
+			result << pMap->GetMinLevelReq();
+
 		Send(&result);
 		return;
 	}

--- a/Server/GameServer/User.h
+++ b/Server/GameServer/User.h
@@ -54,21 +54,6 @@ enum ClassType
 	ClassPriestMaster	= 12
 };
 
-enum WarpListResponse
-{
-	WarpListGenericError		= 0,
-	WarpListSuccess				= 1,  // "You've arrived at."
-	WarpListMinLevel			= 2,  // "You need to be at least level <level>."
-	WarpListNotDuringCSW		= 3,  // "You cannot enter during the Castle Siege War."
-	WarpListNotDuringWar		= 4,  // "You cannot enter during the Lunar War."
-	WarpListNeedNP				= 5,  // "You cannot enter when you have 0 national points."
-	WarpListWrongLevelDLW		= 6,  // "Only characters with level 30~50 can enter." (dialog) 
-	WarpListDoNotQualify		= 7,  // "You can not enter because you do not qualify." (dialog) 
-	WarpListRecentlyTraded		= 8,  // "You can't teleport for 2 minutes after trading." (dialog) 
-	WarpListArenaFull			= 9,  // "Arena Server is full to capacity. Please try again later." (dialog) 
-	WarpListFinished7KeysQuest	= 10, // "You can't enter because you completed Guardian of 7 Keys quest." (dialog) 
-};
-
 enum TransformationType
 {
 	TransformationNone,
@@ -827,7 +812,7 @@ public:
 	void SendMannerChange(int32_t iMannerPoints);
 
 	bool CanLevelQualify(uint8_t sLevel);
-	bool CanChangeZone(C3DMap * pTargetMap, WarpListResponse & errorReason);
+	bool CanChangeZone(C3DMap* pTargetMap, e_WarpListError& errorReason);
 	void ZoneChange(uint16_t sNewZone, float x, float z);
 	void ZoneChangeParty(uint16_t sNewZone, float x, float z);
 	void ZoneChangeClan(uint16_t sNewZone, float x, float z);

--- a/Server/shared/packets.h
+++ b/Server/shared/packets.h
@@ -425,6 +425,23 @@ enum RankTypes
 	RANK_TYPE_CHAOS_DUNGEON = 3,
 };
 
+enum e_WarpListError : uint8_t
+{
+	WARP_LIST_ERROR_GENERIC					= 0,
+	WARP_LIST_ERROR_SUCCESS					= 1,  // "You've arrived at <destination>."
+	WARP_LIST_ERROR_MIN_LEVEL				= 2,  // "You need to be at least level <level>."
+	WARP_LIST_ERROR_NOT_DURING_CSW			= 3,  // "You cannot enter during the Castle Siege War."
+	WARP_LIST_ERROR_NOT_DURING_WAR			= 4,  // "You cannot enter during the Lunar War."
+	WARP_LIST_ERROR_NEED_LOYALTY			= 5,  // "You cannot enter when you have 0 national points."
+	WARP_LIST_ERROR_WRONG_LEVEL_DLW			= 6,  // "Only characters with level 30~50 can enter." (dialog) 
+	WARP_LIST_ERROR_DO_NOT_QUALIFY			= 7,  // "You can not enter because you do not qualify." (dialog) 
+
+	// Available only in newer client versions:
+	WARP_LIST_ERROR_RECENTLY_TRADED			= 8,  // "You can't teleport for 2 minutes after trading." (dialog) 
+	WARP_LIST_ERROR_ARENA_FULL				= 9,  // "Arena Server is full to capacity. Please try again later." (dialog) 
+	WARP_LIST_ERROR_FINISHED_7_KEYS_QUEST	= 10, // "You can't enter because you completed Guardian of 7 Keys quest." (dialog)
+};
+
 ////////////////////////////////////////////////////////////////
 // WareHouse Packet sub define
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
packet WIZ_WARP_LIST was causing game crash when an user tries to enter a zone ( Eslant ) without satisfying level requirement (40 or 60 in this version, tbl says 40 ). Packet did not read in correct order and warning message to user not shown. 

This commit aims to fix game crash problem when user tries to enter Eslant with low level character.