### PR TITLE
fx particle crash fix

### DIFF
--- a/Client/N3Base/N3FXBundleGame.cpp
+++ b/Client/N3Base/N3FXBundleGame.cpp
@@ -558,9 +558,19 @@ bool CN3FXBundleGame::Load(HANDLE hFile)
 		{
 			int iType;
 
+			if (i != 0)
+			{
+				//push right 2 bytes, need to read 2 bytes of data here -- 01 01 hex
+				SetFilePointer(hFile, 2, NULL, FILE_CURRENT);
+			}
+
 			ReadFile(hFile, &iType, sizeof(int), &dwRWC, NULL);
 
-			if(iType == FX_PART_TYPE_NONE) continue;
+			if (iType == FX_PART_TYPE_NONE)
+			{
+				SetFilePointer(hFile, -2, NULL, FILE_CURRENT);
+				continue;
+			} 
 
 			else if(iType == FX_PART_TYPE_PARTICLE)
 			{

--- a/Client/N3Base/N3FXPartBase.cpp
+++ b/Client/N3Base/N3FXPartBase.cpp
@@ -493,6 +493,10 @@ bool CN3FXPartBase::Load(HANDLE hFile)
 		else m_bAlpha = FALSE;		
 	}
 	
+	//this is not required as long as file read correct
+	if (m_iNumTex >= 19)
+		m_iNumTex = 1;
+
 	m_ppRefTex = new CN3Texture* [m_iNumTex];
 
 	std::string FileName;


### PR DESCRIPTION
this address issue #104 

fx files read wrong after 1st. Some data which is 2 byte long is not read at all and so the following readings are wrong and this causes game crash because of too big trash data from the file. 

2 byte offset has been add to fix this issue and to avoid crash simple controll has been added ( which is not be needed as long as file read correctly, but at this stage I am not sure about all the files / skills ) 

tested most of the skills works OK, some skill animations are incomplete like safety (rogue), and some are different from the original version ( like 45 mage skills, staff skills etc. )