### PR TITLE
remove type 4 magic check from client

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -854,37 +854,7 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 		}
 	}
 
-	if( (pSkill->dw1stTableType==4 || pSkill->dw2ndTableType==4) && 
-		( (pSkill->iTarget==SKILLMAGIC_TARGET_SELF) || (iTargetID==s_pPlayer->IDNumber()) ) )
-	{
-		__TABLE_UPC_SKILL_TYPE_4* pType4 = m_pTbl_Type_4->Find(pSkill->dwID);
-		if(!pType4) return false;
-		
-		switch(pType4->iBuffType)
-		{
-		case BUFFTYPE_MAXHP:
-			if(m_iMaxHP != 0) return false;
-			break;
-		case BUFFTYPE_AC:
-			if(m_iAC != 0) return false;
-			break;
-		case BUFFTYPE_ATTACK:
-			if(m_iAttack != 0) return false;
-			break;
-		case BUFFTYPE_ATTACKSPEED:
-			if(m_fAttackSpeed != 1.0f) return false;
-			break;
-		case BUFFTYPE_SPEED:
-			if(m_fSpeed != 1.0f) return false;
-			break;
-		case BUFFTYPE_ABILITY:
-			if(	m_iStr != 0 || m_iSta != 0 || m_iDex != 0 || m_iInt != 0 || m_iMAP != 0) return false;
-			break;
-		case BUFFTYPE_RESIST:
-			if(	m_iFireR != 0 || m_iColdR != 0 || m_iLightningR != 0 || m_iMagicR != 0 || m_iDeseaseR != 0 || m_iPoisonR != 0) return false;
-			break;
-		}
-	}
+	
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 // 스킬 사용시 오브젝트 체크


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
magicskillmanager on client checking for type 4 skills and preventing sendin packet. this causes unofficial behavior ( character should act and try to buff himself and get skill failed )

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
works as official.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
tested orginal client with openko server. orginal client sends packet even if user has the buff. there is no client filter for type 4 magic ( can be tested with priest buffs, used grace ).

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
