### PR TITLE
size_t to int convertion for the methods inside N3UITrackBar.cpp

### DIFF
--- a/Client/N3Base/N3UITrackBar.cpp
+++ b/Client/N3Base/N3UITrackBar.cpp
@@ -162,7 +162,7 @@ uint32_t CN3UITrackBar::MouseProc(uint32_t dwFlags, const POINT& ptCur, const PO
 //	if (m_pThumbImageRef) m_pThumbImageRef->Render();
 //}
 
-void CN3UITrackBar::SetRange(size_t iMin, size_t iMax)
+void CN3UITrackBar::SetRange(int iMin, int iMax)
 {
 	if (m_iMaxPos == iMax && m_iMinPos == iMin) return;
 	m_iMaxPos = iMax;		m_iMinPos = iMin;
@@ -171,12 +171,12 @@ void CN3UITrackBar::SetRange(size_t iMin, size_t iMax)
 	UpdateThumbPos();
 }
 
-void CN3UITrackBar::SetCurrentPos(size_t iPos)
+void CN3UITrackBar::SetCurrentPos(int iPos)
 {
 	if (iPos == m_iCurPos) return;
 	m_iCurPos = iPos;
-	if (m_iCurPos>m_iMaxPos)	m_iCurPos = m_iMaxPos;
-	if (m_iCurPos<m_iMinPos)	m_iCurPos = m_iMinPos;
+	if (m_iCurPos > m_iMaxPos)	m_iCurPos = m_iMaxPos;
+	if (m_iCurPos < m_iMinPos)	m_iCurPos = m_iMinPos;
 	UpdateThumbPos();
 }
 

--- a/Client/N3Base/N3UITrackBar.h
+++ b/Client/N3Base/N3UITrackBar.h
@@ -24,9 +24,9 @@ protected:
 	CN3UIImage*		m_pBkGndImageRef;		// 배경 이미지 referance (메모리 할당은 children list로 관리)
 	CN3UIImage*		m_pThumbImageRef;		// 가운데 드레그 하여 옮길 수 있는 이미지 referance
 
-	size_t			m_iMaxPos;									// 최대
-	size_t			m_iMinPos;									// 최소
-	size_t 			m_iCurPos;									// 현재 값
+	int				m_iMaxPos;									// 최대
+	int				m_iMinPos;									// 최소
+	int 			m_iCurPos;									// 현재 값
 	int				m_iPageSize;								// page단위 이동할때 이동값
 // Operations
 public:
@@ -36,15 +36,15 @@ public:
 	virtual uint32_t	MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld);
 //	virtual void	Render();
 
-	void			SetRange(size_t iMin, size_t iMax);
-	void			SetRangeMax(size_t iMax) {SetRange(m_iMinPos, iMax);}
-	void			SetRangeMin(size_t iMin) {SetRange(iMin, m_iMaxPos);}
-	void			SetCurrentPos(size_t iPos);
-	size_t			GetPos() const {return m_iCurPos;}
+	void			SetRange(int iMin, int iMax);
+	void			SetRangeMax(int iMax) {SetRange(m_iMinPos, iMax);}
+	void			SetRangeMin(int iMin) {SetRange(iMin, m_iMaxPos);}
+	void			SetCurrentPos(int iPos);
+	int				GetPos() const {return m_iCurPos;}
 	void			SetPageSize(int iSize) {m_iPageSize = iSize;}
 	int				GetPageSize() const {return m_iPageSize;}
-	size_t			GetMaxPos() const {return m_iMaxPos;}
-	size_t			GetMinPos() const {return m_iMinPos;}
+	int				GetMaxPos() const {return m_iMaxPos;}
+	int				GetMinPos() const {return m_iMinPos;}
 protected:
 	void			UpdateThumbPos();							// m_iCurPos를 계산하여 Thumb위치 다시 계산하여 바꾸기
 	void			UpDownThumbPos(int iDiff);					// Thumb위치를 아래 위로 iDiff pixel만큼 움직인 후 m_iCurPos 갱신하기


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
currently functions under N3UITrackBar expecting variable in size_t and that causing overflow when a negative number is send. This results in scrollbar to jump from top to bottom when up button is clicked.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Clicking up button does not result in jump to bottom.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Realized at some old part of the code negative check is not done before setting the position of scroll. Sending uncontrolled values resulting in overflow and scroll to get maxPos instead of minPos.

This PR aims to solve issue #404 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
