### PR TITLE
fix for item ext 23, blue chest items

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -805,7 +805,7 @@ typedef struct __TABLE_ITEM_BASIC // 장착 아이템에 관한 리소스 레코
 	uint8_t    byIDK3;
 } TABLE_ITEM_BASIC;
 
-const int MAX_ITEM_EXTENSION = 24; // [0-23] ex: Item_Ext_23.tbl
+const int MAX_ITEM_EXTENSION = 24; // Number of item extension tables. (Item_Ext_0..23.tbl is a total of 24)
 const int LIMIT_FX_DAMAGE = 64;
 const int ITEM_LIMITED_EXHAUST = 17;
 

--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -805,7 +805,7 @@ typedef struct __TABLE_ITEM_BASIC // 장착 아이템에 관한 리소스 레코
 	uint8_t    byIDK3;
 } TABLE_ITEM_BASIC;
 
-const int MAX_ITEM_EXTENSION = 23; // 확장 아이템 테이블 갯수.
+const int MAX_ITEM_EXTENSION = 24; // [0-23] ex: Item_Ext_23.tbl
 const int LIMIT_FX_DAMAGE = 64;
 const int ITEM_LIMITED_EXHAUST = 17;
 


### PR DESCRIPTION
this fix issue #188 

thankfully no need to change any tbl files or database

it was just the length of array MAX_ITEM_EXTENSION causing the problem.

Item_Ext tbls start with 0 and includes also 23 so array lenght must be 24, probably forgotten or changed to test something. 

All blue chest items like hanguk sword, hell breaker, enion bow visible with this update.