### PR TITLE
FXZonePointer fix

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -1277,38 +1277,39 @@ typedef struct __TABLE_FX	// FX Table
 #endif
 } TABLE_FX;
 
-const int	MAX_COMBO = 3;
+constexpr int	MAX_COMBO = 3;
 
-const int   FXID_CLASS_CHANGE			= 603;
-const int	FXID_BLOOD					= 10002;
-const int	FXID_LEVELUP_KARUS			= 10012;
-const int	FXID_LEVELUP_ELMORAD		= 10018;
-const int	FXID_REGEN_ELMORAD			= 10019;
-const int	FXID_REGEN_KARUS			= 10020;
-const int	FXID_SWORD_FIRE_MAIN		= 10021;
-const int	FXID_SWORD_FIRE_TAIL		= 10022;
-const int	FXID_SWORD_FIRE_TARGET		= 10031;
-const int	FXID_SWORD_ICE_MAIN			= 10023;
-const int	FXID_SWORD_ICE_TAIL			= 10024;
-const int	FXID_SWORD_ICE_TARGET		= 10032;
-const int	FXID_SWORD_LIGHTNING_MAIN	= 10025;
-const int	FXID_SWORD_LIGHTNING_TAIL	= 10026;
-const int	FXID_SWORD_LIGHTNING_TARGET = 10033;
-const int	FXID_SWORD_POISON_MAIN		= 10027;
-const int	FXID_SWORD_POISON_TAIL		= 10028;
-const int	FXID_SWORD_POISON_TARGET	= 10034;
-//const int	FXID_GROUND_TARGET = 10035;
-const int	FXID_REGION_TARGET_EL_ROGUE		= 10035;
-const int	FXID_REGION_TARGET_EL_WIZARD	= 10036;
-const int	FXID_REGION_TARGET_EL_PRIEST	= 10037;
-const int	FXID_REGION_TARGET_KA_ROGUE		= 10038;
-const int	FXID_REGION_TARGET_KA_WIZARD	= 10039;
-const int	FXID_REGION_TARGET_KA_PRIEST	= 10040;
-const int	FXID_CLAN_RANK_1				= 10041;
-const int	FXID_WARP_KARUS					= 10046;
-const int	FXID_WARP_ELMORAD				= 10047;
-const int	FXID_REGION_POISON				= 10100;
-const int	FXID_TARGET_POINTER				= 30001;
+constexpr int   FXID_CLASS_CHANGE				= 603;
+constexpr int	FXID_BLOOD						= 10002;
+constexpr int	FXID_LEVELUP_KARUS				= 10012;
+constexpr int	FXID_LEVELUP_ELMORAD			= 10018;
+constexpr int	FXID_REGEN_ELMORAD				= 10019;
+constexpr int	FXID_REGEN_KARUS				= 10020;
+constexpr int	FXID_SWORD_FIRE_MAIN			= 10021;
+constexpr int	FXID_SWORD_FIRE_TAIL			= 10022;
+constexpr int	FXID_SWORD_FIRE_TARGET			= 10031;
+constexpr int	FXID_SWORD_ICE_MAIN				= 10023;
+constexpr int	FXID_SWORD_ICE_TAIL				= 10024;
+constexpr int	FXID_SWORD_ICE_TARGET			= 10032;
+constexpr int	FXID_SWORD_LIGHTNING_MAIN		= 10025;
+constexpr int	FXID_SWORD_LIGHTNING_TAIL		= 10026;
+constexpr int	FXID_SWORD_LIGHTNING_TARGET		= 10033;
+constexpr int	FXID_SWORD_POISON_MAIN			= 10027;
+constexpr int	FXID_SWORD_POISON_TAIL			= 10028;
+constexpr int	FXID_SWORD_POISON_TARGET		= 10034;
+//constexpr int	FXID_GROUND_TARGET = 10035;
+constexpr int	FXID_REGION_TARGET_EL_ROGUE		= 10035;
+constexpr int	FXID_REGION_TARGET_EL_WIZARD	= 10036;
+constexpr int	FXID_REGION_TARGET_EL_PRIEST	= 10037;
+constexpr int	FXID_REGION_TARGET_KA_ROGUE		= 10038;
+constexpr int	FXID_REGION_TARGET_KA_WIZARD	= 10039;
+constexpr int	FXID_REGION_TARGET_KA_PRIEST	= 10040;
+constexpr int	FXID_CLAN_RANK_1				= 10041;
+constexpr int	FXID_WARP_KARUS					= 10046;
+constexpr int	FXID_WARP_ELMORAD				= 10047;
+constexpr int	FXID_REGION_POISON				= 10100;
+constexpr int	FXID_TARGET_POINTER				= 30001;
+constexpr int	FXID_ZONE_POINTER				= 30002;
 
 //define skillmagic_type4_bufftype
 enum e_SkillMagicType4	{	BUFFTYPE_MAXHP = 1,				//MaxHP변화..

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -1,13 +1,4 @@
-﻿// MagicSkillMng.h: interface for the CMagicSkillMng class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_MAGICSKILLMNG_H__2C75CDA2_45CC_495F_BCE9_ED2E7CB1B60E__INCLUDED_)
-#define AFX_MAGICSKILLMNG_H__2C75CDA2_45CC_495F_BCE9_ED2E7CB1B60E__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "GameDef.h"
 #include "GameBase.h"
@@ -28,7 +19,7 @@ public:
 	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_4>*	m_pTbl_Type_4;
 //	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_5>*	m_pTbl_Type_5;
 //	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_6>*	m_pTbl_Type_6;
-//	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_7>*	m_pTbl_Type_7;
+	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_7>*	m_pTbl_Type_7;
 //	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_8>*	m_pTbl_Type_8;
 //	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_9>*	m_pTbl_Type_9;
 //	CN3TableBase<struct __TABLE_UPC_SKILL_TYPE_10>*	m_pTbl_Type_10;
@@ -85,10 +76,8 @@ public:
 
 private:
 	bool m_bZonePointerActive;
-	float m_fRotationAngle;
-	float m_fRotationSpeed;
-	__Vector3 m_vZoneCenter;
-	float m_fZoneRadius;
+	float m_fZonePointerRotRad;
+	float m_fZonePointerRadius;
 
 protected:
 	bool	CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkill);
