### PR TITLE
Replace client login opcodes with the server's definitions

### DIFF
--- a/Client/WarFare/GameProcLogIn_1098.h
+++ b/Client/WarFare/GameProcLogIn_1098.h
@@ -38,7 +38,6 @@ public:
 	void ConnectToGameServer(); // 고른 게임 서버에 접속
 	CGameProcLogIn_1098();
 	~CGameProcLogIn_1098() override;
-//	void PacketSend_MGameLogin();
 };
 
 class CGameProcLogIn : public CGameProcLogIn_1098 {};

--- a/Client/WarFare/GameProcLogIn_1298.cpp
+++ b/Client/WarFare/GameProcLogIn_1298.cpp
@@ -124,7 +124,7 @@ void CGameProcLogIn_1298::Init()
 			// 게임 서버 리스트 요청..
 			int iOffset = 0;
 			uint8_t byBuffs[4];
-			CAPISocket::MP_AddByte(byBuffs, iOffset, N3_GAMESERVER_GROUP_LIST);					// 커멘드.
+			CAPISocket::MP_AddByte(byBuffs, iOffset, LS_SERVERLIST);					// 커멘드.
 			s_pSocket->Send(byBuffs, iOffset);											// 보낸다
 		}
 	}
@@ -184,13 +184,9 @@ bool CGameProcLogIn_1298::MsgSend_AccountLogIn(e_LogInClassification eLIC)
 	uint8_t byBuff[256];										// 패킷 버퍼..
 	int iOffset = 0;										// 버퍼의 오프셋..
 
-	uint8_t byCmd = N3_ACCOUNT_LOGIN;
-	if (LIC_KNIGHTONLINE == eLIC)
-		byCmd = N3_ACCOUNT_LOGIN;
-	else if (LIC_MGAME == eLIC)
-		byCmd = N3_ACCOUNT_LOGIN_MGAME;
-//	else if (LIC_DAUM == eLIC)
-//		byCmd = N3_ACCOUNT_LOGIN_DAUM;
+	uint8_t byCmd = LS_LOGIN_REQ;
+	if (eLIC == LIC_MGAME)
+		byCmd = LS_MGAME_LOGIN;
 
 	CAPISocket::MP_AddByte(byBuff, iOffset, byCmd);				// 커멘드.
 	CAPISocket::MP_AddShort(byBuff, iOffset, (int16_t) s_szAccount.size());	// 아이디 길이..
@@ -208,7 +204,7 @@ bool CGameProcLogIn_1298::MsgSend_NewsReq()
 	uint8_t byBuff[2];
 	int iOffset = 0;
 
-	CAPISocket::MP_AddByte(byBuff, iOffset, N3_NEWS);
+	CAPISocket::MP_AddByte(byBuff, iOffset, LS_NEWS);
 	s_pSocket->Send(byBuff, iOffset);
 
 	return true;
@@ -284,7 +280,7 @@ void CGameProcLogIn_1298::MsgRecv_AccountLogIn(int iCmd, Packet& pkt)
 	// ID not found
 	else if (2 == iResult)
 	{
-		if (N3_ACCOUNT_LOGIN == iCmd)
+		if (iCmd == LS_LOGIN_REQ)
 		{
 			std::string szMsg = fmt::format_text_resource(IDS_NOACCOUNT_RETRY_MGAMEID);
 			std::string szTmp = fmt::format_text_resource(IDS_CONNECT_FAIL);
@@ -437,15 +433,16 @@ bool CGameProcLogIn_1298::ProcessPacket(Packet & pkt)
 	s_pPlayer->m_InfoBase.eNation = NATION_UNKNOWN;
 	switch (iCmd)										// 커멘드에 다라서 분기..
 	{
-		case N3_GAMESERVER_GROUP_LIST: // 접속하면 바로 보내준다..
+		case LS_SERVERLIST: // 접속하면 바로 보내준다..
 			MsgRecv_GameServerGroupList(pkt);
 			return true;
 
-		case N3_ACCOUNT_LOGIN: // 계정 접속 성공..
-		case N3_ACCOUNT_LOGIN_MGAME: // MGame 계정 접속 성공..
+		case LS_LOGIN_REQ: // 계정 접속 성공..
+		case LS_MGAME_LOGIN: // MGame 계정 접속 성공..
 			MsgRecv_AccountLogIn(iCmd, pkt);
 			return true;
-		case N3_NEWS:
+	
+		case LS_NEWS:
 			MsgRecv_News(pkt);
 			return true;
 	}
@@ -474,28 +471,4 @@ void CGameProcLogIn_1298::ConnectToGameServer() // 고른 게임 서버에 접�
 		MsgSend_VersionCheck();
 	}
 }
-//	By : Ecli666 ( On 2002-07-15 오후 7:35:16 )
-//
-/*
-void CGameProcLogIn_1298::PacketSend_MGameLogin()
-{
-	if(m_szID.size() >= 20 || m_szPW.size() >= 12)
-	{
-//		MessageBox("ID는 20 자 PassWord 는 12 자 미만이어야 합니다.", "LogIn Error");
-		return;
-	}
-
-	int send_index = 0;
-	uint8_t send_buff[128];
-
-	CAPISocket::MP_AddByte( send_buff, send_index, N3_ACCOUNT_LOGIN_MGAME); // Send - s1(ID길이) str1(ID문자열:20바이트이하) s1(PW길이) str1(PW문자열:12바이트이하) | Recv - b1(0:실패 1:성공 2:ID없음 3:PW틀림 4:서버점검중)
-	CAPISocket::MP_AddShort( send_buff, send_index, (int16_t)(m_szID.size()));
-	CAPISocket::MP_AddString( send_buff, send_index, m_szID);
-	CAPISocket::MP_AddShort( send_buff, send_index, (int16_t)(m_szPW.size()));
-	CAPISocket::MP_AddString( send_buff, send_index, m_szPW);
-
-	s_pSocket->Send( send_buff, send_index );
-}*/
-
-//	~(By Ecli666 On 2002-07-15 오후 7:35:16 )
 #endif

--- a/Client/WarFare/GameProcLogIn_1298.h
+++ b/Client/WarFare/GameProcLogIn_1298.h
@@ -34,7 +34,6 @@ public:
 	void ConnectToGameServer(); // 고른 게임 서버에 접속
 	CGameProcLogIn_1298();
 	~CGameProcLogIn_1298() override;
-//	void PacketSend_MGameLogin();
 };
 
 class CGameProcLogIn : public CGameProcLogIn_1298 {};

--- a/Client/WarFare/PacketDef.h
+++ b/Client/WarFare/PacketDef.h
@@ -7,11 +7,6 @@ const int SOCKET_PORT_LOGIN = 15100;
 #include "shared/types.h"
 #include "shared/packets.h"
 
-#define N3_ACCOUNT_LOGIN			0xf3
-#define N3_ACCOUNT_LOGIN_MGAME		0xf4	// !!! LOGIN_REQ !!! 와 동일
-#define N3_GAMESERVER_GROUP_LIST	0xf5	// Recv - b1(ServerCount) loop(	s1(IP길이), str1(IP문자열), s1(서버이름길이), str1(서버이름문자열), s1(서버접속인원) )
-#define N3_NEWS						0xf6	//notice messages on login screen
-
 	enum e_ChatMode {	N3_CHAT_NORMAL = 1,
 						N3_CHAT_PRIVATE,
 						N3_CHAT_PARTY,


### PR DESCRIPTION
We have duplicate definitions for opcodes here. We should just use the server's definitions for consistency like the game opcodes.