### PR TITLE
required mana for skill should not scale with attack power

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -184,38 +184,18 @@ bool CMagicSkillMng::IsCasting()
 	return false;
 }
 
+//Used to inform Hotkey and skill tree UI
 bool CMagicSkillMng::CheckValidSkillMagic(__TABLE_UPC_SKILL* pSkill)
 {
 	__InfoPlayerBase* pInfoBase = &(s_pPlayer->m_InfoBase);
 	__InfoPlayerMySelf* pInfoExt = &(s_pPlayer->m_InfoExt);
 
 	e_Class_Represent Class = CGameProcedure::GetRepresentClass(pInfoBase->eClass);
+	
+	//mana check for all classes, no need to 
+	//separate because error message is not required
 	if(pInfoExt->iMSP < pSkill->iExhaustMSP)
-	{
-		if(Class==CLASS_REPRESENT_PRIEST || Class==CLASS_REPRESENT_WIZARD)
-		{
-			return false;
-		}
-	}
-
-	if(pSkill->dw1stTableType==1 || pSkill->dw1stTableType==2)
-	{
-		if(Class==CLASS_REPRESENT_WARRIOR || Class==CLASS_REPRESENT_ROGUE)
-		{
-			int ExhaustSP = pInfoExt->iAttack * pSkill->iExhaustMSP / 100;
-			if(pInfoExt->iMSP < ExhaustSP)
-			{
-				return false;
-			}
-		}
-	}
-	else if(pInfoExt->iMSP < pSkill->iExhaustMSP)
-	{
-		if(Class==CLASS_REPRESENT_WARRIOR || Class==CLASS_REPRESENT_ROGUE)
-		{
-			return false;
-		}
-	}
+		return false;
 
 	int LeftItem = s_pPlayer->ItemClass_LeftHand();
 	int RightItem = s_pPlayer->ItemClass_RightHand();
@@ -569,39 +549,21 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 
 	if(pInfoExt->iMSP < pSkill->iExhaustMSP)
 	{
+		std::string buff;
+
 		if(Class==CLASS_REPRESENT_PRIEST || Class==CLASS_REPRESENT_WIZARD)
 		{
-			std::string buff;
 			GetText(IDS_MSG_CASTING_FAIL_LACK_MP, &buff);
 			m_pGameProcMain->MsgOutput(buff, 0xffffff00);
-			return false;
 		}
-	}
-
-	if(pSkill->dw1stTableType==1 || pSkill->dw1stTableType==2)
-	{
-		if(Class==CLASS_REPRESENT_WARRIOR || Class==CLASS_REPRESENT_ROGUE)
+		else if (Class == CLASS_REPRESENT_WARRIOR || Class == CLASS_REPRESENT_ROGUE)
 		{
-			int ExhaustSP = pInfoExt->iAttack * pSkill->iExhaustMSP / 100;
-			if(pInfoExt->iMSP < ExhaustSP)
-			{
-				std::string buff;
-				GetText(IDS_SKILL_FAIL_LACK_SP, &buff);
-				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
-				return false;
-			}
-		}
-	}
-	else if(pInfoExt->iMSP < pSkill->iExhaustMSP)
-	{
-		if(Class==CLASS_REPRESENT_WARRIOR || Class==CLASS_REPRESENT_ROGUE)
-		{
-			std::string buff;
 			GetText(IDS_SKILL_FAIL_LACK_SP, &buff);
 			m_pGameProcMain->MsgOutput(buff, 0xffffff00);
-			return false;
 		}
-	}
+
+		return false;
+	}	
 
 	int LeftItem = s_pPlayer->ItemClass_LeftHand();
 	int RightItem = s_pPlayer->ItemClass_RightHand();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Skill mana requirement scales with attack for classes warrior and rogue.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Skill mana requirement now don't scale with attack.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This needs to be changed because at higher attack points ( if player is higher level and have better weapons ) this causes skills to be not casted. For example, a warrior with 500 AP cannot cast sword dancing, or cast it for high amount of mana. Normally it should be fixed to constant value which is 300 for sword dancing.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] For client changes, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).

this is related to issue #201 
