### PR TITLE
Automate tool builds via Github workflows

### DIFF
--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -6,8 +6,55 @@
 name: Build tools
 
 on:
-  schedule:
-    - cron: "0 0 * * 0" # once a week every Sunday at midnight
+  push:
+    branches:
+    - master
+
+    # This specifically builds only the tool projects.
+    # Everything else can be ignored.
+    paths:
+      - 'props/**'
+      - 'deps/dx9sdk/**'
+      - 'ItemEditor/**'
+      - 'N3CE/**'
+      - 'N3FXE/**'
+      - 'N3ME/**'
+      - 'N3TexViewer/**'
+      - 'N3Viewer/**'
+      - 'SkyViewer/**'
+      - 'TblEditor/**'
+      - 'UIE/**'
+      - 'Server/shared/**'
+      - 'Client/N3Base/**'
+      - 'All.sln'
+      - 'Tools.sln'
+      - 'ThirdParty.sln'
+
+  pull_request:
+    branches:
+    - master
+
+    # This specifically builds only the tool projects.
+    # Everything else can be ignored.
+    paths:
+      - 'props/**'
+      - 'deps/dx9sdk/**'
+      - 'ItemEditor/**'
+      - 'N3CE/**'
+      - 'N3FXE/**'
+      - 'N3ME/**'
+      - 'N3TexViewer/**'
+      - 'N3Viewer/**'
+      - 'SkyViewer/**'
+      - 'TblEditor/**'
+      - 'UIE/**'
+      - 'Server/shared/**'
+      - 'Client/N3Base/**'
+      - 'All.sln'
+      - 'Tools.sln'
+      - 'ThirdParty.sln'
+ 
+  merge_group: 
   workflow_dispatch:
     
 env:


### PR DESCRIPTION
No longer schedule them, we can detect and trigger them as appropriate.