### PR TITLE
Skill recast map fix

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -1664,7 +1664,7 @@ void CMagicSkillMng::Tick()
 		char szMsg[100];
 		std::snprintf(szMsg, sizeof(szMsg), "m_RecastTimes skill %.1f seconds", pair.second);
 		std::string strMsg(szMsg);
-		if(pair.second > 0)
+		if(pair.second > 0.1)
 		m_pGameProcMain->MsgOutput(szMsg, 0xffffff00);
 #endif
 		pair.second -= CN3Base::s_fSecPerFrm;
@@ -1676,7 +1676,7 @@ void CMagicSkillMng::Tick()
 		char szMsg[100];
 		std::snprintf(szMsg, sizeof(szMsg), "m_NonActionRecastTimes skill %.1f seconds", pair.second);
 		std::string strMsg(szMsg);
-		if(pair.second > 0)
+		if(pair.second > 0.1)
 		m_pGameProcMain->MsgOutput(szMsg, 0xffffff00);
 #endif
 		pair.second -= CN3Base::s_fSecPerFrm;

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -57,7 +57,7 @@ public:
 	int						m_iPoisonR;
 
 	//recast time...
-	float					m_fRecastTime;
+	//float					m_fRecastTime;
 	float					m_fDelay;
 		
 	//related region magic...
@@ -69,12 +69,14 @@ public:
 	float					m_fCastTimeNonAction;
 	uint32_t					m_dwNonActionMagicID;
 	int						m_iNonActionMagicTarget;
-	float					m_fRecastTimeNonAction;
+	//float					m_fRecastTimeNonAction;
 
 	//지역마법..
 	int						m_iMyRegionTargetFXID;
 
 private:
+	std::map<uint32_t, float> m_RecastTimes;          // Casting skills
+	std::map<uint32_t, float> m_NonActionRecastTimes; // Instant skills, don't think this is actually needed
 	float m_fZonePointerRotRad;
 	float m_fZonePointerRadius;
 	float m_fZonePointerRadiusEffective;
@@ -116,6 +118,7 @@ public:
 	uint32_t	GetMagicID(int idx);
 		
 	bool	MsgSend_MagicProcess(int iTargetID, __TABLE_UPC_SKILL* pSkill);
+	void	SetSkillCooldown(__TABLE_UPC_SKILL* pSkill);
 	void	MsgRecv_Casting(Packet& pkt);
 	void	MsgRecv_Flying(Packet& pkt);
 	void	MsgRecv_Effecting(Packet& pkt);

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -77,6 +77,9 @@ public:
 private:
 	std::map<uint32_t, float> m_RecastTimes;          // Casting skills
 	std::map<uint32_t, float> m_NonActionRecastTimes; // Instant skills, don't think this is actually needed
+#ifdef _DEBUG
+	float m_fMsgUpdateTimer = 0.0f;
+#endif
 	float m_fZonePointerRotRad;
 	float m_fZonePointerRadius;
 	float m_fZonePointerRadiusEffective;


### PR DESCRIPTION
Simply put it works, I haven't tested potions items only mage skills but in theory they should work.
Not sure what to do with legacy code as it confuses me but this is better than what we have.
It does the job the only issue I came across is you cant Z (select nearest enemy) or select a monster with your mouse for 1-2 seconds after casting ends not sure if its related  to the packets we are sending the same .cpp or elsewhere like gameproc.

Addresses the following PR/issue: https://github.com/srmeier/KnightOnline/pull/163

![image](https://github.com/user-attachments/assets/d82e9797-7845-4b36-990f-cbe13073be37)
