### PR TITLE
Implement EVENT_TRIGGER table

### DIFF
--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -5596,6 +5596,7 @@ void CNpc::FillNpcInfo(char* temp_send, int& index, BYTE flag)
 	SetByte(temp_send, m_byGateOpen, index);
 	SetShort(temp_send, m_sHitRate, index);
 	SetByte(temp_send, m_byObjectType, index);
+	SetByte(temp_send, m_byTrapNumber, index);
 }
 
 // game server에 npc정보를 전부 전송...
@@ -5628,6 +5629,7 @@ void CNpc::SendNpcInfoAll(char* temp_send, int& index, int count)
 	SetByte(temp_send, m_byGateOpen, index);
 	SetShort(temp_send, m_sHitRate, index);
 	SetByte(temp_send, m_byObjectType, index);
+	SetByte(temp_send, m_byTrapNumber, index);
 
 	//TRACE(_T("monster info all = %d, name=%hs, count=%d \n"), m_sNid+NPC_BAND, m_strName, count);
 }

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -270,8 +270,8 @@ void CAISocket::RecvServerInfo(char* pBuf)
 void CAISocket::RecvNpcInfoAll(char* pBuf)
 {
 	int index = 0;
-	BYTE		byCount = 0;	// 마리수
-	BYTE        byType;			// 0:처음에 등장하지 않는 몬스터, 1:등장
+	uint8_t		byCount = 0;	// 마리수
+	uint8_t        byType;			// 0:처음에 등장하지 않는 몬스터, 1:등장
 	short		instanceId;			// NPC index
 	short		npcId;			// NPC index
 	short       sZone;			// Current zone number
@@ -281,20 +281,21 @@ void CAISocket::RecvNpcInfoAll(char* pBuf)
 	int			iweapon_1;
 	int			iweapon_2;
 	char		npcName[MAX_NPC_NAME_SIZE + 1];
-	BYTE		byGroup;		// 소속 집단
-	BYTE		byLevel;		// level
+	uint8_t		byGroup;		// 소속 집단
+	uint8_t		byLevel;		// level
 	float		fPosX;			// X Position
 	float		fPosZ;			// Z Position
 	float		fPosY;			// Y Position
-	BYTE		byDirection;	// 
-	BYTE		tNpcType;		// 00	: Monster
+	uint8_t		byDirection;	// 
+	uint8_t		tNpcType;		// 00	: Monster
 								// 01	: NPC
 	int			iSellingGroup;
 	int			nMaxHP;			// 최대 HP
 	int			nHP;			// 현재 HP
-	BYTE		byGateOpen;		// 성문일경우 열림과 닫힘 정보
+	uint8_t		byGateOpen;		// 성문일경우 열림과 닫힘 정보
 	short		sHitRate;
-	BYTE		byObjectType;	// 보통 : 0, 특수 : 1
+	uint8_t		byObjectType;	// 보통 : 0, 특수 : 1
+	uint8_t		byTrapNumber;
 
 	byCount = GetByte(pBuf, index);
 
@@ -323,6 +324,7 @@ void CAISocket::RecvNpcInfoAll(char* pBuf)
 		byGateOpen = GetByte(pBuf, index);
 		sHitRate = GetShort(pBuf, index);
 		byObjectType = GetByte(pBuf, index);
+		byTrapNumber = GetByte(pBuf, index);
 
 		//TRACE(_T("RecvNpcInfoAll  : nid=%d, szName=%hs, count=%d\n"), nid, szName, byCount);
 
@@ -391,6 +393,7 @@ void CAISocket::RecvNpcInfoAll(char* pBuf)
 		pNpc->m_sHitRate = sHitRate;
 		pNpc->m_byObjectType = byObjectType;
 		pNpc->m_NpcState = NPC_LIVE;
+		pNpc->m_byTrapNumber = byTrapNumber;
 
 		int nRegX = static_cast<int32_t>(fPosX / VIEW_DISTANCE);
 		int nRegZ = static_cast<int32_t>(fPosZ / VIEW_DISTANCE);
@@ -866,7 +869,7 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 {
 	int index = 0;
 
-	BYTE		Mode;						// 01(INFO_MODIFY)	: NPC 정보 변경
+	uint8_t		Mode;						// 01(INFO_MODIFY)	: NPC 정보 변경
 											// 02(INFO_DELETE)	: NPC 정보 삭제
 	short		instanceId;						// NPC index
 	short		npcId;						// NPC index
@@ -877,23 +880,24 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 	short       sZone;						// Current zone number
 	short       sZoneIndex;					// Current zone index
 	char		npcName[MAX_NPC_NAME_SIZE + 1];	// NPC Name
-	BYTE		byGroup;					// 소속 집단
-	BYTE		byLevel;					// level
+	uint8_t		byGroup;					// 소속 집단
+	uint8_t		byLevel;					// level
 	float		fPosX;						// X Position
 	float		fPosZ;						// Z Position
 	float		fPosY;						// Y Position
-	BYTE		byDirection;				// 방향
-	BYTE		tState;						// NPC 상태
+	uint8_t		byDirection;				// 방향
+	uint8_t		tState;						// NPC 상태
 											// 00	: NPC Dead
 											// 01	: NPC Live
-	BYTE		tNpcKind;					// 00	: Monster
+	uint8_t		tNpcKind;					// 00	: Monster
 											// 01	: NPC
 	int			iSellingGroup;
 	int			nMaxHP;						// 최대 HP
 	int			nHP;						// 현재 HP
-	BYTE		byGateOpen;
+	uint8_t		byGateOpen;
 	short		sHitRate;					// 공격 성공률
-	BYTE		byObjectType;				// 보통 : 0, 특수 : 1
+	uint8_t		byObjectType;				// 보통 : 0, 특수 : 1
+	uint8_t		byTrapNumber;
 
 	Mode = GetByte(pBuf, index);
 	instanceId = GetShort(pBuf, index);
@@ -925,6 +929,7 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 	byGateOpen = GetByte(pBuf, index);
 	sHitRate = GetShort(pBuf, index);
 	byObjectType = GetByte(pBuf, index);
+	byTrapNumber = GetByte(pBuf, index);
 
 	CNpc* pNpc = m_pMain->m_NpcMap.GetData(instanceId);
 	if (pNpc == nullptr)
@@ -966,6 +971,7 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 	pNpc->m_byGateOpen = byGateOpen;
 	pNpc->m_sHitRate = sHitRate;
 	pNpc->m_byObjectType = byObjectType;
+	pNpc->m_byTrapNumber = byTrapNumber;
 
 	int nRegX = static_cast<int32_t>(fPosX / VIEW_DISTANCE);
 	int nRegZ = static_cast<int32_t>(fPosZ / VIEW_DISTANCE);

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -24,6 +24,7 @@
 #include <shared/logger.h>
 #include <shared/STLMap.h>
 
+#include <unordered_map>
 #include <vector>
 
 #include "resource.h"
@@ -71,6 +72,8 @@ typedef CSTLMap <model::ServerResource>		ServerResourceTableMap;
 typedef CSTLMap <model::StartPosition>		StartPositionTableMap;
 typedef	CSTLMap	<EVENT>						EventMap;
 
+using EventTriggerMap = std::unordered_map<uint32_t, int32_t>;
+
 enum class NameType
 {
 	Account		= 1,
@@ -86,6 +89,9 @@ public:
 		return s_pInstance;
 	}
 
+	uint32_t GetEventTriggerKey(uint8_t byNpcType, uint16_t sTrapNumber) const;
+	int32_t GetEventTrigger(uint8_t byNpcType, uint16_t sTrapNumber) const;
+	BOOL LoadEventTriggerTable();
 	C3DMap* GetMapByID(int iZoneID) const;
 	C3DMap* GetMapByIndex(int iZoneIndex) const;
 	void FlySanta();
@@ -215,6 +221,7 @@ public:
 	ServerResourceTableMap	m_ServerResourceTableMap;
 	StartPositionTableMap	m_StartPositionTableMap;
 	EventMap				m_EventMap;
+	EventTriggerMap			m_EventTriggerMap;
 
 	CKnightsManager			m_KnightsManager;
 

--- a/Server/Ebenezer/Npc.cpp
+++ b/Server/Ebenezer/Npc.cpp
@@ -69,6 +69,7 @@ void CNpc::Initialize()
 	m_byDirection = 0;			// npc의 방향,,
 
 	m_byEvent = -1;				//  This is for the event.
+	m_byTrapNumber = 0;
 }
 
 void CNpc::MoveResult(float xpos, float ypos, float zpos, float speed)
@@ -93,7 +94,7 @@ void CNpc::MoveResult(float xpos, float ypos, float zpos, float speed)
 	//TRACE(_T("RecvNpcMove ==> nid = %d, zone=%d, x = %f, z = %f\n"), m_sNid, m_sCurZone, m_fCurX, m_fCurZ);
 }
 
