### PR TITLE
Stat skill reset

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -1242,6 +1242,8 @@ enum e_Behavior {	BEHAVIOR_NOTHING = 0,
 					BEHAVIOR_PARTY_BBS_REGISTER_CANCEL, // 파티 게시판에 등록 해제
 
 					BEHAVIOR_EXECUTE_OPTION,			// 게임 종료하고 옵션 실행..
+					BEHAVIOR_STAT_RESET,				//user clicked confirm on stat reset
+					BEHAVIOR_SKILL_RESET,				//user clicked confirm on skill reset
 				
 					BEHAVIOR_UNKNOWN = 0xffffffff
 				};

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -6612,17 +6612,57 @@ void CGameProcMain::MsgRecv_NoahChange(Packet& pkt)		// 노아 변경..
 
 void CGameProcMain::MsgRecv_WarpList(Packet& pkt)		// 워프 리스트 - 존 체인지가 될 수도 있다..
 {
-	int iByte = pkt.read<uint8_t>();
-
 	m_pUIWarp->Reset();
 
-	int iStrLen = 0;
+	int result = pkt.read<uint8_t>();
+
+
+	if (result == 0)
+	{
+		
+		int errorReason = pkt.read<uint8_t>();
+		std::string szFmt; char szBuff[128] = "";
+
+		if (errorReason == 2) //level requirement is not met
+		{
+			int requiredLevel = pkt.read<uint8_t>();
+
+			::_LoadStringFromResource(6610, szFmt);
+			sprintf(szBuff, szFmt.c_str(), requiredLevel);
+			this->MsgOutput(szBuff, 0xffff0000);
+		}
+		else if (errorReason == 3) //user cannot enter during CSW
+		{
+			::_LoadStringFromResource(6612, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		else if (errorReason == 4) //cannot enter during war
+		{
+			::_LoadStringFromResource(6611, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		else if (errorReason == 5) //cannot enter with zero National Points
+		{
+			::_LoadStringFromResource(6613, szFmt);
+			this->MsgOutput(szFmt, 0xffff0000);
+		}
+		//this is not present in Texts_us.tbl, 60+ tries to enter Ardream
+		else if (errorReason == 7) //user do not qualify to enter zone, level is higher
+		{
+
+		}
+		
+
+		return;
+	}
 
 	int iListCount = pkt.read<int16_t>();
 
 	// if there are no warp info (if m_bZoneChangeSameZone is true) - No need to show empty list. 
 	if (iListCount == 0)
 		return;
+
+	int iStrLen = 0;
 
 	for(int i = 0; i < iListCount; i++)
 	{

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -68,6 +68,7 @@ public:
 	class CUITradeBBSEditDlg*	m_pUITradeBBSEdit;				// 상거래 게시물 설명
 
 	class CUIUpgradeSelect*		m_pUIUpgradeSelect;
+	class CUIStatSkillReset*	m_pUIStatSkillReset;			//stat & skill reset UI
 
 	class CN3Shape*				m_pTargetSymbol;				// 플레이어가 타겟으로 잡은 캐릭터의 위치위에 그리면 된다..
 
@@ -209,6 +210,7 @@ protected:
 	void	MsgRecv_Knights_Duty_Change(Packet& pkt);
 	void	MsgRecv_Knigts_Join_Req(Packet& pkt);
 	void	MsgRecv_ItemUpgrade(Packet& pkt);
+	void	MsgRecv_ResetStatSkill(Packet& pkt);
 
 public:
 	void	ProcessUIKeyInput(bool bEnable = true);

--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -21,7 +21,6 @@
 #include "N3SndObj.h"
 #include "N3SndObjStream.h"
 #include "N3ShapeExtra.h"
-
 //#include "StdAfxBase.h"
 
 #ifdef _DEBUG
@@ -1107,17 +1106,34 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 bool CMagicSkillMng::MsgSend_MagicProcess(int iTargetID, __TABLE_UPC_SKILL* pSkill)
 {
 	//if(m_fRecastTime > 0.0f) return;//recast time이 아직 안되었네..^^
-	if(s_pPlayer->IsDead()) return false; // 죽어 있네.. ^^
+	if (s_pPlayer->IsDead()) {
+		return false; // 죽어 있네.. ^^
+	}
 
 	///////////////////////////////////////////////////////////////////////////////////
 	// 스킬 쓸 조건이 되는지 검사...
 	if(pSkill->iSelfAnimID1 >= 0)
 	{
-		if(IsCasting() || m_fRecastTime > 0.0f) return false;
+		
+
+		if (IsCasting())
+		{
+			return false;
+		}
+
+		//BUG: m_fRecastTime > 0 even if we use different skill, canceling following lines solves issue
+		//needs to be investigated in more detail
+		/*
+		if (m_fRecastTime > 0.0f) {
+			return false;
+		} 
+		*/
 	}
 	else //캐스팅동작없는 마법..
 	{
-		if( m_dwCastingStateNonAction != 0 || m_fRecastTimeNonAction > 0.0f ) return false;
+		if (m_dwCastingStateNonAction != 0 || m_fRecastTimeNonAction > 0.0f) {
+			return false;
+		} 
 
 		m_dwCastingStateNonAction = 0;
 		m_fCastTimeNonAction = 0.0f;
@@ -1125,7 +1141,9 @@ bool CMagicSkillMng::MsgSend_MagicProcess(int iTargetID, __TABLE_UPC_SKILL* pSki
 		m_iNonActionMagicTarget = -1;
 	}
 	
-	if(!pSkill) return false;
+	if (!pSkill) {
+		return false;
+	} 
 	if(!CheckValidCondition(iTargetID, pSkill)) return false;
 
 	//TRACE("마법성공 state : %d time %.2f\n", s_pPlayer->State(), CN3Base::TimeGet());
@@ -1433,8 +1451,13 @@ void CMagicSkillMng::StartSkillMagicAtPosPacket(__TABLE_UPC_SKILL* pSkill, __Vec
 
 void CMagicSkillMng::StartSkillMagicAtTargetPacket(__TABLE_UPC_SKILL* pSkill, int16_t TargetID)
 {
-	if(!pSkill) return;
+	if (!pSkill) {
+		return;
+	}
+
 	int SourceID = s_pPlayer->IDNumber();
+	
+
 	if(pSkill->iSelfAnimID1<0)
 	{
 		m_dwCastingStateNonAction = 1;
@@ -1454,8 +1477,11 @@ void CMagicSkillMng::StartSkillMagicAtTargetPacket(__TABLE_UPC_SKILL* pSkill, in
 
 	m_pGameProcMain->CommandSitDown(false, false); // 혹시라도 앉아있음 일으켜 세운다..
 	
+
+
 	if((pSkill->dw1stTableType==1 || pSkill->dw2ndTableType==1) && pSkill->iCastTime==0)
 	{
+
 		CPlayerBase* pTarget = m_pGameProcMain->CharacterGetByID(TargetID, true);
 		if(!pTarget) return;
 
@@ -1514,6 +1540,7 @@ void CMagicSkillMng::StartSkillMagicAtTargetPacket(__TABLE_UPC_SKILL* pSkill, in
 
 	if(pSkill->iCastTime==0)
 	{
+
 		char szBuff[80];
 		std::string szFmt;
 		::_LoadStringFromResource(IDS_SKILL_USE, szFmt);
@@ -1763,6 +1790,8 @@ void CMagicSkillMng::SuccessCast(__TABLE_UPC_SKILL* pSkill, CPlayerBase* pTarget
 		sprintf(szBuff, szFmt.c_str(), pSkill->szName.c_str());
 		m_pGameProcMain->MsgOutput(szBuff, 0xffffff00);
 		m_fRecastTime = (float)pSkill->iReCastTime / 10.0f;
+
+
 		m_fDelay = 0.3f;
 		s_pPlayer->m_iSkillStep = 0;
 
@@ -1910,7 +1939,9 @@ void CMagicSkillMng::ProcessCombo()
 		if(m_iCurrStep==m_iNumStep)//콤보공격 끝났다..
 		{
 			__TABLE_UPC_SKILL* pSkill = s_pTbl_Skill.Find(m_iComboSkillID);
-			if(pSkill) m_fRecastTime = (float)pSkill->iReCastTime / 10.0f;
+			if (pSkill) {
+				m_fRecastTime = (float)pSkill->iReCastTime / 10.0f;
+			}
 			m_iCurrStep = -1;
 			s_pPlayer->m_iSkillStep = -1;
 			m_iNumStep = 0;			

--- a/Client/WarFare/UIMessageBox.cpp
+++ b/Client/WarFare/UIMessageBox.cpp
@@ -10,6 +10,7 @@
 #include "UIKnightsOperation.h"
 #include "UICreateClanName.h"
 #include "UIPartyBBS.h"
+#include "UIStatSkillReset.h"
 #include "GameEng.h"
 #include "GameProcedure.h"
 #include "GameProcLogin.h"
@@ -158,6 +159,15 @@ bool CUIMessageBox::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 						PostQuitMessage(0);	// 종료...
 					}
 					break;
+				case BEHAVIOR_STAT_RESET:			
+					if (pProcMain->m_pUIStatSkillReset)
+						pProcMain->m_pUIStatSkillReset->MsgSend_ResetStats();
+					break;
+				case BEHAVIOR_SKILL_RESET:			
+					if (pProcMain->m_pUIStatSkillReset)
+						pProcMain->m_pUIStatSkillReset->MsgSend_ResetSkills();
+					break;
+
 				default: break;
 			}
 		}

--- a/Client/WarFare/UIStatSkillReset.cpp
+++ b/Client/WarFare/UIStatSkillReset.cpp
@@ -1,0 +1,371 @@
+﻿// CUIStatSkillReset.cpp: implementation of the CUIStatSkillReset class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "resource.h"
+
+#include "UIStatSkillReset.h"
+
+#include "GameProcedure.h"
+#include "GameProcMain.h"
+
+#include "PlayerMySelf.h"
+#include "PlayerOtherMgr.h"
+
+#include "UIManager.h"
+
+#include "APISocket.h"
+#include "GameDef.h"
+#include "PacketDef.h"
+
+#include <cmath>
+
+#include <afx.h>
+
+#ifdef _DEBUG
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#define new DEBUG_NEW
+#endif
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+CUIStatSkillReset::CUIStatSkillReset()
+{
+	//get player info
+	m_pInfo = &(CGameProcedure::s_pPlayer->m_InfoBase);
+	m_pInfoExt = &(CGameProcedure::s_pPlayer->m_InfoExt);
+}
+
+CUIStatSkillReset::~CUIStatSkillReset()
+{
+	
+}
+
+void CUIStatSkillReset::Release()
+{
+	CN3UIBase::Release();
+}
+
+bool CUIStatSkillReset::Load(HANDLE hFile)
+{
+	if (CN3UIBase::Load(hFile) == false)
+		return false;
+	
+	m_pBtn_WalkAway = (CN3UIButton*) GetChildByID("btn_close");		
+	__ASSERT(m_pBtn_WalkAway, "NULL UI Component!!");
+	m_pBtn_ResetStats = (CN3UIButton*) GetChildByID("Btn_repoint0");
+	__ASSERT(m_pBtn_ResetStats, "NULL UI Component!!");
+	m_pBtn_ResetSkills = (CN3UIButton*) GetChildByID("Btn_repoint1");
+	__ASSERT(m_pBtn_ResetSkills, "NULL UI Component!!");
+
+	return true;
+}
+
+void CUIStatSkillReset::UpdateRequiredCoinValues()
+{
+	//stats
+	//Required coins for stat reset
+	int RequiredCoinsStatReset = (int) pow((m_pInfo->iLevel * 2.0f), 3.4f);
+	if (m_pInfo->iLevel < 30)
+		RequiredCoinsStatReset = (int) (RequiredCoinsStatReset * 0.4f);
+	else if (m_pInfo->iLevel >= 60)
+		RequiredCoinsStatReset = (int) (RequiredCoinsStatReset * 1.5f);
+
+	// discount need to be implemented for client
+	/*if ((CGameBase::g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == GetNation())
+		|| g_pMain->m_sDiscount == 2)
+		RequiredCoinsStatReset /= 2;
+	*/
+	m_iRequiredCoinsStatReset = RequiredCoinsStatReset;
+
+	//skills
+
+	//Required coins for skill reset
+	int RequiredCoinsSkillReset = (int) pow((m_pInfo->iLevel * 2.0f), 3.4f);
+	if (m_pInfo->iLevel < 30)
+		RequiredCoinsSkillReset = (int) (RequiredCoinsSkillReset * 0.4f);
+	else if (m_pInfo->iLevel >= 60)
+		RequiredCoinsSkillReset = (int) (RequiredCoinsSkillReset * 1.5f);
+
+	RequiredCoinsSkillReset = (int) (RequiredCoinsSkillReset * 1.5f);
+
+	// need to be implemented for client
+	/*
+	if (g_pMain->m_sDiscount == 2 // or war discounts are enabled
+		|| (g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == m_bNation))
+		RequiredCoinsSkillReset /= 2;
+	*/
+	m_iRequiredCoinsSkillReset = RequiredCoinsSkillReset;
+}
+
+
+bool CUIStatSkillReset::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+
+	
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender == m_pBtn_WalkAway)
+		{
+			this->SetVisible(false);
+		}
+		else if (pSender == m_pBtn_ResetStats)
+		{
+			//close UI first
+			SetVisible(false);
+
+
+			//Send packet
+			std::string szTmp = "Resetting stats will cost %d, Do you want to proceed ?";
+			//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+			
+			char szMsg[80];
+			sprintf(szMsg, szTmp.c_str(), m_iRequiredCoinsStatReset);
+			CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_STAT_RESET);
+
+		}
+		else if (pSender == m_pBtn_ResetSkills)
+		{
+
+			//close UI first
+			SetVisible(false);
+
+		
+
+			//Send packet
+			std::string szTmp = "Resetting skills will cost %d, Do you want to proceed ?";
+			//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+			char szMsg[80];
+			sprintf(szMsg, szTmp.c_str(), m_iRequiredCoinsSkillReset);
+			CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_SKILL_RESET);
+
+		}
+
+
+		
+	}
+
+	return true;
+}
+
+
+
+bool CUIStatSkillReset::CanChangeStats()
+{
+	
+	//basic controlls should be added to avoid sending wrong packet on click
+	//isDead() ,isTrading(), isStoreOpen() ,isMerchanting(), isSellingMerchant()
+	
+	//level check, level must be higher than 10
+	if (m_pInfo->iLevel < m_iStatResetLevelMin)
+	{
+		ShowStatErrorLevel();
+		return false;
+	}
+
+	//Coins check
+	if (m_iRequiredCoinsStatReset > m_pInfoExt->iGold)
+	{
+		ShowStatErrorCoins();
+		return false;
+	}
+
+	//avoid sending wrong packet at UI
+	//inventory needs to be checked, no items should be equiped to reset stats
+
+
+
+	
+	return true;
+}
+
+bool CUIStatSkillReset::CanChangeSkills()
+{
+
+	//level check, level must be higher than 10
+
+
+	if (m_pInfo->iLevel < m_iSkillResetLevelMin)
+	{
+		ShowSkillErrorLevel();
+		return false;
+	}
+
+	//Coins check
+
+	if (m_iRequiredCoinsSkillReset > m_pInfoExt->iGold)
+	{
+		ShowSkillErrorCoins();
+		return false;
+	}
+
+	return true;
+}
+
+//show error messages to user
+//NOTE: this needs better organization, done to keep clean other parts
+//6116 = szText, npc distance need to checked
+void CUIStatSkillReset::ShowStatErrorLevel()
+{
+	std::string szTmp;
+	::_LoadStringFromResource(6610, szTmp);
+	char szMsg[80];
+	sprintf(szMsg, szTmp.c_str(), m_iSkillResetLevelMin);
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorCoins()
+{
+	//std::string szTmp = "You need %d Coins, to reset your stats !";
+	std::string szMsg;
+	::_LoadStringFromResource(6306, szMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorEquipedItem()
+{
+	std::string szMsg;
+	::_LoadStringFromResource(6112, szMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorAlreadyReset()
+{
+	std::string szMsg = "Error : Stats have already been reset !.";
+		//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorAlreadyReset()
+{
+	std::string szMsg = "Error : Skills have already been reset !.";
+		//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorLevel()
+{
+	std::string szTmp;
+	::_LoadStringFromResource(6610, szTmp);
+	char szMsg[80];
+	sprintf(szMsg, szTmp.c_str(), m_iSkillResetLevelMin);
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorCoins()
+{
+	std::string szMsg;
+	::_LoadStringFromResource(6306, szMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatResetSuccess()
+{
+	std::string szMsg = "Stats have been reset successfully.";
+		//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+	
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillResetSuccess()
+{
+	std::string szMsg = "Skills have been reset successfully.";
+		//::_LoadStringFromResource(IDS_CLAN_WARNING_COST, szTmp);
+
+	CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_OK);
+}
+
+
+//end of error messages
+
+void CUIStatSkillReset::MsgSend_ResetStats()
+{
+
+	
+	//don't send packet if not met requirements
+	if (!CanChangeStats()) 
+	{
+		return;
+	}
+
+	uint8_t byBuff[2];
+	int iOffset = 0;
+	CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_STAT_SKILL_RESET);
+	CAPISocket::MP_AddByte(byBuff, iOffset, STAT_RESET_REQ);
+	CGameProcedure::s_pSocket->Send(byBuff, iOffset);
+}
+
+void CUIStatSkillReset::MsgSend_ResetSkills()
+{
+	
+	//don't send packet if not met requirements
+	if (!CanChangeSkills())
+	{
+		return;
+	}
+
+	uint8_t byBuff[2];
+	int iOffset = 0;
+	CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_STAT_SKILL_RESET);
+	CAPISocket::MP_AddByte(byBuff, iOffset, SKILL_RESET_REQ);
+	CGameProcedure::s_pSocket->Send(byBuff, iOffset);
+
+}
+
+void CUIStatSkillReset::Open()
+{
+	SetVisible(true);
+	if (m_pBtn_WalkAway)
+	{
+		if (!m_pBtn_WalkAway->IsVisible())
+		{
+			m_pBtn_WalkAway->SetVisible(true);
+		}
+	}
+
+	if (m_pBtn_ResetStats)
+	{
+		if (!m_pBtn_ResetStats->IsVisible())
+		{
+			m_pBtn_ResetStats->SetVisible(true);
+		}
+	}
+
+	if (m_pBtn_ResetSkills)
+	{
+		if (!m_pBtn_ResetSkills->IsVisible())
+		{
+			m_pBtn_ResetSkills->SetVisible(true);
+		}
+	}
+
+	UpdateRequiredCoinValues();
+}
+
+
+
+bool CUIStatSkillReset::OnKeyPress(int iKey)
+{
+	if (DIK_ESCAPE == iKey)
+	{
+		SetVisible(false);
+		return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUIStatSkillReset::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}
+

--- a/Client/WarFare/UIStatSkillReset.h
+++ b/Client/WarFare/UIStatSkillReset.h
@@ -1,0 +1,68 @@
+﻿// CUIStatSkillReset.h: interface for the CUIStatSkillReset class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_)
+#define AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_
+#endif // !defined(AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_)
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include "GameDef.h"
+
+#include "N3UIBase.h"
+#include "N3UIButton.h"
+#include "N3UIString.h"
+#include "N3UIImage.h"
+#include "PlayerMySelf.h"
+
+
+class CUIStatSkillReset : public CN3UIBase
+{
+private:
+	__InfoPlayerBase* m_pInfo;
+	__InfoPlayerMySelf* m_pInfoExt;
+public:
+	CN3UIButton* m_pBtn_WalkAway;
+	CN3UIButton* m_pBtn_ResetStats;
+	CN3UIButton* m_pBtn_ResetSkills;
+
+	CN3UIString* m_pStr_TextWalkAway;
+	CN3UIString* m_pStr_TextResetStats;
+	CN3UIString* m_pStr_TextResetSkills;
+	CN3UIString* m_pStr_TextTitle;
+
+
+public:
+	int m_iRequiredCoinsStatReset;
+	int m_iRequiredCoinsSkillReset;
+	int m_iStatResetLevelMin = 10;
+	int m_iSkillResetLevelMin = 10;
+
+	bool OnKeyPress(int iKey);
+	void Release();
+	void Open();
+	void SetVisible(bool bVisible);
+	bool	Load(HANDLE hFile);
+	bool	ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg);
+	void MsgSend_ResetStats();
+	void MsgSend_ResetSkills();
+	bool CanChangeStats();
+	bool CanChangeSkills();
+	void ShowStatErrorLevel();
+	void ShowStatErrorCoins();
+	void ShowStatErrorEquipedItem();
+	void ShowStatErrorAlreadyReset();
+	void ShowSkillErrorAlreadyReset();
+	void ShowSkillErrorLevel();
+	void ShowSkillErrorCoins();
+	void ShowStatResetSuccess();
+	void ShowSkillResetSuccess();
+	void UpdateRequiredCoinValues();
+	CUIStatSkillReset();
+	virtual ~CUIStatSkillReset();
+};
+
+

--- a/Server/GameServer/CharacterMovementHandler.cpp
+++ b/Server/GameServer/CharacterMovementHandler.cpp
@@ -335,13 +335,16 @@ void CUser::ZoneChange(uint16_t sNewZone, float x, float z)
 	WarpListResponse errorReason;
 	if (!CanChangeZone(pMap, errorReason))
 	{
-		Packet result(WIZ_WARP_LIST);
+		Packet result;
 
-		result << uint8_t(2) << uint8_t(errorReason);
+		result << uint8_t(WIZ_WARP_LIST); //packet header
+		result << uint8_t(false);   //packet result is false
+		result << uint8_t(errorReason);   //errorReason
 
-		if (errorReason == WarpListMinLevel)
-			result << pMap->GetMinLevelReq();
-
+		//additional required level info
+		if (errorReason == WarpListMinLevel) 
+			result << pMap->GetMinLevelReq(); 
+	
 		Send(&result);
 		return;
 	}

--- a/Server/GameServer/LuaEngine.cpp
+++ b/Server/GameServer/LuaEngine.cpp
@@ -23,6 +23,7 @@ DEFINE_LUA_FUNCTION_TABLE(g_globalFunctions,
 						  MAKE_LUA_FUNCTION(CheckClanGrade)
 						  MAKE_LUA_FUNCTION(CheckLoyalty)
 						  MAKE_LUA_FUNCTION(SelectMsg)
+						  MAKE_LUA_FUNCTION(OpenStatSkillReset)
 						  MAKE_LUA_FUNCTION(CastSkill)
 						  MAKE_LUA_FUNCTION(GetName)
 						  MAKE_LUA_FUNCTION(GetAccountName)

--- a/Server/GameServer/User.cpp
+++ b/Server/GameServer/User.cpp
@@ -414,6 +414,10 @@ bool CUser::HandlePacket(Packet & pkt)
 	case WIZ_SELECT_MSG:
 		RecvSelectMsg(pkt);
 		break;
+	case WIZ_STAT_SKILL_RESET:
+		TRACE("\nUser.cpp | WIZ_STAT_SKILL_RESET\n");
+		HandleStatSkillReset(pkt);
+		break;
 	case WIZ_ITEM_UPGRADE:
 		ItemUpgradeProcess(pkt);
 		break;
@@ -444,6 +448,9 @@ bool CUser::HandlePacket(Packet & pkt)
 	Update();
 	return true;
 }
+
+
+
 
 /**
 * @brief	Updates timed player data, e.g. skills & save requests.
@@ -2629,6 +2636,8 @@ void CUser::StateChangeServerDirect(uint8_t bType, uint32_t nBuff)
 	SendToRegion(&result);
 }
 
+
+
 /**
 * @brief	Takes a target's loyalty points (NP)
 * 			and rewards some/all to the killer (current user).
@@ -3969,6 +3978,244 @@ void CUser::AllPointChange(bool bIsFree)
 fail_return:
 	result << bResult << temp_money;
 	Send(&result);
+}
+
+bool CUser::StatReset(int & coins)
+{
+	
+	uint16_t statTotal, byStr, bySta, byDex, byInt, byCha;
+
+	
+	// TODO: Pull this from the database.
+	switch (m_bRace)
+	{
+		case KARUS_BIG:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_MIDDLE:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_SMALL:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_WOMAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case BABARIAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case ELMORAD_MAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case ELMORAD_WOMAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+	}
+
+	// Players gain 3 stats points for each level up to and including 60.
+	// They also received 10 free stat points on creation. 
+	m_sPoints = 10 + (GetLevel() - 1) * 3;
+
+	// For every level after 60, we add an additional two points.
+	if (GetLevel() > 60)
+		m_sPoints += 2 * (GetLevel() - 60);
+
+	statTotal = GetStatTotal();
+	ASSERT(statTotal == 290);
+	m_iGold -= coins;
+
+	SetUserAbility();
+	Send2AI_UserUpdateInfo();
+	
+	byStr = GetStat(STAT_STR);
+	bySta = GetStat(STAT_STA),
+	byDex = GetStat(STAT_DEX);
+	byInt = GetStat(STAT_INT),
+	byCha = GetStat(STAT_CHA);
+
+	return true;
+	
+}
+
+bool CUser::SkillReset(int & coins)
+{
+	int index = 0, skill_point = 0, money = 0, temp_value = 0, old_money = 0;
+	uint8_t type = 0;
+
+	// Get total skill points
+	for (int i = 1; i < 9; i++)
+		skill_point += m_bstrSkill[i];
+
+	// If we don't have any skill points, there's no point resetting now is there.
+	if (skill_point <= 0)
+	{
+		type = 2;
+		return false;
+	}
+
+	// Reset skill points.
+	m_bstrSkill[0] = (GetLevel() - 9) * 2;
+	for (int i = 1; i < 9; i++)
+		m_bstrSkill[i] = 0;
+
+	m_iGold -= coins;
+	Send2AI_UserUpdateInfo();
+
+	return true;
+
 }
 
 void CUser::GoldChange(int16_t tid, int gold)

--- a/Server/GameServer/User.h
+++ b/Server/GameServer/User.h
@@ -551,6 +551,7 @@ public:
 	bool JobGroupCheck(int16_t jobgroupid);
 	void SendSay(int32_t nTextID[10]);
 	void SelectMsg(int32_t menuHeaderText, int32_t menuButtonText[MAX_MESSAGE_EVENT], int32_t menuButtonEvents[MAX_MESSAGE_EVENT]);
+	void OpenStatSkillReset();
 
 	// NOTE(srmeier): testing this debug string functionality
 	void SendDebugString(const char* pString);
@@ -749,6 +750,11 @@ public:
 	void ClassChangeReq();
 	void SendStatSkillDistribute();
 	void AllPointChange(bool bIsFree = false);
+	
+	//AllPointChange & AllSkillPointChange replaced with
+	bool StatReset(int & coins);
+	bool SkillReset(int & coins);
+
 	void AllSkillPointChange(bool bIsFree = false);
 
 	void CountConcurrentUser();
@@ -788,6 +794,11 @@ public:
 	bool AttemptSelectMsg(uint8_t byMenuID);
 
 	// from the client
+	void HandleStatSkillReset(Packet& pkt);
+	void SendStatSkillResetFailed(e_StatSkillResetOpcode opcode);
+
+
+
 	void ItemUpgradeProcess(Packet & pkt);
 	void ItemUpgrade(Packet & pkt, uint8_t nUpgradeType = ITEM_UPGRADE_PROCESS);
 	void ItemUpgradeNotice(_ITEM_TABLE * pItem, uint8_t UpgradeResult);
@@ -941,6 +952,7 @@ public:
 	void ReqChangeName(Packet & pkt);
 	void ReqChangeCape(Packet & pkt);
 	void InsertTaxUpEvent(uint8_t Nation, uint32_t TerritoryTax);
+	void ReqStatSkillReset(Packet& pkt);
 
 	//private:
 	static ChatCommandTable s_commandTable;
@@ -1150,6 +1162,13 @@ public:
 
 		LUA_NO_RETURN(pUser->SelectMsg(menuHeaderText, menuButtonText, menuButtonEvents));
 	}
+
+	//NOTE:
+	DECLARE_LUA_FUNCTION(OpenStatSkillReset) {
+		LUA_NO_RETURN(LUA_GET_INSTANCE()->OpenStatSkillReset());
+	}
+
+	
 
 	DECLARE_LUA_FUNCTION(CheckWeight) {
 		LUA_RETURN(LUA_GET_INSTANCE()->CheckWeight(

--- a/Server/GameServer/lua_bindings.cpp
+++ b/Server/GameServer/lua_bindings.cpp
@@ -106,6 +106,7 @@ DEFINE_LUA_CLASS
 	MAKE_LUA_METHOD(RobLoyalty)
 	MAKE_LUA_METHOD(SaveEvent)
 	MAKE_LUA_METHOD(SelectMsg) // menu
+	MAKE_LUA_METHOD(OpenStatSkillReset) // send packet for stat/skill reset UI
 	MAKE_LUA_METHOD(NpcSay) // dialog
 	MAKE_LUA_METHOD(CheckWeight)
 	MAKE_LUA_METHOD(CheckSkillPoint)
@@ -355,6 +356,15 @@ LUA_FUNCTION(SelectMsg)
 	}
 
 	LUA_NO_RETURN(pUser->SelectMsg(menuHeaderText, menuButtonText, menuButtonEvents));
+}
+
+LUA_FUNCTION(OpenStatSkillReset)
+{
+	CUser * pUser = Lua_GetUser();
+	if (pUser == nullptr)
+		return LUA_NO_RESULTS;
+
+	LUA_NO_RETURN(pUser->OpenStatSkillReset());
 }
 
 LUA_FUNCTION(CastSkill)

--- a/Server/GameServer/lua_bindings.h
+++ b/Server/GameServer/lua_bindings.h
@@ -14,6 +14,7 @@ LUA_FUNCTION(ShowEffect);
 LUA_FUNCTION(ShowNpcEffect);
 LUA_FUNCTION(PromoteKnight);
 LUA_FUNCTION(SelectMsg);
+LUA_FUNCTION(OpenStatSkillReset);
 LUA_FUNCTION(CastSkill);
 LUA_FUNCTION(GetName);
 LUA_FUNCTION(GetAccountName);

--- a/Server/bin/Debug/QUESTS/21.lua
+++ b/Server/bin/Debug/QUESTS/21.lua
@@ -2553,7 +2553,7 @@ elseif nEventID == 21126 then
 	pUser:SelectMsg(21128, 21130, 21130, 21135, 21135, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
 elseif nEventID == 21129 then
 	pUser:NpcSay(21125, 21126, -1, -1, -1, -1, -1, -1);
-elseif nEventID == 21130 then	
+elseif nEventID == 21130 then
 	if not pUser:CheckExistEvent(11,2) then
 	local lvl = pUser:GetLevel();
 	if lvl >= 10 and lvl <= 99 then
@@ -2683,7 +2683,7 @@ elseif nEventID == 21288 then
 	do return; end
 	end
 elseif nEventID == 21951 then
-	pUser:SendDebugString("Unknown EXEC command 'STAT_POINT_DISTRIBUTE'."); -- unknown execute command (STAT_POINT_DISTRIBUTE)
+	pUser:OpenStatSkillReset();
 	do return; end
 elseif nEventID == 21981 then
 	pUser:SendDebugString("Unknown EXEC command 'SKILL_POINT_DISTRIBUTE'."); -- unknown execute command (SKILL_POINT_DISTRIBUTE)

--- a/Server/bin/Release/QUESTS/21.lua
+++ b/Server/bin/Release/QUESTS/21.lua
@@ -2684,7 +2684,7 @@ elseif nEventID == 21288 then
 	do return; end
 	end
 elseif nEventID == 21951 then
-	pUser:SendDebugString("Unknown EXEC command 'STAT_POINT_DISTRIBUTE'."); -- unknown execute command (STAT_POINT_DISTRIBUTE)
+	pUser:OpenStatSkillReset();
 	do return; end
 elseif nEventID == 21981 then
 	pUser:SendDebugString("Unknown EXEC command 'SKILL_POINT_DISTRIBUTE'."); -- unknown execute command (SKILL_POINT_DISTRIBUTE)

--- a/Server/shared/packets.h
+++ b/Server/shared/packets.h
@@ -123,6 +123,7 @@
 #define WIZ_SKILLDATA			0x79
 #define WIZ_PROGRAMCHECK		0x7A
 #define WIZ_BIFROST				0x7B
+#define WIZ_STAT_SKILL_RESET	0x7C //stat & skill reset 124
 #define WIZ_SERVER_KILL			0x7F
 
 // NOTE(srmeier): testing this debug string functionality
@@ -489,6 +490,23 @@ enum e_ItemUpgradeOpcode
 	ITEM_BIFROST_REQ			= 4,
 	ITEM_BIFROST_EXCHANGE		= 5,
 };
+
+enum e_StatSkillResetOpcode {
+	STAT_SKILL_RESET_REQ = 1,
+	STAT_RESET_REQ = 2,
+	SKILL_RESET_REQ = 3,
+	STAT_RESET_LEVEL_TOO_LOW = 4,
+	SKILL_RESET_LEVEL_TOO_LOW = 5,
+	STAT_RESET_NO_GOLD = 6,
+	SKILL_RESET_NO_GOLD = 7,
+	STAT_RESET_ITEMS_EQUIPED = 8,
+	STAT_RESET_SUCCESS = 9,
+	SKILL_RESET_SUCCESS = 10,
+	STAT_ALREADY_RESET = 11,
+	SKILL_ALREADY_RESET = 12,
+	STAT_SKILL_RESET_SUCCESS = 13,
+};
+
 
 ////////////////////////////////////////////////////////////////
 // Party BBS subpacket define


### PR DESCRIPTION
I was working on this before new update of GetText() so my LoadStringFromResource should be replaced with new method. This is a working skill & stat reset for openko. We can use it for testing. Some string could not be found in .tbl files ( Texts_us ) so new not original messages generated. Maybe in the future text issues can be solved. Some client side controlls skipped ( like : isDead, isTrading etc. ) they can be added later, they have been checked on gameserver for now. 

For this to work
Server/bin/Debug/Quests/21.lua
Server/bin/Release/Quests/21.lua
where nEventID == 21951
change as 
elseif nEventID == 21951 then
	pUser:OpenStatSkillReset();
	do return; end
 should be changed as mentioned on top, I force pushed those because git don't track them. 
 
 Thank you for maintaining this nice project. Soon I will update latest version to commit properly.

#changed files

Client
GameProcMain.cpp
GameProcMain.h
UIMessageBox.cpp
UIStatSkillReset.cpp
UIStatSkillReset.h
GameDef.h ( button behaviors )

Server/shared
packets.h

Server
LuaEngine.cpp
lua_bindings.cpp
lua_bindings.h
NPCHandler.cpp
User.h
User.cpp

Server/bin/Debug/Quests/21.lua
Server/bin/Release/Quests/21.lua
where nEventID == 21951
change as 
elseif nEventID == 21951 then
	pUser:OpenStatSkillReset();
	do return; end