### PR TITLE
tracing npc names from std::string to c_str

### DIFF
--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -1287,7 +1287,7 @@ BOOL CNpc::SetLive(CIOCPort* pIOCP)
 	SetUid(m_fCurX, m_fCurZ, m_sNid + NPC_BAND);
 	m_byDeadType = 0;
 	CTime t = CTime::GetCurrentTime();
-	TRACE(_T("NPC Init(nid=%d, sid=%d, th_num=%d, name=%hs) - %.2f %.2f, gate = %d, m_byDeadType=%d, time=%d:%d-%d\n"), m_sNid + NPC_BAND, m_sSid, m_sThreadNumber, m_strName, m_fCurX, m_fCurZ, m_byGateOpen, m_byDeadType, t.GetHour(), t.GetMinute(), t.GetSecond());
+	TRACE(_T("NPC Init(nid=%d, sid=%d, th_num=%d, name=%hs) - %.2f %.2f, gate = %d, m_byDeadType=%d, time=%d:%d-%d\n"), m_sNid + NPC_BAND, m_sSid, m_sThreadNumber, m_strName.c_str(), m_fCurX, m_fCurZ, m_byGateOpen, m_byDeadType, t.GetHour(), t.GetMinute(), t.GetSecond());
 
 	// 유저에게 NPC 정보전송...
 	int modify_index = 0;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
npc names in std::sting and this causes their names to destroy debug output (extreamely long numbers make searching something else harder)

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
names corrected by c_str now the don't display long numbers.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
prevents me from searching for other output.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
