### PR TITLE
stat skill reset that works fully, cleaned up version

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -1242,7 +1242,8 @@ enum e_Behavior {	BEHAVIOR_NOTHING = 0,
 					BEHAVIOR_PARTY_BBS_REGISTER_CANCEL, // 파티 게시판에 등록 해제
 
 					BEHAVIOR_EXECUTE_OPTION,			// 게임 종료하고 옵션 실행..
-				
+					BEHAVIOR_STAT_RESET,				//user clicked confirm on stat reset
+					BEHAVIOR_SKILL_RESET,				//user clicked confirm on skill reset
 					BEHAVIOR_UNKNOWN = 0xffffffff
 				};
 

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -59,7 +59,7 @@ public:
 	class CUITradeBBSEditDlg*	m_pUITradeBBSEdit;				// 상거래 게시물 설명
 
 	class CUIUpgradeSelect*		m_pUIUpgradeSelect;
-
+	class CUIStatSkillReset*	m_pUIStatSkillReset;			//stat & skill reset UI
 	class CN3Shape*				m_pTargetSymbol;				// 플레이어가 타겟으로 잡은 캐릭터의 위치위에 그리면 된다..
 
 	class CN3SndObjStream*		m_pSnd_Town, *m_pSnd_Battle;	//마을음악, 전투음악 포인터..
@@ -204,7 +204,7 @@ protected:
 	void	MsgRecv_Knights_Duty_Change(Packet& pkt);
 	void	MsgRecv_Knigts_Join_Req(Packet& pkt);
 	void	MsgRecv_ItemUpgrade(Packet& pkt);
-
+	void	MsgRecv_ResetStatSkill(Packet& pkt);
 public:
 	void	ProcessUIKeyInput(bool bEnable = true);
 	bool	OnMouseMove(POINT ptCur, POINT ptPrev);

--- a/Client/WarFare/UIMessageBox.cpp
+++ b/Client/WarFare/UIMessageBox.cpp
@@ -18,6 +18,7 @@
 #include "SubProcPerTrade.h"
 #include <shellapi.h>
 #include "APISocket.h"
+#include "UIStatSkillReset.h"
 
 #include "N3UIButton.h"
 #include "N3UIString.h"
@@ -157,6 +158,14 @@ bool CUIMessageBox::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 						::ShellExecute(NULL, "open", "Option.exe", NULL, NULL, SW_SHOWNORMAL); // 홈페이지로 이동..
 						PostQuitMessage(0);	// 종료...
 					}
+					break;
+				case BEHAVIOR_STAT_RESET:
+					if (pProcMain->m_pUIStatSkillReset)
+						pProcMain->m_pUIStatSkillReset->MsgSend_ResetStats();
+					break;
+				case BEHAVIOR_SKILL_RESET:
+					if (pProcMain->m_pUIStatSkillReset)
+						pProcMain->m_pUIStatSkillReset->MsgSend_ResetSkills();
 					break;
 				default: break;
 			}

