### PR TITLE
Require a minimum Visual Studio version for msbuild (VS2022)

### DIFF
--- a/build_scripts/env_find_msbuild.cmd
+++ b/build_scripts/env_find_msbuild.cmd
@@ -10,15 +10,18 @@ IF NOT EXIST "%VSWHERE%" (
 	EXIT /B 1
 )
 
+REM Required minimum VS version (17.0 = VS2022)
+SET "VS_VERSION=17.0"
+
 REM Find latest MSBuild.exe path
 SET "MSBUILD="
 SET "MSBUILD_PREVIEW="
 
-FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -version %VS_VERSION% -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
 	SET "MSBUILD=%%i"
 )
 
-FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -version %VS_VERSION% -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
 	SET "MSBUILD_PREVIEW=%%i"
 )
 


### PR DESCRIPTION
It needs to support v143 (2022).
If it's between a preview and mainline build, they NEED to be 2022+.

e.g. Mainline build: 2019 build tools
Preview build: 2022

We prefer the mainline build, so previously it would select the 2019 build tools. Now it will still ignore the mainline build if it's not VS2022 or newer (v17.0+).