### PR TITLE
Update CPlayerBase::InitChr() to load *.n3chr & *.n3fxplug

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -856,7 +856,9 @@ struct __TABLE_PLAYER_LOOKS
 	std::string	szJointFN;		// Joint filename
 	std::string	szAniFN;		// Animation filename
 	std::string	szPartFNs[10];	// Each character part — upper body, lower body, head, arms, legs, hair, cape
-	std::string	szIdk0[3];
+	std::string	szSkinFN;
+	std::string	szChrFN;
+	std::string	szFXPlugFN;
 
 	int			iIdk1;
 

--- a/Client/WarFare/PlayerBase.cpp
+++ b/Client/WarFare/PlayerBase.cpp
@@ -2136,17 +2136,31 @@ void CPlayerBase::DurabilitySet(e_ItemSlot eSlot, int iDurability)
 
 bool CPlayerBase::InitChr(__TABLE_PLAYER_LOOKS* pTbl)
 {
-	if(nullptr == pTbl) return false;
+	if (pTbl == nullptr)
+		return false;
 
 	m_pLooksRef = pTbl;
 
-	m_Chr.JointSet(pTbl->szJointFN);
-	m_Chr.AniCtrlSet(pTbl->szAniFN);
-
-	if(RACE_NPC != m_InfoBase.eRace) // 상,하체 따로 놀 준비..
+	if (!pTbl->szChrFN.empty())
 	{
-		m_Chr.JointPartSet(0, 16, 23); // 하체
-		m_Chr.JointPartSet(1, 1, 15); // 상체
+		__Vector3 vPos = Position();
+		m_Chr.LoadFromFile(pTbl->szChrFN);
+		m_Chr.PosSet(vPos);
+	}
+	else
+	{
+		m_Chr.JointSet(pTbl->szJointFN);
+		m_Chr.AniCtrlSet(pTbl->szAniFN);
+
+		// 상,하체 따로 놀 준비..
+		if (RACE_NPC != m_InfoBase.eRace)
+		{
+			m_Chr.JointPartSet(0, 16, 23); // 하체
+			m_Chr.JointPartSet(1, 1, 15); // 상체
+		}
+
+		if (!pTbl->szFXPlugFN.empty())
+			m_Chr.FXPlugSet(pTbl->szFXPlugFN);
 	}
 
 	return true;


### PR DESCRIPTION
Some models don't have individual parts setup. Instead they require loading the associated *.n3chr file instead.

Resolves #515, resolves #340