### PR TITLE
correcting mana reduction for skill manager

### DIFF
--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -310,17 +310,14 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 				// Only if Flying Effect is greater than 0.
 				if (pMagic->FlyingEffect > 0)
 				{
-					int total_hit = m_pSrcUser->m_sTotalHit + m_pSrcUser->m_sItemHit;
-					int skill_mana = total_hit * pMagic->ManaCost / 100;
-
 					// Reduce Magic Point!
-					if (skill_mana > m_pSrcUser->m_pUserData->m_sMp)
+					if (pMagic->ManaCost > m_pSrcUser->m_pUserData->m_sMp)
 					{
 						command = MAGIC_FAIL;
 						goto return_echo;
 					}
 
-					m_pSrcUser->MSpChange(-(skill_mana));
+					m_pSrcUser->MSpChange(-(pMagic->ManaCost));
 				}
 
 				// Subtract Arrow!
@@ -848,9 +845,6 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 		// MP/SP SUBTRACTION ROUTINE!!! ITEM AND HP TOO!!!
 		if (type == MAGIC_EFFECTING)
 		{
-			int total_hit = m_pSrcUser->m_sTotalHit;
-			int skill_mana = (pTable->ManaCost * total_hit) / 100;
-
 			// Type 2 related...
 			if (pTable->Type1 == 2
 				&& pTable->FlyingEffect != 0)
@@ -866,17 +860,9 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 				return pTable;		// Do not reduce MP/SP when combo number is higher than 0.
 			}
 
-			if (pTable->Type1 == 1
-				|| pTable->Type1 == 2)
-			{
-				if (skill_mana > m_pSrcUser->m_pUserData->m_sMp)
-					goto fail_return;
-			}
-			else
-			{
-				if (pTable->ManaCost > m_pSrcUser->m_pUserData->m_sMp)
-					goto fail_return;
-			}
+			if (pTable->ManaCost > m_pSrcUser->m_pUserData->m_sMp)
+				goto fail_return;
+			
 
 /*
 			 // Actual deduction of Skill or Magic point.
@@ -997,12 +983,10 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 			}
 
 			// Actual deduction of Skill or Magic point.
-			if (pTable->Type1 == 1
-				|| pTable->Type1 == 2)
-				m_pSrcUser->MSpChange(-skill_mana);
-			else if (pTable->Type1 != 4
-				|| (pTable->Type1 == 4 && tid == -1))
+			if (pTable->Type1 != 4 || (pTable->Type1 == 4 && tid == -1))
+			{
 				m_pSrcUser->MSpChange(-pTable->ManaCost);
+			}
 
 			// DEDUCTION OF HPs in Magic/Skill using HPs.
 			if (pTable->HpCost > 0


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
mana cost of a skill scales with total damage put.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
damage does not affecting mana cost.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Ebenezer/MagicProcess.cpp mana related parts edited.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
