### PR TITLE
CUIWarp: Use N3_VERIFY_UI_COMPONENT

### DIFF
--- a/Client/WarFare/UIWarp.cpp
+++ b/Client/WarFare/UIWarp.cpp
@@ -37,13 +37,13 @@ CUIWarp::~CUIWarp()
 
 bool CUIWarp::Load(HANDLE hFile)
 {
-	if(CN3UIBase::Load(hFile)==false) 
+	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok, (CN3UIButton*) GetChildByID("Btn_Ok"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, (CN3UIButton*) GetChildByID("Btn_Cancel"));
-	N3_VERIFY_UI_COMPONENT(m_pList_Infos, (CN3UIList*) GetChildByID("List_Infos"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Agreement, (CN3UIString*) GetChildByID("Text_Agreement"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok,			GetChildByID<CN3UIButton>("Btn_Ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,		GetChildByID<CN3UIButton>("Btn_Cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pList_Infos,		GetChildByID<CN3UIList>("List_Infos"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Agreement,	GetChildByID<CN3UIString>("Text_Agreement"));
 
 	return true;
 }
@@ -101,7 +101,8 @@ bool CUIWarp::InfoGetCur(__WarpInfo& WI)
 
 void CUIWarp::UpdateList()
 {
-	if(m_pList_Infos == nullptr) return;
+	if (m_pList_Infos == nullptr)
+		return;
 
 	m_pList_Infos->ResetContent();
 	it_WI it = m_ListInfos.begin(), itEnd = m_ListInfos.end();
@@ -116,7 +117,9 @@ void CUIWarp::UpdateList()
 
 void CUIWarp::UpdateAgreement()
 {
-	if(m_pList_Infos == nullptr || m_pText_Agreement == nullptr) return;
+	if (m_pList_Infos == nullptr || m_pText_Agreement == nullptr)
+		return;
+
 	int iSel = m_pList_Infos->GetCurSel();
 	if (iSel < 0
 		|| iSel >= static_cast<int>(m_ListInfos.size()))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Old NULL macro is used

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
NULL macro replaced with nullptr and N3_VERIFY_UI_COMPONENTS used to load instead of __ASSERT macro.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
clean up.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
