### PR TITLE
Server: Send rental packet for NPC_RENTAL NPCs to open UI

### DIFF
--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -4623,6 +4623,15 @@ void CUser::NpcEvent(char* pBuf)
 			Send(send_buff, send_index);
 			break;
 
+		case NPC_RENTAL:
+			SetByte(send_buff, WIZ_RENTAL, send_index);
+			SetByte(send_buff, RENTAL_NPC, send_index);
+			// 1 = enabled, -1 = disabled
+			SetShort(send_buff, 1, send_index);
+			SetDWORD(send_buff, pNpc->m_iSellingGroup, send_index);
+			Send(send_buff, send_index);
+			break;
+
 #if 0 // not typically available
 		case NPC_COUPON:
 			if (m_pMain->m_byNationID == 1


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Interacting with rental NPC results in no action on official client. This prevents adding the same behavior for openko client.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Rental UI opens after interacting with NPC.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
snoxd approach used inside Ebenezer - CUser::NpcEvent

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
