### PR TITLE
Update object NPC spawn & visibility behaviour

### DIFF
--- a/Client/N3Base/N3ShapeMgr.cpp
+++ b/Client/N3Base/N3ShapeMgr.cpp
@@ -12,6 +12,8 @@
 #include "N3ShapeExtra.h"
 #endif // end of #ifndef _3DSERVER
 
+#include <shared/globals.h>
+
 #ifdef _DEBUG
 #undef THIS_FILE
 static char THIS_FILE[] = __FILE__;
@@ -159,9 +161,8 @@ bool CN3ShapeMgr::Load(HANDLE hFile)
 
 				switch (pShape->m_iEventType)
 				{
-					case 1: // 좌우열림성문,
-					case 2: // 상하열림성문
-					case 3: // 상하 레버
+					case OBJECT_TYPE_BIND: // 좌우열림성문,
+					case OBJECT_TYPE_WARP_GATE:
 						pShape->m_bVisible = true;
 						break;
 

--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -1251,15 +1251,6 @@ enum e_SkillMagicType3	{	DDTYPE_TYPE3_DUR_OUR = 100,
 							DDTYPE_TYPE3_DUR_ENEMY = 200
 };
 
-enum e_ObjectType	{	OBJECT_TYPE_BINDPOINT,
-						OBJECT_TYPE_DOOR_LEFTRIGHT,
-						OBJECT_TYPE_DOOR_TOPDOWN,
-						OBJECT_TYPE_LEVER_TOPDOWN,
-						OBJECT_TYPE_FLAG,
-						OBJECT_TYPE_WARP_POINT,
-						OBJECT_TYPE_UNKNOWN = 0xffffffff
-					};
-
 // Special items associated with skill usage
 constexpr uint32_t ITEM_ID_MASTER_SCROLL_WARRIOR	= 379063000;
 constexpr uint32_t ITEM_ID_MASTER_SCROLL_ROGUE		= 379064000;

--- a/Server/AIServer/Map.cpp
+++ b/Server/AIServer/Map.cpp
@@ -485,13 +485,14 @@ void MAP::LoadObjectEvent(HANDLE hFile)
 		//TRACE(_T("Object - belong=%d, index=%d, type=%d, con=%d, sta=%d\n"), pEvent->sBelong, pEvent->sIndex, pEvent->sType, pEvent->sControlNpcID, pEvent->sStatus);
 
 		// 작업할것 : 맵데이터가 바뀌면 Param1이 2이면 성문인것을 판단..  3이면 레버..
-		if (pEvent->sType == 1
-			|| pEvent->sType == 2
-			|| pEvent->sType == 3)
-		{
-			// sungyong test
+		if (pEvent->sType == OBJECT_TYPE_GATE
+			|| pEvent->sType == OBJECT_TYPE_DOOR_TOPDOWN
+			|| pEvent->sType == OBJECT_TYPE_GATE_LEVER
+			|| pEvent->sType == OBJECT_TYPE_BARRICADE
+			|| pEvent->sType == OBJECT_TYPE_REMOVE_BIND
+			|| pEvent->sType == OBJECT_TYPE_ANVIL
+			|| pEvent->sType == OBJECT_TYPE_ARTIFACT)
 			m_pMain->AddObjectEventNpc(pEvent, m_nZoneNumber);
-		}
 
 		if (pEvent->sIndex <= 0)
 			continue;

--- a/Server/shared/globals.h
+++ b/Server/shared/globals.h
@@ -193,6 +193,25 @@ enum e_NpcType : uint8_t
 	NPC_BATTLE_MONUMENT		= 211
 };
 
+enum e_ObjectType
+{
+	OBJECT_TYPE_BIND				= 0,
+	OBJECT_TYPE_BINDPOINT			= OBJECT_TYPE_BIND,
+	OBJECT_TYPE_GATE				= 1,
+	OBJECT_TYPE_DOOR_LEFTRIGHT		= OBJECT_TYPE_GATE,
+	OBJECT_TYPE_DOOR_TOPDOWN		= 2,
+	OBJECT_TYPE_GATE_LEVER			= 3,
+	OBJECT_TYPE_LEVER_TOPDOWN		= OBJECT_TYPE_GATE_LEVER,
+	OBJECT_TYPE_FLAG				= 4,
+	OBJECT_TYPE_WARP_GATE			= 5,
+	OBJECT_TYPE_WARP_POINT			= OBJECT_TYPE_WARP_GATE,
+	OBJECT_TYPE_BARRICADE			= 6,
+	OBJECT_TYPE_REMOVE_BIND			= 7, // this seems to behave identically to OBJECT_TYPE_BIND
+	OBJECT_TYPE_ANVIL				= 8,
+	OBJECT_TYPE_ARTIFACT			= 9,
+	OBJECT_TYPE_UNKNOWN				= 0xffffffff
+};
+
 // These control neutrality-related settings client-side, 
 // including whether collision is enabled for other players.
 enum e_ZoneAbilityType

--- a/Server/shared/packets.h
+++ b/Server/shared/packets.h
@@ -600,20 +600,6 @@ enum e_ZoneAbilityOpcode
 	ZONE_ABILITY_UPDATE	= 1
 };
 
-enum ObjectType
-{
-	OBJECT_BIND			= 0,
-	OBJECT_GATE			= 1,
-	OBJECT_GATE2		= 2,
-	OBJECT_GATE_LEVER	= 3,
-	OBJECT_FLAG_LEVER	= 4,
-	OBJECT_WARP_GATE	= 5,
-	OBJECT_REMOVE_BIND	= 7,
-	OBJECT_ANVIL		= 8,
-	OBJECT_ARTIFACT		= 9,
-	OBJECT_NPC			= 11
-};
-
 // ---------------------------------------------------------------------
 // AI Server와 게임서버간의 Npc에 관련된 패킷은 1번~49번 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
We intend to *show* objects on an opt-in basis, not hide them.
This is why there's a desync with the official client regarding things like the anvil.
The anvil isn't being sent in the NPC info packet, so it's not shown in the official client.
It's only shown here because the default visibility state is flipped.

The anvil isn't being sent to the client because it's excluded from spawning as an object NPC.
Supported types have been updated to allow it, so it's spawned and sent to the client now -- ensuring it's now displayed consistently in both the official and our client.

Additionally, officially we generate detailed meshes here, otherwise walking up to things like warp gates is a mess.

Refs #336