### PR TITLE
Update Github workflows

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build all
+
+on:
+  pull_request:
+    types: [labeled]
+    
+  workflow_dispatch:
+    
+env:
+  # We use a debug build for slightly faster build times
+  BUILD_CONFIGURATION: Debug
+  BUILD_PLATFORM: Win32
+
+jobs:
+  analyze:
+    if: |
+      github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-all')
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'false'
+
+    - name: Fetch required submodules only
+      run: |
+        git submodule update --init deps/dx9sdk
+        git submodule update --init deps/zlib
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Build third party dependencies
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" ThirdParty.sln
+
+    - name: Build all
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" All.sln

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -17,6 +17,7 @@ on:
       - 'deps/dx9sdk/**'
       - 'deps/ZipArchive/**'
       - 'deps/zlib/**'
+      - 'deps/zlib-msvc/**'
       - 'Server/AIServer/**'
       - 'Server/Aujard/**'
       - 'Server/Ebenezer/**'
@@ -28,6 +29,7 @@ on:
       - 'Client/N3Base/N3ShapeMgr.cpp'
       - 'All.sln'
       - 'Server.sln'
+      - 'ThirdParty.sln'
 
   pull_request:
     branches:
@@ -40,6 +42,7 @@ on:
       - 'deps/dx9sdk/**'
       - 'deps/ZipArchive/**'
       - 'deps/zlib/**'
+      - 'deps/zlib-msvc/**'
       - 'Server/AIServer/**'
       - 'Server/Aujard/**'
       - 'Server/Ebenezer/**'
@@ -51,6 +54,7 @@ on:
       - 'Client/N3Base/N3ShapeMgr.cpp'
       - 'All.sln'
       - 'Server.sln'
+      - 'ThirdParty.sln'
  
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
Update build_server.yml for new third-party dependencies + zlib-msvcx changes (VersionManager)
Add build_all.yml to trigger building all projects without CodeQL manually or via the build-all label.