@@ -136,11 +125,10 @@ public:
 	void	Init();
 	void	Tick();
 	void	CancelZonePointer();
+	void	UpdateZonePointerPositions();
 
 
 	CMagicSkillMng();
 	CMagicSkillMng(CGameProcMain* pGameProcMain);
 	virtual ~CMagicSkillMng();
 };
-
-#endif // !defined(AFX_MAGICSKILLMNG_H__2C75CDA2_45CC_495F_BCE9_ED2E7CB1B60E__INCLUDED_)

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -83,7 +83,12 @@ public:
 	//지역마법..
 	int						m_iMyRegionTargetFXID;
 
-
+private:
+	bool m_bZonePointerActive;
+	float m_fRotationAngle;
+	float m_fRotationSpeed;
+	__Vector3 m_vZoneCenter;
+	float m_fZoneRadius;
 
 protected:
 	bool	CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkill);
@@ -129,7 +134,9 @@ public:
 	void	MsgRecv_BuffType(Packet& pkt);
 	
 	void	Init();
-	void	Tick();	
+	void	Tick();
+	void	CancelZonePointer();
+
 
 	CMagicSkillMng();
 	CMagicSkillMng(CGameProcMain* pGameProcMain);

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -75,9 +75,9 @@ public:
 	int						m_iMyRegionTargetFXID;
 
 private:
-	bool m_bZonePointerActive;
 	float m_fZonePointerRotRad;
 	float m_fZonePointerRadius;
+	float m_fZonePointerRadiusEffective;
 
 protected:
 	bool	CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkill);
@@ -124,9 +124,8 @@ public:
 	
 	void	Init();
 	void	Tick();
-	void	CancelZonePointer();
 	void	UpdateZonePointerPositions();
-
+	void	CancelZonePointer();
 
 	CMagicSkillMng();
 	CMagicSkillMng(CGameProcMain* pGameProcMain);


### PR DESCRIPTION
We have implemented a rotating loop for the mage and priest skills that target an area, the groundboard is in the centre rotating and the zonepointers are out the outer layer rotating clockwise it also scales by reading skilltbl3->iRadius and same for type4->iRadius
![image](https://github.com/user-attachments/assets/bd0ba15e-d57b-423a-b150-494c41ab9d43)
![image](https://github.com/user-attachments/assets/d9c3f9b5-1b44-4cb0-9430-e9ea228dd8a4)