--- a/Client/WarFare/UIStatSkillReset.cpp
+++ b/Client/WarFare/UIStatSkillReset.cpp
@@ -1,0 +1,370 @@
+﻿// CUIStatSkillReset.cpp: implementation of the CUIStatSkillReset class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+//#include "resource.h"
+
+#include "UIStatSkillReset.h"
+
+#include "GameProcedure.h"
+#include "GameProcMain.h"
+
+#include "PlayerMySelf.h"
+#include "PlayerOtherMgr.h"
+
+#include "UIManager.h"
+
+#include "APISocket.h"
+#include "GameDef.h"
+#include "PacketDef.h"
+
+#include <cmath>
+#include <afx.h>
+
+#ifdef _DEBUG
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#define new DEBUG_NEW
+#endif
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+CUIStatSkillReset::CUIStatSkillReset()
+{
+	//get player info
+	m_pInfo = &(CGameProcedure::s_pPlayer->m_InfoBase);
+	m_pInfoExt = &(CGameProcedure::s_pPlayer->m_InfoExt);
+}
+
+CUIStatSkillReset::~CUIStatSkillReset()
+{
+
+}
+
+void CUIStatSkillReset::Release()
+{
+	CN3UIBase::Release();
+}
+
+bool CUIStatSkillReset::Load(HANDLE hFile)
+{
+	if (CN3UIBase::Load(hFile) == false)
+		return false;
+
+	m_pBtn_WalkAway = (CN3UIButton*) GetChildByID("btn_close");
+	__ASSERT(m_pBtn_WalkAway, "NULL UI Component!!");
+	m_pBtn_ResetStats = (CN3UIButton*) GetChildByID("Btn_repoint0");
+	__ASSERT(m_pBtn_ResetStats, "NULL UI Component!!");
+	m_pBtn_ResetSkills = (CN3UIButton*) GetChildByID("Btn_repoint1");
+	__ASSERT(m_pBtn_ResetSkills, "NULL UI Component!!");
+
+	return true;
+}
+
+void CUIStatSkillReset::UpdateRequiredCoinValues()
+{
+	//Required coins for stat reset
+	int iCoinsStatReset = (int) pow((m_pInfo->iLevel * 2.0f), 3.4f);
+	if (m_pInfo->iLevel < 30)
+		iCoinsStatReset = (int) (iCoinsStatReset * 0.4f);
+	else if (m_pInfo->iLevel >= 60)
+		iCoinsStatReset = (int) (iCoinsStatReset * 1.5f);
+
+	// discount need to be implemented for client
+	/*if ((g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == GetNation())
+		|| g_pMain->m_sDiscount == 2)
+		iCoinsStatReset /= 2;
+	*/
+
+	m_iRequiredCoinsStatReset = iCoinsStatReset;
+	m_sRequiredCoinsStatReset = FormatCoin(iCoinsStatReset);
+
+	//Required coins for skill reset
+	int iCoinsSkillReset = (int) pow((m_pInfo->iLevel * 2.0f), 3.4f);
+	if (m_pInfo->iLevel < 30)
+		iCoinsSkillReset = (int) (iCoinsSkillReset * 0.4f);
+	else if (m_pInfo->iLevel >= 60)
+		iCoinsSkillReset = (int) (iCoinsSkillReset * 1.5f);
+
+	iCoinsSkillReset = (int) (iCoinsSkillReset * 1.5f);
+	// discount need to be implemented for client
+	/*
+	if (g_pMain->m_sDiscount == 2 // or war discounts are enabled
+		|| (g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == m_bNation))
+		iCoinsSkillReset /= 2;
+	*/
+
+	m_iRequiredCoinsSkillReset = iCoinsSkillReset;
+	m_sRequiredCoinsSkillReset = FormatCoin(iCoinsSkillReset);
+}
+
+std::string CUIStatSkillReset::FormatCoin(int iCoin)
+{
+	//same as in UIInventory
+	char szBuff[32] = "";
+	sprintf(szBuff, "%d", iCoin);
+	int buffLength = strlen(szBuff);
+	int goldLength = buffLength + (buffLength / 3) - (buffLength % 3 == 0 ? 1 : 0);
+
+	char szGold[42] = "";
+	szGold[goldLength] = '\0';
+
+	for (int i = buffLength - 1, k = goldLength - 1; i >= 0; i--, k--)
+	{
+		if ((buffLength - 1 - i) % 3 == 0 && (buffLength - 1 != i))
+			szGold[k--] = ',';
+
+		szGold[k] = szBuff[i];
+	}
+
+	return std::string(szGold);
+}
+
+
+bool CUIStatSkillReset::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+
+
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender == m_pBtn_WalkAway)
+		{
+			this->SetVisible(false);
+		}
+		else if (pSender == m_pBtn_ResetStats)
+		{
+			//close UI first
+			SetVisible(false);
+
+			//Send packet
+			std::string szTmp = "Resetting stats will cost %s. Do you want to proceed ?";
+			char szMsg[80];
+			sprintf(szMsg, szTmp.c_str(), m_sRequiredCoinsStatReset.c_str());
+			CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_STAT_RESET);
+
+		}
+		else if (pSender == m_pBtn_ResetSkills)
+		{
+			//close UI first
+			SetVisible(false);
+
+			std::string szTmp = "Resetting skills will cost %s. Do you want to proceed ?";
+			char szMsg[80];
+			sprintf(szMsg, szTmp.c_str(), m_sRequiredCoinsSkillReset.c_str());
+			CGameProcedure::s_pProcMain->MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_SKILL_RESET);
+		}
+
+
+
+	}
+
+	return true;
+}
+
+
+
+bool CUIStatSkillReset::CanChangeStats()
+{
+
+	//TODO: basic controlls should be added to avoid sending wrong packet on click
+	//isDead() ,isTrading(), isStoreOpen() ,isMerchanting(), isSellingMerchant()
+	
+	//level check, level must be higher than 10
+	if (m_pInfo->iLevel < m_iStatResetLevelMin)
+	{
+		ShowStatErrorLevel();
+		return false;
+	}
+
+	//Coins check
+	if (m_iRequiredCoinsStatReset > m_pInfoExt->iGold)
+	{
+		ShowStatErrorCoins();
+		return false;
+	}
+
+	//avoid sending wrong packet at Client
+	//TODO: inventory needs to be checked, no items should be equiped to reset stats
+
+
+
+
+	return true;
+}
+
+bool CUIStatSkillReset::CanChangeSkills()
+{
+	//level check, level must be higher than 10
+	if (m_pInfo->iLevel < m_iSkillResetLevelMin)
+	{
+		ShowSkillErrorLevel();
+		return false;
+	}
+
+	//Coins check
+	if (m_iRequiredCoinsSkillReset > m_pInfoExt->iGold)
+	{
+		ShowSkillErrorCoins();
+		return false;
+	}
+
+	return true;
+}
+
+//NOTE: error messages can be merged into one function ShowMessage(int iTextID)
+//but some of the messages are not in TBL files
+void CUIStatSkillReset::ShowStatErrorLevel()
+{
+	std::string strMsg;
+	CGameBase::GetText(6610, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorCoins()
+{
+	std::string strMsg;
+	CGameBase::GetText(6306, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorEquipedItem()
+{
+	std::string strMsg;
+	CGameBase::GetText(6112, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorLevel()
+{
+	std::string strMsg;
+	CGameBase::GetText(6610, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorCoins()
+{
+	std::string strMsg;
+	CGameBase::GetText(6306, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowStatErrorUnusedPoints()
+{
+	std::string strMsg = "You have unused stat points!";
+	//CGameBase::GetText(iID, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillErrorUnusedPoints()
+{
+	std::string strMsg = "You have unused skill points!";
+	//CGameBase::GetText(iID, &strMsg);
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+//NOTE: Trigger healing animation instead of showing message on success
+//but healing animation crash game FXParticles 
+void CUIStatSkillReset::ShowStatResetSuccess()
+{
+	std::string strMsg = "Stats have been reset successfully.";
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+void CUIStatSkillReset::ShowSkillResetSuccess()
+{
+	std::string strMsg = "Skills have been reset successfully.";
+	CGameProcedure::s_pProcMain->MessageBoxPost(strMsg, "", MB_OK);
+}
+
+//packet senders
+void CUIStatSkillReset::MsgSend_ResetStats()
+{
+	//don't send packet if not met requirements
+	if (!CanChangeStats())
+	{
+		return;
+	}
+	
+	uint16_t iPlayerTargetID = CGameProcMain::s_pPlayer->m_iIDTarget;
+
+	uint8_t byBuff[8];
+	int iOffset = 0;
+	CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_STAT_SKILL_RESET);
+	CAPISocket::MP_AddByte(byBuff, iOffset, STAT_RESET_REQ);
+	CAPISocket::MP_AddWord(byBuff, iOffset, iPlayerTargetID);
+
+	CGameProcedure::s_pSocket->Send(byBuff, iOffset);
+}
+
+void CUIStatSkillReset::MsgSend_ResetSkills()
+{
+	//don't send packet if not met requirements
+	if (!CanChangeSkills())
+	{
+		return;
+	}
+
+	uint16_t iPlayerTargetID = CGameProcMain::s_pPlayer->m_iIDTarget;
+	
+	uint8_t byBuff[8];
+	int iOffset = 0;
+	CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_STAT_SKILL_RESET);
+	CAPISocket::MP_AddByte(byBuff, iOffset, SKILL_RESET_REQ);
+	CAPISocket::MP_AddWord(byBuff, iOffset, iPlayerTargetID);
+
+	CGameProcedure::s_pSocket->Send(byBuff, iOffset);
+}
+
+void CUIStatSkillReset::Open()
+{
+	SetVisible(true);
+	if (m_pBtn_WalkAway)
+	{
+		if (!m_pBtn_WalkAway->IsVisible())
+		{
+			m_pBtn_WalkAway->SetVisible(true);
+		}
+	}
+
+	if (m_pBtn_ResetStats)
+	{
+		if (!m_pBtn_ResetStats->IsVisible())
+		{
+			m_pBtn_ResetStats->SetVisible(true);
+		}
+	}
+
+	if (m_pBtn_ResetSkills)
+	{
+		if (!m_pBtn_ResetSkills->IsVisible())
+		{
+			m_pBtn_ResetSkills->SetVisible(true);
+		}
+	}
+
+	UpdateRequiredCoinValues();
+}
+
+
+
+bool CUIStatSkillReset::OnKeyPress(int iKey)
+{
+	if (DIK_ESCAPE == iKey)
+	{
+		SetVisible(false);
+		return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUIStatSkillReset::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}

--- a/Client/WarFare/UIStatSkillReset.h
+++ b/Client/WarFare/UIStatSkillReset.h
@@ -1,0 +1,69 @@
+﻿// CUIStatSkillReset.h: interface for the CUIStatSkillReset class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_)
+#define AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_
+#endif // !defined(AFX_UICmd_H__CA4F5382_D9A9_447C_B717_7A0A38724715__INCLUDED_)
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include "GameDef.h"
+
+#include "N3UIBase.h"
+#include "N3UIButton.h"
+#include "N3UIString.h"
+#include "N3UIImage.h"
+#include "PlayerMySelf.h"
+
+
+class CUIStatSkillReset : public CN3UIBase
+{
+private:
+	__InfoPlayerBase* m_pInfo;
+	__InfoPlayerMySelf* m_pInfoExt;
+public:
+	CN3UIButton* m_pBtn_WalkAway;
+	CN3UIButton* m_pBtn_ResetStats;
+	CN3UIButton* m_pBtn_ResetSkills;
+
+	CN3UIString* m_pStr_TextWalkAway;
+	CN3UIString* m_pStr_TextResetStats;
+	CN3UIString* m_pStr_TextResetSkills;
+	CN3UIString* m_pStr_TextTitle;
+
+
+public:
+	int m_iRequiredCoinsStatReset = 0;
+	int m_iRequiredCoinsSkillReset = 0;
+	uint8_t m_iStatResetLevelMin = 10;
+	uint8_t m_iSkillResetLevelMin = 10;
+	std::string m_sRequiredCoinsStatReset;
+	std::string m_sRequiredCoinsSkillReset;
+
+	bool OnKeyPress(int iKey);
+	void Release();
+	void Open();
+	void SetVisible(bool bVisible);
+	bool	Load(HANDLE hFile);
+	bool	ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg);
+	void MsgSend_ResetStats();
+	void MsgSend_ResetSkills();
+	bool CanChangeStats();
+	bool CanChangeSkills();
+	void ShowStatErrorLevel();
+	void ShowStatErrorCoins();
+	void ShowStatErrorEquipedItem();
+	void ShowSkillErrorLevel();
+	void ShowSkillErrorCoins();
+	void ShowStatErrorUnusedPoints();
+	void ShowSkillErrorUnusedPoints();
+	void ShowStatResetSuccess();
+	void ShowSkillResetSuccess();
+	void UpdateRequiredCoinValues();
+	std::string FormatCoin(int iCoin);
+	CUIStatSkillReset();
+	virtual ~CUIStatSkillReset();
+};

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -48,6 +48,8 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
     <TargetName>KnightOnLine</TargetName>
+    <IncludePath>$(IncludePath);$(DependencyDir)dx9sdk\Include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include</IncludePath>
+    <LibraryPath>$(DependencyDir)dx9sdk\Lib\x86;$(LibraryPath);C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -175,6 +177,7 @@
     <ClCompile Include="UIRepairTooltipDlg.cpp" />
     <ClCompile Include="UISkillTreeDlg.cpp" />
     <ClCompile Include="UIStateBar.cpp" />
+    <ClCompile Include="UIStatSkillReset.cpp" />
     <ClCompile Include="UITargetBar.cpp" />
     <ClCompile Include="UITradeBBSEditDlg.cpp" />
     <ClCompile Include="UITradeBBSSelector.cpp" />
@@ -286,6 +289,7 @@
     <ClInclude Include="UIRepairTooltipDlg.h" />
     <ClInclude Include="UISkillTreeDlg.h" />
     <ClInclude Include="UIStateBar.h" />
+    <ClInclude Include="UIStatSkillReset.h" />
     <ClInclude Include="UITargetBar.h" />
     <ClInclude Include="UITradeBBSEditDlg.h" />
     <ClInclude Include="UITradeBBSSelector.h" />

--- a/Client/WarFare/WarFare.vcxproj.filters
+++ b/Client/WarFare/WarFare.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClCompile Include="UIUpgradeSelect.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UIStatSkillReset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameProcedure.h">
@@ -612,6 +615,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UIUpgradeSelect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UIStatSkillReset.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Server/GameServer/LuaEngine.cpp
+++ b/Server/GameServer/LuaEngine.cpp
@@ -95,6 +95,7 @@ DEFINE_LUA_FUNCTION_TABLE(g_globalFunctions,
 						  MAKE_LUA_FUNCTION(CheckMonsterChallengeTime)
 						  MAKE_LUA_FUNCTION(CheckMonsterChallengeUserCount)
 						  MAKE_LUA_FUNCTION(GetPVPMonumentNation)
+						  MAKE_LUA_FUNCTION(OpenStatSkillReset)
 						  );
 
 CLuaEngine::CLuaEngine() : m_lock(new RWLock())

--- a/Server/GameServer/StatSkillResetHandler.cpp
+++ b/Server/GameServer/StatSkillResetHandler.cpp
@@ -1,0 +1,395 @@
+﻿#include "stdafx.h"
+#include "GameDefine.h"
+#include <afx.h>
+
+void CUser::OpenStatSkillReset()
+{
+	Packet result(WIZ_STAT_SKILL_RESET);
+
+	result
+		<< uint8_t(STAT_SKILL_RESET_REQ);
+
+	Send(&result);
+}
+
+void CUser::HandleStatSkillReset(Packet& pkt)
+{
+	uint8_t opcode = pkt.read<uint8_t>();
+	uint16_t iPlayerTargetID = pkt.read<uint16_t>();
+
+	CNpc* pNpc = g_pMain->GetNpcPtr(iPlayerTargetID);
+	
+	if (pNpc == nullptr)
+	{
+		return;
+	}
+
+	if (!isInRange(pNpc, MAX_NPC_RANGE))
+	{
+		return;
+	}
+		
+	switch (opcode)
+	{
+		case STAT_RESET_REQ:
+			StatReset();
+			break;
+		case SKILL_RESET_REQ:
+			SkillReset();
+			break;
+	}
+
+}
+
+void CUser::SendStatSkillResetFailed(e_StatSkillResetOpcode opcode)
+{
+	Packet result(WIZ_STAT_SKILL_RESET);
+	result << uint8_t(opcode);
+	Send(&result);
+}
+
+void CUser::SkillReset()
+{
+	if (isDead() || isTrading() || isStoreOpen() || isMerchanting() || isSellingMerchant())
+		return;
+
+	//unused skill points
+	if (m_bstrSkill[0] > 0)
+	{
+		SendStatSkillResetFailed(SKILL_RESET_UNUSED_POINTS);
+		return;
+	}
+
+	//Required coins for skill reset
+	uint32_t iRequiredCoinsSkillReset = (int) pow((GetLevel() * 2.0f), 3.4f);
+	if (GetLevel() < 30)
+		iRequiredCoinsSkillReset = (int) (iRequiredCoinsSkillReset * 0.4f);
+	else if (GetLevel() >= 60)
+		iRequiredCoinsSkillReset = (int) (iRequiredCoinsSkillReset * 1.5f);
+
+	iRequiredCoinsSkillReset = (int) (iRequiredCoinsSkillReset * 1.5f);
+
+	// If global discounts are enabled 
+	if (g_pMain->m_sDiscount == 2 // or war discounts are enabled
+		|| (g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == m_bNation))
+		iRequiredCoinsSkillReset /= 2;
+
+	//calculate currentSkillPoints
+	uint16_t iCurrentSkillPoints;
+
+	if (GetLevel() >= 10)
+		iCurrentSkillPoints = (GetLevel() - 9) * 2;
+	else
+		iCurrentSkillPoints = 0;
+
+	if (GetLevel() < 10)
+	{
+		SendStatSkillResetFailed(SKILL_RESET_LEVEL_TOO_LOW);
+		return;
+	}
+
+	if (!hasCoins(iRequiredCoinsSkillReset))
+	{
+		SendStatSkillResetFailed(SKILL_RESET_NO_GOLD);
+		return;
+	}
+
+	// Reset skill points.
+	
+	m_bstrSkill[0] = (GetLevel() - 9) * 2;
+	
+	for (int i = 1; i < 9; i++)
+		m_bstrSkill[i] = 0;
+
+	m_iGold -= iRequiredCoinsSkillReset;
+	
+	SetUserAbility();
+
+	Packet result(WIZ_STAT_SKILL_RESET);
+	result << uint8_t(SKILL_RESET_SUCCESS)
+		   << uint32_t(iRequiredCoinsSkillReset)
+		   << uint32_t(m_iGold)
+		   << uint8_t(m_bstrSkill[0]);
+
+	Send(&result);
+}
+
+void CUser::StatReset()
+{
+	if (isDead() || isTrading() || isStoreOpen() || isMerchanting() || isSellingMerchant())
+		return;
+
+	//check level
+	if (GetLevel() < 10)
+	{
+		SendStatSkillResetFailed(STAT_RESET_LEVEL_TOO_LOW);
+		return;
+	}
+
+	//unused stat points
+	if (m_sPoints > 0)
+	{
+		SendStatSkillResetFailed(STAT_RESET_UNUSED_POINTS);
+		return;
+	}
+
+	//Calculate Required coins for stat reset
+	uint32_t iCoinsStatReset = (int) pow((GetLevel() * 2.0f), 3.4f);
+	if (GetLevel() < 30)
+		iCoinsStatReset = (int) (iCoinsStatReset * 0.4f);
+	else if (GetLevel() >= 60)
+		iCoinsStatReset = (int) (iCoinsStatReset * 1.5f);
+
+	// discount
+	if ((g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == GetNation())
+		|| g_pMain->m_sDiscount == 2)
+		iCoinsStatReset /= 2;
+
+	//check gold
+	if (!hasCoins(iCoinsStatReset))
+	{
+		SendStatSkillResetFailed(STAT_RESET_NO_GOLD);
+		return;
+	}
+
+	//check if user has equiped item, accessories not important.
+	//check for 1,4,6,8,10,12,13,
+
+	int aiEquipControlSlots[7] = { 1,4,6,8,10,12,13 };
+
+	for (int slot : aiEquipControlSlots)
+	{
+		if (m_sItemArray[slot].nSerialNum != 0)
+		{
+			SendStatSkillResetFailed(STAT_RESET_ITEMS_EQUIPED);
+			return;
+		}
+	}
+	
+	//calculate stat points user have at the moment.
+	uint16_t iCurrentStatPoints;
+	uint8_t iStartingStatPoints = 10;
+	
+	if (GetLevel() < 60)
+	{
+		iCurrentStatPoints = (GetLevel() - 1) * 3;
+		iCurrentStatPoints += iStartingStatPoints;
+	}
+	else
+	{
+		iCurrentStatPoints = 59 * 3;
+		iCurrentStatPoints += (GetLevel() - 60) * 5;
+		iCurrentStatPoints += iStartingStatPoints;
+	}
+
+	// TODO: Pull this from the database.
+	switch (m_bRace)
+	{
+		case KARUS_BIG:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_MIDDLE:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_SMALL:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case KARUS_WOMAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case BABARIAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case ELMORAD_MAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+		case ELMORAD_WOMAN:
+			if (isWarrior())
+			{
+				SetStat(STAT_STR, 65);
+				SetStat(STAT_STA, 65);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isRogue())
+			{
+				SetStat(STAT_STR, 60);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 50);
+				SetStat(STAT_CHA, 50);
+			}
+			else if (isPriest())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 50);
+				SetStat(STAT_DEX, 70);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			else  if (isMage())
+			{
+				SetStat(STAT_STR, 50);
+				SetStat(STAT_STA, 60);
+				SetStat(STAT_DEX, 60);
+				SetStat(STAT_INT, 70);
+				SetStat(STAT_CHA, 50);
+			}
+			break;
+	}
+
+	//NOTE: As final control weight check can be performed for the items in inventory
+
+
+	//turn back points to the user
+
+	if (iCurrentStatPoints > 290)
+		iCurrentStatPoints = 290;
+
+	m_sPoints = iCurrentStatPoints;
+	
+	m_iGold -= iCoinsStatReset;
+
+	//recalculate resistances, ac and other things which change with stats
+	//this also updates AI server about user
+	SetUserAbility();
+
+	Packet result(WIZ_STAT_SKILL_RESET);
+	result << uint8_t(STAT_RESET_SUCCESS)
+		<< uint32_t(iCoinsStatReset)
+		<< uint32_t(m_iGold)
+		<< uint16_t(GetStat(STAT_STR))
+		<< uint16_t(GetStat(STAT_STA))
+		<< uint16_t(GetStat(STAT_DEX))
+		<< uint16_t(GetStat(STAT_INT))
+		<< uint16_t(GetStat(STAT_CHA))
+		<< uint16_t(m_sPoints);
+
+	Send(&result);
+
+	return;
+
+}

--- a/Server/GameServer/User.cpp
+++ b/Server/GameServer/User.cpp
@@ -435,6 +435,9 @@ bool CUser::HandlePacket(Packet & pkt)
 	case WIZ_SIEGE:
 		SiegeWarFareNpc(pkt);
 		break;
+	case WIZ_STAT_SKILL_RESET:
+		HandleStatSkillReset(pkt);
+		break;
 
 	default:
 		TRACE("[SID=%d] Unknown packet %X\n", GetSocketID(), command);
@@ -3662,6 +3665,7 @@ void CUser::SendStatSkillDistribute()
 	result << uint8_t(CLASS_CHANGE_REQ);
 	Send(&result); 
 }
+
 
 void CUser::AllSkillPointChange(bool bIsFree)
 {

--- a/Server/GameServer/User.h
+++ b/Server/GameServer/User.h
@@ -536,6 +536,7 @@ public:
 	bool JobGroupCheck(int16_t jobgroupid);
 	void SendSay(int32_t nTextID[10]);
 	void SelectMsg(int32_t menuHeaderText, int32_t menuButtonText[MAX_MESSAGE_EVENT], int32_t menuButtonEvents[MAX_MESSAGE_EVENT]);
+	void OpenStatSkillReset();
 
 	// NOTE(srmeier): testing this debug string functionality
 	void SendDebugString(const char* pString);
@@ -735,6 +736,9 @@ public:
 	void SendStatSkillDistribute();
 	void AllPointChange(bool bIsFree = false);
 	void AllSkillPointChange(bool bIsFree = false);
+	//AllPointChange & AllSkillPointChange replaced with
+	void StatReset();
+	void SkillReset();
 
 	void CountConcurrentUser();
 	void UserDataSaveToAgent();
@@ -773,6 +777,8 @@ public:
 	bool AttemptSelectMsg(uint8_t byMenuID);
 
 	// from the client
+	void HandleStatSkillReset(Packet& pkt);
+	void SendStatSkillResetFailed(e_StatSkillResetOpcode opcode);
 	void ItemUpgradeProcess(Packet & pkt);
 	void ItemUpgrade(Packet & pkt, uint8_t nUpgradeType = ITEM_UPGRADE_PROCESS);
 	void ItemUpgradeNotice(_ITEM_TABLE * pItem, uint8_t UpgradeResult);
@@ -926,7 +932,7 @@ public:
 	void ReqChangeName(Packet & pkt);
 	void ReqChangeCape(Packet & pkt);
 	void InsertTaxUpEvent(uint8_t Nation, uint32_t TerritoryTax);
-
+	void ReqStatSkillReset(Packet& pkt);
 	//private:
 	static ChatCommandTable s_commandTable;
 	GameState m_state;
@@ -1134,6 +1140,11 @@ public:
 		}
 
 		LUA_NO_RETURN(pUser->SelectMsg(menuHeaderText, menuButtonText, menuButtonEvents));
+	}
+
+	DECLARE_LUA_FUNCTION(OpenStatSkillReset)
+	{
+		LUA_NO_RETURN(LUA_GET_INSTANCE()->OpenStatSkillReset());
 	}
 
 	DECLARE_LUA_FUNCTION(CheckWeight) {

--- a/Server/GameServer/lua_bindings.cpp
+++ b/Server/GameServer/lua_bindings.cpp
@@ -143,6 +143,7 @@ DEFINE_LUA_CLASS
 	MAKE_LUA_METHOD(GetMonsterChallengeTime)
 	MAKE_LUA_METHOD(GetMonsterChallengeUserCount)
 	MAKE_LUA_METHOD(GetPVPMonumentNation)
+	MAKE_LUA_METHOD(OpenStatSkillReset)
 	);
 #undef LUA_CLASS
 
@@ -378,4 +379,13 @@ LUA_FUNCTION(CastSkill)
 LUA_FUNCTION(RollDice) {
 	//LUA_RETURN(myrand(0, LUA_ARG(uint16_t, 2)));
 	LUA_RETURN(myrand(1, LUA_ARG(uint16_t, 2)));
+}
+
+LUA_FUNCTION(OpenStatSkillReset)
+{
+	CUser* pUser = Lua_GetUser();
+	if (pUser == nullptr)
+		return LUA_NO_RESULTS;
+
+	LUA_NO_RETURN(pUser->OpenStatSkillReset());
 }

--- a/Server/GameServer/lua_bindings.h
+++ b/Server/GameServer/lua_bindings.h
@@ -90,3 +90,4 @@ LUA_FUNCTION(RollDice);
 LUA_FUNCTION(CheckMonsterChallengeTime);
 LUA_FUNCTION(CheckMonsterChallengeUserCount);
 LUA_FUNCTION(GetPVPMonumentNation);
+LUA_FUNCTION(OpenStatSkillReset);

--- a/Server/GameServer/proj-GameServer.vcxproj
+++ b/Server/GameServer/proj-GameServer.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="RentalHandler.cpp" />
     <ClCompile Include="LoadServerData.cpp" />
     <ClCompile Include="ShoppingMallHandler.cpp" />
+    <ClCompile Include="StatSkillResetHandler.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/Server/GameServer/proj-GameServer.vcxproj.filters
+++ b/Server/GameServer/proj-GameServer.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClCompile Include="EventHandler.cpp">
       <Filter>Source Files\Handlers</Filter>
     </ClCompile>
+    <ClCompile Include="StatSkillResetHandler.cpp">
+      <Filter>Source Files\Handlers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">

--- a/Server/bin/Debug/QUESTS/21.lua
+++ b/Server/bin/Debug/QUESTS/21.lua
@@ -2683,7 +2683,7 @@ elseif nEventID == 21288 then
 	do return; end
 	end
 elseif nEventID == 21951 then
-	pUser:SendDebugString("Unknown EXEC command 'STAT_POINT_DISTRIBUTE'."); -- unknown execute command (STAT_POINT_DISTRIBUTE)
+	pUser:OpenStatSkillReset();
 	do return; end
 elseif nEventID == 21981 then
 	pUser:SendDebugString("Unknown EXEC command 'SKILL_POINT_DISTRIBUTE'."); -- unknown execute command (SKILL_POINT_DISTRIBUTE)

--- a/Server/bin/Release/QUESTS/21.lua
+++ b/Server/bin/Release/QUESTS/21.lua
@@ -2684,7 +2684,7 @@ elseif nEventID == 21288 then
 	do return; end
 	end
 elseif nEventID == 21951 then
-	pUser:SendDebugString("Unknown EXEC command 'STAT_POINT_DISTRIBUTE'."); -- unknown execute command (STAT_POINT_DISTRIBUTE)
+	pUser:OpenStatSkillReset();
 	do return; end
 elseif nEventID == 21981 then
 	pUser:SendDebugString("Unknown EXEC command 'SKILL_POINT_DISTRIBUTE'."); -- unknown execute command (SKILL_POINT_DISTRIBUTE)

--- a/Server/shared/packets.h
+++ b/Server/shared/packets.h
@@ -123,6 +123,7 @@
 #define WIZ_SKILLDATA			0x79
 #define WIZ_PROGRAMCHECK		0x7A
 #define WIZ_BIFROST				0x7B
+#define WIZ_STAT_SKILL_RESET	0x7C //stat & skill reset
 #define WIZ_SERVER_KILL			0x7F
 
 // NOTE(srmeier): testing this debug string functionality
@@ -215,6 +216,22 @@ enum e_PremiumPropertyType
 	PremiumRepairDiscountPercent = 4,
 	PremiumItemSellPercent = 5,
 	PremiumExpPercent = 6
+};
+
+enum e_StatSkillResetOpcode {
+	STAT_SKILL_RESET_REQ = 1,
+	STAT_RESET_REQ = 2,
+	SKILL_RESET_REQ = 3,
+	STAT_RESET_LEVEL_TOO_LOW = 4,
+	SKILL_RESET_LEVEL_TOO_LOW = 5,
+	STAT_RESET_NO_GOLD = 6,
+	SKILL_RESET_NO_GOLD = 7,
+	STAT_RESET_ITEMS_EQUIPED = 8,
+	STAT_RESET_SUCCESS = 9,
+	SKILL_RESET_SUCCESS = 10,
+	STAT_RESET_UNUSED_POINTS = 11,
+	SKILL_RESET_UNUSED_POINTS = 12,
+	STAT_SKILL_RESET_SUCCESS = 13,
 };
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
That is a cleaned up version of old PR. Old PR had some issues about updating user information after stat skill, that issues are solved and user interface is updated with success at the end of resetting stat and skills.

Old packets which are reserved for stat & skill reset behavior is not used, new packet headers defined. Old packet structure starts with packet header WIZ_CLASS_CHANGE and followed by opcodes CLASS_CHANGE_REQ,ALL_POINT_CHANGE,ALL_SKILLPT_CHANGE,CHANGE_MONEY_REQ. Opcodes handled in switch block inside NPCHandler.cpp void CUser::ClassChange()

Imitating the same seemed me wrong because NPCHandler is already about 1000 lines, and managing many opcodes inside Switch block is inefficient. Therefore, all related functions placed under StatSkillResetHandler.cpp.

some parts of AllPointChange(); and AllSkillPointChange(); has been used (copy pasted from old work ie. new stat resetting function).

Normaly after successfull stat & skill reset user should be informed with Superior Healing animation, but instead of it normal text message is used ( because healing skill causes client to crash ) .

To display error messages on UIStatSkillReset, different functions have been used because some text missing in TBL file.

Some client side features can be added in the future like preventing packet send if the user is dead, trading, mertchanting etc. All those controlled in server side for now. 

Discount should also be added in the future for client side, ( server side has it already, but coin amount displayed can be wrong if discount is active ) 

For this to become perfect, any commits appreciated. Need some help to check things on Client side (like isDead(), isTrading(), isStoreOpen(), isMerchanting(),isSellingMerchant(), npcInRange() ). Need also rework on Texts_us.tbl to add missing messages.
Also some commits to make discount visible on client side would be good, those are included as comment from server side as follows

`// discount need to be implemented for client
/*if ((g_pMain->m_sDiscount == 1 && g_pMain->m_byOldVictory == GetNation())
	|| g_pMain->m_sDiscount == 2)
	iCoinsStatReset /= 2;
*/`


Please remove other commit it has huge mistakes, this is just better version.