### PR TITLE
UITreeSkillDlg - Update to tooltip on skill hover - show skill_item2

### DIFF
--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1075,6 +1075,8 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill* spSkill)
 	szStr.clear();
 
 	// Tooltip - item consumed
+	if (!m_pStr_skill_item2->IsVisible())
+		m_pStr_skill_item2->SetVisible(true);
 	uint32_t requiredItemID = spSkill->pSkill->dwExhaustItem;
 	uint32_t consumedItemID = 0;
 	
@@ -1104,8 +1106,8 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill* spSkill)
 
 		if (pItem != nullptr)
 			CGameBase::GetTextF(IDS_SKILL_TOOLTIP_USE_ITEM_EXIST, &szStr, pItem->szName.c_str());
-		if (pItem == nullptr)
-			CGameBase::GetTextF(IDS_SKILL_TOOLTIP_USE_ITEM_EXIST, &szStr, pItem->szName.c_str());
+		else
+			CGameBase::GetText(IDS_SKILL_TOOLTIP_USE_ITEM_NO, &szStr);
 	}
 	else
 	{


### PR DESCRIPTION

## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
The code committed to #311 during my clean up was not the correct one due to commits being wrong 

## What is the new behaviour?
Fixes a bug introduced in my code clean up where the bottom row (m_pStr_skill_item2) was not displayed

## Why and how did I change this?
Render m_pStr_skill_item2 to show the bottom line of the hover-over skill tips.

## Demo
Line is highlighted in yellow on demo below.
<img width="370" height="526" alt="image" src="https://github.com/user-attachments/assets/95faf976-28bc-4a53-9279-e78ff1109b14" />


## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
