### PR TITLE
Fix inconsistent collision mesh generation

### DIFF
--- a/Client/N3Base/N3Chr.cpp
+++ b/Client/N3Base/N3Chr.cpp
@@ -1969,12 +1969,23 @@ void CN3Chr::Init()
 	}
 
 	this->RemakePlugTracePolygons();
-
-	this->FindMinMax();
 	
 	// 충돌 체크를 위한 폴리곤.. 크기에 맞게 변환..
-	if(nullptr == m_pMeshCollision) m_pMeshCollision = new CN3VMesh();
-	m_pMeshCollision->CreateCube(m_vMin, m_vMax);
+	if (m_pMeshCollision == nullptr)
+		m_pMeshCollision = new CN3VMesh();
+
+	RegenerateCollisionMesh();
+}
+
+void CN3Chr::RegenerateCollisionMesh()
+{
+	__Matrix44 mtxInverse;
+	D3DXMatrixInverse(&mtxInverse, nullptr, &m_Matrix);
+
+	FindMinMax();
+
+	if (m_pMeshCollision != nullptr)
+		m_pMeshCollision->CreateCube(Min() * mtxInverse, Max() * mtxInverse);
 }
 
 void CN3Chr::JointSet(const std::string& szFN)

--- a/Client/N3Base/N3Chr.h
+++ b/Client/N3Base/N3Chr.h
@@ -401,6 +401,7 @@ public:
 //////////////////////////////////////////////////
 
 	void		Init();
+	void		RegenerateCollisionMesh();
 	void		BuildMesh();
 	void		BuildMesh(int nLOD);
 	void		Render();

--- a/Client/N3Base/N3Joint.cpp
+++ b/Client/N3Base/N3Joint.cpp
@@ -237,14 +237,17 @@ void CN3Joint::ChildDelete(CN3Joint *pChild)
 	}
 }
 
-void CN3Joint::ParentSet(CN3Joint *pParent)
+void CN3Joint::ParentSet(CN3Joint* pParent)
 {
-	if(pParent == m_pParent) return;
+	if (pParent == m_pParent)
+		return;
 
 	m_pParent = pParent;
-	if(pParent) pParent->ChildAdd(this);
-
-	m_iFileFormatVersion = pParent->m_iFileFormatVersion;
+	if (pParent != nullptr)
+	{
+		pParent->ChildAdd(this);
+		m_iFileFormatVersion = pParent->m_iFileFormatVersion;
+	}
 }
 
 void CN3Joint::NodeCount(int &nCount)
@@ -447,12 +450,12 @@ void CN3Joint::ReCalcMatrixBlended(float fFrm0, float fFrm1, float fWeight0)
 		m_qRot.Slerp(qt1, qt2, fWeight1);
 
 	bHaveKey1 = m_KeyScale.DataGet(fFrm0, v1);
-	bHaveKey1 = m_KeyScale.DataGet(fFrm1, v2);
+	bHaveKey2 = m_KeyScale.DataGet(fFrm1, v2);
 	if(bHaveKey1 && bHaveKey2) 
 		m_vScale = (v1 * fWeight0) + (v2 * fWeight1);
 
 	bHaveKey1 = m_KeyOrient.DataGet(fFrm0, qt1);
-	bHaveKey1 = m_KeyOrient.DataGet(fFrm1, qt2);
+	bHaveKey2 = m_KeyOrient.DataGet(fFrm1, qt2);
 	if(bHaveKey1 && bHaveKey2) 
 		m_qOrient.Slerp(qt1, qt2, fWeight1);
 

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -2079,7 +2079,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	// 기본값 읽기..
 	////////////////////////////////////////////////////////////
 
-	this->InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
+	InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
+	s_pPlayer->RegenerateCollisionMesh();
 
 	// berserk temp
 	//s_pPlayer->PlugSet(PLUG_POS_BACK, "item/babacloak.n3cplug_cloak", nullptr);	// 파트를 셋팅..
@@ -4388,6 +4389,7 @@ void CGameProcMain::InitZone(int iZone, const __Vector3& vPosPlayer)
 	CLogWriter::Write("InitPlayerPosition() Position({:.1f}, {:.1f}, {:.1f})",
 		vPosPlayer.x, vPosPlayer.y, vPosPlayer.z); // TmpLog1122
 	InitPlayerPosition(vPosPlayer); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
+	s_pPlayer->RegenerateCollisionMesh(); // 충돌 메시를 다시 만든다..
 	s_pOPMgr->Release(); // 다른 플레이어 삭제...
 }
 
@@ -4837,13 +4839,7 @@ void CGameProcMain::MsgRecv_ZoneChange(
 
 			LoadingUIChange(iVictoryNation);
 
-			__Vector3 vPosPlayer;
-			vPosPlayer.x = fX;
-			vPosPlayer.y = fY;
-			vPosPlayer.z = fZ;
-			InitPlayerPosition(vPosPlayer); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 
-			s_pPlayer->RegenerateCollisionMesh(); // 충돌 메시를 다시 만든다..
 			s_pPlayer->m_iSendRegeneration = 0; // 한번 보내면 다시 죽을때까지 안보내는 플래그
 			s_pPlayer->m_fTimeAfterDeath = 0; // 한번 보내면 다시 죽을때까지 안보내는 플래그
 

--- a/Client/WarFare/PlayerBase.cpp
+++ b/Client/WarFare/PlayerBase.cpp
@@ -2169,10 +2169,7 @@ bool CPlayerBase::InitChr(__TABLE_PLAYER_LOOKS* pTbl)
 
 void CPlayerBase::RegenerateCollisionMesh() // 최대 최소값을 다시 찾고 충돌메시를 다시 만든다..
 {
-	m_Chr.FindMinMax();
-	__Matrix44 mtxInverse;
-	D3DXMatrixInverse(&mtxInverse, 0, &(m_Chr.m_Matrix));
-	if(m_Chr.CollisionMesh()) m_Chr.CollisionMesh()->CreateCube(m_Chr.Min() * mtxInverse, m_Chr.Max() * mtxInverse);
+	m_Chr.RegenerateCollisionMesh();
 }
 
 CPlayerBase* CPlayerBase::TargetPointerCheck(bool bMustAlive)


### PR DESCRIPTION
The core issue here is that it doesn't consistently rebuild the mesh after repositioning, and at least in one case where it does, the zone hasn't changed yet so y isn't clamped correctly for this zone (in this case, the position is actually updated twice -- the 2nd occurs at the end of InitZone(), which is correctly clamped... but the mesh wasn't rebuilt there. We remove the first and fix the second.).

Additionally, there's a couple of joint updates that aren't correctly triggered. This is an official bug with 1.298 but we can correct it here as with newer client versions.

Resolves #55