### PR TITLE
Update README.md to better explain dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > 
 > **Failure to do so will result in build errors or missing functionality.**
 >
-> This extends to compilers like the following (this one specifically is caused by a compiler update):
+> This extends to compiler errors such as the following (this one specifically is caused by a compiler update):
 >
 > "**LINK : fatal error C1047: The object or library file 'zlib.lib' was created by a different version of the compiler than other objects like '{some file}.obj'; rebuild all objects and libraries with the same compiler**".
 >


### PR DESCRIPTION
Judging by #291, I didn't do a good job of explaining how this was setup. Glossing over it could lead you to believe you just needed to update the submodules without actually looking too hard at it, especially with the remnants at the start of the warning message.

This change tries to reword this to avoid 1. explaining it directly in the warning and 2. misleading that it's just "updating" anything.
Further, I try to go above and beyond to make it clear that there's 2 distinct options for setting this up; the easy way, with the script, and manually.
As the manual method stood out more with the git submodule command highlighted, I put the `update_dependencies.cmd` on its own line to stand out equally, and specifically reworded the manual method section such that it tries to be clear upfront that there's 2 things that need to be done (not just updating the submodules). I do this by specifically stating as such, and explicitly making it numbered, so you'd see that it's the first of 2 steps.

Hopefully, collectively this will help to avoid further confusion.

The ideal method is to just run the script. It's the quick, easy option.