### PR TITLE
btn behavior for character delete changed

### DIFF
--- a/Client/WarFare/UICharacterSelect.cpp
+++ b/Client/WarFare/UICharacterSelect.cpp
@@ -114,7 +114,7 @@ bool CUICharacterSelect::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		{
 			std::string szMsg;
 			CGameBase::GetText(IDS_CONFIRM_DELETE_CHR, &szMsg);
-			CGameProcedure::MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_DELETE_CHR);
+			CGameProcedure::MessageBoxPost(szMsg, "", MB_YESNO, BEHAVIOR_CANCEL);
 		}
 	}
 	


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Character delete requesting input from user although it is showing "character delete is disabled right now" message.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
button behavior changed to BUTTON_CANCEL, now it does not ask for user input, just inform user about the current state of character deletion process.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This was misleading, if current patch of the game has such speciality to remove character from game, button type can be switched between BUTTON_CANCEL and BUTTON_CHARACTER_DELETE by defining and checking constant in GameDef.h in the future updates.

This is also related to issue #180 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code.
- [ ] For client changes, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes).
- [ ] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