-void CNpc::NpcInOut(BYTE Type, float fx, float fz, float fy)
+void CNpc::NpcInOut(uint8_t Type, float fx, float fz, float fy)
 {
 	int send_index = 0;
 	char buff[1024] = {};

--- a/Server/Ebenezer/Npc.h
+++ b/Server/Ebenezer/Npc.h
@@ -36,10 +36,10 @@ public:
 	char	m_strName[MAX_NPC_NAME_SIZE + 1];		// MONSTER(NPC) Name
 	int		m_iMaxHP;			// 최대 HP
 	int		m_iHP;				// 현재 HP
-	BYTE	m_byState;			// 몬스터 (NPC) 상태
-	BYTE	m_byGroup;			// 소속 집단
-	BYTE	m_byLevel;			// 레벨
-	BYTE	m_tNpcType;			// NPC Type
+	uint8_t	m_byState;			// 몬스터 (NPC) 상태
+	uint8_t	m_byGroup;			// 소속 집단
+	uint8_t	m_byLevel;			// 레벨
+	uint8_t	m_tNpcType;			// NPC Type
 								// 0 : Normal Monster
 								// 1 : NPC
 								// 2 : 각 입구,출구 NPC
@@ -49,13 +49,14 @@ public:
 
 	short	m_sRegion_X;			// region x position
 	short	m_sRegion_Z;			// region z position
-	BYTE	m_NpcState;			// NPC의 상태 - 살았다, 죽었다, 서있다 등등...
-	BYTE	m_byGateOpen;		// Gate Npc Status -> 1 : open 0 : close
+	uint8_t	m_NpcState;			// NPC의 상태 - 살았다, 죽었다, 서있다 등등...
+	uint8_t	m_byGateOpen;		// Gate Npc Status -> 1 : open 0 : close
 	short   m_sHitRate;			// 공격 성공률
-	BYTE    m_byObjectType;     // 보통은 0, object타입(성문, 레버)은 1
-	BYTE	m_byDirection;		// NPC가 보고 있는 방향
+	uint8_t   m_byObjectType;     // 보통은 0, object타입(성문, 레버)은 1
+	uint8_t	m_byDirection;		// NPC가 보고 있는 방향
 
 	short   m_byEvent;		    // This is for the quest. 
+	uint8_t	m_byTrapNumber;
 
 public:
 	CNpc();
@@ -63,7 +64,7 @@ public:
 
 	void Initialize();
 	void MoveResult(float xpos, float ypos, float zpos, float speed);
-	void NpcInOut(BYTE Type, float fx, float fz, float fy);
+	void NpcInOut(uint8_t Type, float fx, float fz, float fy);
 	void RegisterRegion();
 	void RemoveRegion(int del_x, int del_z);
 	void InsertRegion(int del_x, int del_z);

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -11121,9 +11121,7 @@ void CUser::ClientEvent(char* pBuf)
 			break;
 
 		case NPC_TELEPORT_GATE:
-#if 0 // TODO:
-			eventid = m_pMain->GetEventTrigger(pNpc->m_tNpcType, pNpc->m_sTrapNumber);
-#endif
+			eventid = m_pMain->GetEventTrigger(pNpc->m_tNpcType, pNpc->m_byTrapNumber);
 			if (eventid == -1)
 				return;
 			break;


### PR DESCRIPTION
Additionally, send NPC's "trap number" from AI so it can be used in the GetEventTrigger() lookup.

Refs #500

This fixes the teleport gate lookups, though something down the chain with EVT parsing/runtime continues to cause this behaviour to fail, so we cannot close the associated issue yet.