### PR TITLE
feature/Options-Dynamic-Resolutions Adds the ability for the Options …

### DIFF
--- a/Client/Option/OptionDlg.cpp
+++ b/Client/Option/OptionDlg.cpp
@@ -4,6 +4,10 @@
 #include "stdafx.h"
 #include "Option.h"
 #include "OptionDlg.h"
+#include "Windows.h"
+#include "algorithm"
+#include "set"
+#include "vector"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -92,26 +96,90 @@ BEGIN_MESSAGE_MAP(COptionDlg, CDialog)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
-struct Resolution
-{
-	int Width;
-	int Height;
+struct Resolution {
+    int Width;
+    int Height;
 };
 
-// TODO: This should ideally be a list of the user's supported display resolutions.
+static std::vector<Resolution> dynamicResolutions;
+
 static Resolution s_supportedResolutions[] =
 {
-	{ 800, 600 },
-	{ 1024, 768 },
-	{ 1152, 864 },
-	{ 1280, 768 },
-	{ 1280, 800 },
-	{ 1280, 960 },
-	{ 1280, 1024 },
-	{ 1360, 768 },
-	{ 1366, 768 },
-	{ 1600, 1200 }
+    { 800, 600 },
+    { 1024, 768 },
+    { 1152, 864 },
+    { 1280, 768 },
+    { 1280, 800 },
+    { 1280, 960 },
+    { 1280, 1024 },
+    { 1360, 768 },
+    { 1366, 768 },
+    { 1600, 1200 }
 };
+
+static std::vector<Resolution> GetSupportedResolutions() {
+	if (dynamicResolutions.empty()) {
+		// load dynamic resolutions
+        // Get the primary monitor
+        DISPLAY_DEVICE device;
+        device.cb = sizeof(DISPLAY_DEVICE);
+	    // we point to the device name instead of copying it / using it directly
+	    // that way if we don't find a primary monitor, we pass NULL as the first param into EnumDisplaySettings
+        char* primaryDeviceName = NULL;
+        int deviceNumber = 0;
+        while (EnumDisplayDevices(NULL, deviceNumber, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+            if (device.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
+				// Primary monitor found; get a pointer to the name and break out of the loop
+                primaryDeviceName = &device.DeviceName[0];
+                break;
+            }
+
+            deviceNumber++;
+        }
+
+        // The same resolution can be listed many times on a monitor depending on available refresh rates.
+        // We'll use a set on total pixels (HxW) to filter out duplicates.  Since we're filtering out portriat
+        // resolutions we shouldn't get any odd collisions (width is always greater than height)
+        std::set<unsigned int> totalPixelSet;
+
+        // Discover resolution settings
+        DEVMODEA resolution;
+        for(int iModeNum = 0; EnumDisplaySettings( primaryDeviceName, iModeNum, &resolution ) != 0; iModeNum++)
+        {
+            // Filter out Portrait resolutions and duplicate entries
+            unsigned int totalPixels = resolution.dmPelsHeight * resolution.dmPelsWidth;
+            if (resolution.dmPelsHeight > resolution.dmPelsWidth || totalPixelSet.contains(totalPixels)) {
+                continue;
+            }
+            dynamicResolutions.push_back(
+                    Resolution{.Width = (int) resolution.dmPelsWidth, .Height = (int) resolution.dmPelsHeight});
+            totalPixelSet.insert(totalPixels);
+        }
+
+        totalPixelSet.clear();
+
+	    if (dynamicResolutions.empty()) {
+	        // We failed to dynamically pull available resolutions, fall back to the hard-coded set
+	        for (Resolution r : s_supportedResolutions) {
+	            dynamicResolutions.push_back(r);
+	        }
+	    }
+
+        // sort the vector such that higher resolutions appear at the top of the drop down list.
+        // With modern monitors, this list can get pretty long.  If we're going to send a user scrolling for a resolution,
+        // it should be one that most users aren't looking for (who would want to play on 640x480?)
+        std::sort(dynamicResolutions.begin(), dynamicResolutions.end(), [](const Resolution& a, const Resolution& b) {
+            return a.Width > b.Width || ((a.Width == b.Width) && a.Height > b.Height);
+        });
+	}
+
+	// If dynamic resolutions fail to load for whatever reason, fall back to the original hardcoded list
+	return dynamicResolutions;
+}
+
+
+
+
 
 /////////////////////////////////////////////////////////////////////////////
 // COptionDlg message handlers
@@ -151,7 +219,7 @@ BOOL COptionDlg::OnInitDialog()
 	int iAdd = 0;
 
 	CString szResolution;
-	for (const auto& resolution : s_supportedResolutions)
+    for (const auto &resolution: GetSupportedResolutions())
 	{
 		szResolution.Format(
 			_T("%d X %d"),
@@ -301,12 +369,10 @@ void COptionDlg::SettingSave(CString szIniFile)
 	m_Option.iViewWidth = 1024;
 	m_Option.iViewHeight = 768;
 
-	if (iSel >= 0
-		&& iSel < _countof(s_supportedResolutions))
+	if (iSel >= 0 && iSel < (int)GetSupportedResolutions().size())
 	{
-		const auto& resolution = s_supportedResolutions[iSel];
-		m_Option.iViewWidth = resolution.Width;
-		m_Option.iViewHeight = resolution.Height;
+        m_Option.iViewWidth = GetSupportedResolutions()[iSel].Width;
+        m_Option.iViewHeight = GetSupportedResolutions()[iSel].Height;
 	}
 
 	iSel = m_CB_ColorDepth.GetCurSel();
@@ -420,11 +486,10 @@ void COptionDlg::SettingUpdate()
 	CheckDlgButton(IDC_C_SHADOW, m_Option.iUseShadow);
 
 	int iSel = 0;
-	for (int i = 0; i < _countof(s_supportedResolutions); i++)
+    for (int i = 0; i < (int)GetSupportedResolutions().size(); i++)
 	{
-		const auto& resolution = s_supportedResolutions[i];
-		if (m_Option.iViewWidth == resolution.Width
-			&& m_Option.iViewHeight == resolution.Height)
+        if (m_Option.iViewWidth == GetSupportedResolutions()[i].Width &&
+            m_Option.iViewHeight == GetSupportedResolutions()[i].Height)
 		{
 			iSel = i;
 			break;


### PR DESCRIPTION
Adds the ability for the Options application to load a list of landscape resolutions supported for the primary monitor:
![{7FCF8461-C6FE-4931-A05F-636BC54260B0}](https://github.com/user-attachments/assets/b39cc97b-a0eb-4617-b52e-f3d8d7822def)


## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
The Options application currently has a hard-coded list of resolution options, most of which are outdated for modern monitors.

## What is the new behaviour?
The Options application will populate the resolution options based on available resolutions for the primary monitor.  This list will filter out portrait resolutions as well as duplicate entries from the Windows API (there are many options for the same resolution based on the refresh rates available to a given monitor). 

If this fails or returns no entries, make use of the existing hard-coded list as a fail safe.

The list will be sorted with the highest resolutions listed at the top, as many resolution options are available and a user would most likely want one of the higher resolutions.

## Why and how did I change this?
Why:
I saw the TODO in OptionsDlg.cpp and thought it wouldn't be that hard to implement.

How:
Using the Windows API to identify the primary monitor, get its available resolutions and filter to a usable list.

## Demo
![{33475A5C-09DE-4C19-A028-F199B7C9D440}](https://github.com/user-attachments/assets/2c51078d-4771-4020-8a7a-0dfa1d7c8964)

![{6A746489-D29F-4102-962C-578BA92889AC}](https://github.com/user-attachments/assets/82dc7b1c-3c0f-42ca-9dee-91be2548a6bf)


## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
