### PR TITLE
Update CN3UITooltip + CN3UIString::GetStringRealWidth()

### DIFF
--- a/Client/N3Base/N3UIString.cpp
+++ b/Client/N3Base/N3UIString.cpp
@@ -473,7 +473,7 @@ void CN3UIString::ChangeFont(const std::string& szFont)
 }
 #endif
 
-int CN3UIString::GetStringRealWidth(int iNum)
+int CN3UIString::GetStringRealWidth(int iNum) const
 {
 	SIZE size;
 	BOOL bFlag = m_pDFont->GetTextExtent("가", lstrlen("가"), &size);
@@ -484,12 +484,32 @@ int CN3UIString::GetStringRealWidth(int iNum)
 	return (size.cx*iNum) / 2;
 }
 
-int CN3UIString::GetStringRealWidth(std::string& szText)
+int	CN3UIString::GetStringRealWidth(const std::string& szText) const
 {
-	SIZE size;
-	BOOL bFlag = m_pDFont->GetTextExtent(szText, szText.length(), &size);
-	__ASSERT(bFlag, "cannot get size of dfont");
-	return size.cx;
+	if (szText.empty())
+		return 0;
+
+	int iRealWidth = 0;
+	for (size_t i = 0; i < szText.size();)
+	{
+		char c = szText[i];
+
+		SIZE size = { 0, 0 };
+		if (c & 0x80)
+		{
+			m_pDFont->GetTextExtent(&szText[i], 2, &size);
+			i += 2;
+		}
+		else
+		{
+			m_pDFont->GetTextExtent(&szText[i], 1, &size);
+			i += 1;
+		}
+
+		iRealWidth += size.cx;
+	}
+
+	return iRealWidth;
 }
 
 void CN3UIString::SetStyle(uint32_t dwType, uint32_t dwStyleEx)

--- a/Client/N3Base/N3UIString.h
+++ b/Client/N3Base/N3UIString.h
@@ -43,8 +43,8 @@ public:
 	const std::string&	GetString() { return m_szString; }
 	int					GetLineCount() const {return m_iLineCount;}
 	int					GetStartLine() const {return m_iStartLine;}
-	int					GetStringRealWidth(int iNum);
-	int					GetStringRealWidth(std::string& szText);
+	int					GetStringRealWidth(int iNum) const;
+	int					GetStringRealWidth(const std::string& szText) const;
 
 	virtual	uint32_t	MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld);
 	virtual void	Render();

--- a/Client/N3Base/N3UITooltip.h
+++ b/Client/N3Base/N3UITooltip.h
@@ -22,24 +22,17 @@ class CN3UITooltip : public CN3UIStatic
 {
 public:
 	CN3UITooltip();
-	virtual ~CN3UITooltip();
+	~CN3UITooltip() override;
+	void Release() override;
+	void Render() override;
+	void SetText(const std::string& szText, D3DCOLOR crTooltip);
+	void Tick() override;
+	uint32_t MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld) override;
 
-// Attributes
-public:
 protected:
-	float			m_fHoverTime;	// 마우스가 한곳에서 정지하여 있는 시간(누적)
-	bool			m_bSetText;		// 이미 text가 설정되었는가?
-	POINT			m_ptCursor;		// 커서의 위치
-
-// Operations
-public:
-	void			SetText(const std::string& szText, D3DCOLOR crTooltip);
-	virtual void	Release();
-	virtual void	Tick();
-	virtual void	Render();
-	virtual uint32_t	MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld);
-protected:
-
+	float	m_fHoverTime;	// 마우스가 한곳에서 정지하여 있는 시간(누적)
+	bool	m_bSetText;		// 이미 text가 설정되었는가?
+	POINT	m_ptCursor;		// 커서의 위치
 };
 
 #endif // !defined(AFX_N3UITOOLTIP_H__7085B857_C8EE_410D_AB27_5332D26DF01A__INCLUDED_)


### PR DESCRIPTION
This fixes basic tooltips not rendering the entire tooltip.

Resolves #96 (specifically as regards to the cited example -- word wrapping is implemented on a case-by-case basis).