### PR TITLE
CAujardDlg::AllSaveRoutine() doesn't need to log unused slots

### DIFF
--- a/Server/Aujard/AujardDlg.cpp
+++ b/Server/Aujard/AujardDlg.cpp
@@ -932,11 +932,14 @@ void CAujardDlg::AllSaveRoutine()
 	for (int userId = 0; userId < static_cast<int>(_dbAgent.UserData.size()); userId++)
 	{
 		_USER_DATA* pUser = _dbAgent.UserData[userId];
-		if (pUser == nullptr || strlen(pUser->m_id) == 0)
+		if (pUser == nullptr)
 		{
 			spdlog::debug("AujardDlg::AllSaveRoutine: userId skipped for invalid data: {}", userId);
 			continue;
 		}
+
+		if (strlen(pUser->m_id) == 0)
+			continue;
 
 		if (HandleUserLogout(userId, UPDATE_ALL_SAVE, true))
 		{


### PR DESCRIPTION
It can continue to log on actual issues (if for some reason the instance doesn't exist -- which shouldn't happen), but for conventional cases where nobody's simply using that slot at the moment, there's no real need for the log.

This considerably reduces unnecessary log spam.