### PR TITLE
vGatherPoint fix

### DIFF
--- a/Client/N3Base/N3FXPartParticles.cpp
+++ b/Client/N3Base/N3FXPartParticles.cpp
@@ -1343,7 +1343,7 @@ void CN3FXPartParticles::Duplicate(CN3FXPartParticles* pSrc)
 	}
 	else if( m_dwEmitType == FX_PART_PARTICLE_EMIT_TYPE_GATHER )
 	{
-		m_uEmitCon.vGatherPoint = m_uEmitCon.vGatherPoint;
+		m_uEmitCon.vGatherPoint = pSrc->m_uEmitCon.vGatherPoint;
 	}
 
 	m_vPtEmitDir = pSrc->m_vPtEmitDir;


### PR DESCRIPTION
This fixes the gathering point of particles like the 1920 heal, it should collect towards the upper character instead of dissapearing into the ground.

m_dwEmitType == FX_PART_PARTICLE_EMIT_TYPE_GATHER
m_uEmitCon.vGatherPoint = pSrc->m_uEmitCon.vGatherPoint; 