### PR TITLE
Server projects: treat all warnings as errors

### DIFF
--- a/Server/AIServer/AIServer.vcxproj
+++ b/Server/AIServer/AIServer.vcxproj
@@ -56,6 +56,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(DependencyDir);.;..;..\..;..\..\Client;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Server/AIServer/GameSocket.cpp
+++ b/Server/AIServer/GameSocket.cpp
@@ -307,7 +307,7 @@ void CGameSocket::RecvUserInfo(char* pBuf)
 	pUser->m_curZone = bZone;
 	pUser->m_sZoneIndex = sZoneIndex;
 	pUser->m_bNation = bNation;
-	pUser->m_sLevel = bLevel;
+	pUser->m_byLevel = bLevel;
 	pUser->m_sHP = sHp;
 	pUser->m_sMP = sMp;
 	//pUser->m_sSP = sSp;
@@ -335,7 +335,7 @@ void CGameSocket::RecvUserInfo(char* pBuf)
 	pUserLog = new _USERLOG;
 	pUserLog->t = CTime::GetCurrentTime();
 	pUserLog->byFlag = USER_LOGIN;
-	pUserLog->byLevel = pUser->m_sLevel;
+	pUserLog->byLevel = pUser->m_byLevel;
 	strcpy(pUserLog->strUserID, pUser->m_strUserID);
 	pUser->m_UserLogList.push_back(pUserLog);
 }
@@ -685,7 +685,7 @@ void CGameSocket::RecvUserLogOut(char* pBuf)
 	pUserLog = new _USERLOG;
 	pUserLog->t = CTime::GetCurrentTime();
 	pUserLog->byFlag = USER_LOGOUT;
-	pUserLog->byLevel = pUser->m_sLevel;
+	pUserLog->byLevel = pUser->m_byLevel;
 	strcpy(pUserLog->strUserID, pUser->m_strUserID);
 	pUser->m_UserLogList.push_back(pUserLog);
 
@@ -777,7 +777,7 @@ void CGameSocket::RecvUserUpdate(char* pBuf)
 	if (pUser == nullptr)
 		return;
 
-	if (pUser->m_sLevel < byLevel)		// level up
+	if (pUser->m_byLevel < byLevel)		// level up
 	{
 		pUser->m_sHP = sHP;
 		pUser->m_sMP = sMP;
@@ -791,7 +791,7 @@ void CGameSocket::RecvUserUpdate(char* pBuf)
 		pUser->m_UserLogList.push_back(pUserLog);
 	}
 
-	pUser->m_sLevel = byLevel;
+	pUser->m_byLevel = byLevel;
 	pUser->m_sHitDamage = sDamage;
 	pUser->m_fHitrate = fHitAgi;
 	pUser->m_fAvoidrate = fAvoidAgi;
@@ -973,7 +973,7 @@ void CGameSocket::RecvUserInfoAllData(char* pBuf)
 		pUser->m_curZone = bZone;
 		pUser->m_sZoneIndex = sZoneIndex;
 		pUser->m_bNation = bNation;
-		pUser->m_sLevel = bLevel;
+		pUser->m_byLevel = bLevel;
 		pUser->m_sHP = sHp;
 		pUser->m_sMP = sMp;
 		//pUser->m_sSP = sSp;

--- a/Server/AIServer/MagicProcess.cpp
+++ b/Server/AIServer/MagicProcess.cpp
@@ -544,8 +544,8 @@ void CMagicProcess::ExecuteType4(int magicid, int sid, int tid, int data1, int d
 			pNpc->m_MagicType4[pType->BuffType - 1].byAmount = pType->Speed;
 			pNpc->m_MagicType4[pType->BuffType - 1].sDurationTime = pType->Duration;
 			pNpc->m_MagicType4[pType->BuffType - 1].fStartTime = TimeGet();
-			pNpc->m_fSpeed_1 = pNpc->m_fOldSpeed_1 * ((double) pType->Speed / 100);
-			pNpc->m_fSpeed_2 = pNpc->m_fOldSpeed_2 * ((double) pType->Speed / 100);
+			pNpc->m_fSpeed_1 = pNpc->m_fOldSpeed_1 * (pType->Speed / 100.0f);
+			pNpc->m_fSpeed_2 = pNpc->m_fOldSpeed_2 * (pType->Speed / 100.0f);
 			//TRACE(_T("executeType4 ,, speed1=%.2f, %.2f,, type=%d, cur=%.2f, %.2f\n"), pNpc->m_fOldSpeed_1, pNpc->m_fOldSpeed_2, pType->bSpeed, pNpc->m_fSpeed_1, pNpc->m_fSpeed_2);
 //			}
 			break;
@@ -760,9 +760,9 @@ short CMagicProcess::GetMagicDamage(int tid, int total_hit, int attribute, int d
 			bSign = false;
 		}
 
-		damage = (short) (total_hit - (0.7f * total_hit * total_r / 200));
+		damage = static_cast<short>(total_hit - (0.7f * total_hit * total_r / 200));
 		random = myrand(0, damage);
-		damage = (short) (0.7f * (total_hit - (0.9f * total_hit * total_r / 200))) + 0.2f * random;
+		damage = static_cast<short>((0.7f * (total_hit - (0.9f * total_hit * total_r / 200))) + 0.2f * random);
 //		damage = damage + (3 * righthand_damage);
 		damage = damage + righthand_damage;
 	}
@@ -1075,8 +1075,8 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 						pNpc->m_MagicType4[pType4->BuffType - 1].byAmount = pType4->Speed;
 						pNpc->m_MagicType4[pType4->BuffType - 1].sDurationTime = pType4->Duration;
 						pNpc->m_MagicType4[pType4->BuffType - 1].fStartTime = TimeGet();
-						pNpc->m_fSpeed_1 = pNpc->m_fOldSpeed_1 * ((double) pType4->Speed / 100);
-						pNpc->m_fSpeed_2 = pNpc->m_fOldSpeed_2 * ((double) pType4->Speed / 100);
+						pNpc->m_fSpeed_1 = pNpc->m_fOldSpeed_1 * (pType4->Speed / 100.0f);
+						pNpc->m_fSpeed_2 = pNpc->m_fOldSpeed_2 * (pType4->Speed / 100.0f);
 					//}
 						break;
 

--- a/Server/AIServer/Map.cpp
+++ b/Server/AIServer/Map.cpp
@@ -504,7 +504,6 @@ void MAP::LoadObjectEvent(HANDLE hFile)
 
 bool MAP::LoadRoomEvent(int zone_number)
 {
-	DWORD		length, count;
 	CString		filename;
 	CFile		pFile;
 	BYTE		byte;
@@ -536,11 +535,11 @@ bool MAP::LoadRoomEvent(int zone_number)
 
 	std::wstring filenameWide = evtPath.wstring();
 
-	length = pFile.GetLength();
+	uint64_t length = pFile.GetLength();
 
 	CArchive in(&pFile, CArchive::load);
 	int lineNumber = 0;
-	count = 0;
+	uint64_t count = 0;
 
 	while (count < length)
 	{
@@ -933,12 +932,14 @@ void MAP::InitializeRoom()
 /// \brief Checks if a position is valid for the map
 bool MAP::IsValidPosition(float x, float z) const
 {
-	int mapMaxX = (m_sizeMap.cx-1) * m_fUnitDist;
-	int mapMaxZ = (m_sizeMap.cy-1) * m_fUnitDist;
-	if (x < 0 || x > mapMaxX
-		|| z < 0 || z > mapMaxZ)
-	{
+	int mapMaxX = static_cast<int>((m_sizeMap.cx - 1) * m_fUnitDist);
+	int mapMaxZ = static_cast<int>((m_sizeMap.cy - 1) * m_fUnitDist);
+
+	if (x < 0 || x > mapMaxX)
 		return false;
-	}
+
+	if (z < 0 || z > mapMaxZ)
+		return false;
+
 	return true;
 }

--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -617,7 +617,7 @@ void CNpc::NpcTracing(CIOCPort* pIOCP)
 		Setfloat(pBuf, m_fPrevX, index);
 		Setfloat(pBuf, m_fPrevZ, index);
 		Setfloat(pBuf, m_fPrevY, index);
-		fMoveSpeed = m_fSecForRealMoveMetor / ((double) m_sSpeed / 1000);
+		fMoveSpeed = m_fSecForRealMoveMetor / (m_sSpeed / 1000.0f);
 		Setfloat(pBuf, fMoveSpeed, index);
 		//Setfloat(pBuf, m_fSecForRealMoveMetor, index);
 		//TRACE(_T("Npc Tracing --> nid = %d, cur=[x=%.2f, z=%.2f], prev=[x=%.2f, z=%.2f, metor = %.2f], frame=%d, speed = %d \n"), m_sNid, m_fCurX, m_fCurZ, m_fPrevX, m_fPrevZ, m_fSecForRealMoveMetor, m_sStepCount, m_sSpeed);
@@ -782,10 +782,9 @@ void CNpc::NpcMoving(CIOCPort* pIOCP)
 				m_sNid + NPC_BAND, m_sSid, m_strName, m_fCurX, m_fCurZ);
 		}
 
-		int rx = m_fCurX / VIEW_DIST;
-		int rz = m_fCurZ / VIEW_DIST;
+		// TRACE(_T("** NpcMoving --> IsMovingEnd() 이동이 끝남,, rx=%d, rz=%d, stand로\n"),
+		//	static_cast<int>(m_fCurX / VIEW_DIST), static_cast<int>(m_fCurZ / VIEW_DIST));
 
-		//TRACE(_T("** NpcMoving --> IsMovingEnd() 이동이 끝남,, rx=%d, rz=%d, stand로\n"), rx, rz);
 		m_NpcState = NPC_STANDING;
 		m_Delay = m_sStandTime;
 		m_fDelayTime = TimeGet();
@@ -845,7 +844,7 @@ void CNpc::NpcMoving(CIOCPort* pIOCP)
 		Setfloat(pBuf, m_fPrevX, index);
 		Setfloat(pBuf, m_fPrevZ, index);
 		Setfloat(pBuf, m_fPrevY, index);
-		fMoveSpeed = m_fSecForRealMoveMetor / ((double) m_sSpeed / 1000);
+		fMoveSpeed = m_fSecForRealMoveMetor / (m_sSpeed / 1000.0f);
 		Setfloat(pBuf, fMoveSpeed, index);
 		//Setfloat(pBuf, m_fSecForRealMoveMetor, index);
 		//TRACE(_T("Npc Move --> nid = %d, cur=[x=%.2f, z=%.2f], prev=[x=%.2f, z=%.2f, metor = %.2f], frame=%d, speed = %d \n"), m_sNid+NPC_BAND, m_fCurX, m_fCurZ, m_fPrevX, m_fPrevZ, m_fSecForRealMoveMetor, m_sStepCount, m_sSpeed);
@@ -1062,7 +1061,7 @@ void CNpc::NpcBack(CIOCPort* pIOCP)
 	Setfloat(pBuf, m_fPrevX, index);
 	Setfloat(pBuf, m_fPrevZ, index);
 	Setfloat(pBuf, m_fPrevY, index);
-	fMoveSpeed = m_fSecForRealMoveMetor / ((double) m_sSpeed / 1000);
+	fMoveSpeed = m_fSecForRealMoveMetor / (m_sSpeed / 1000.0f);
 	Setfloat(pBuf, fMoveSpeed, index);
 	//Setfloat(pBuf, m_fSecForRealMoveMetor, index);
 
@@ -1517,8 +1516,8 @@ bool CNpc::RandomMove()
 	vStart.Set(m_fCurX, 0, m_fCurZ);
 	vEnd.Set(fDestX, 0, fDestZ);
 
-	int mapMaxX = (pMap->m_sizeMap.cx-1) * pMap->m_fUnitDist;
-	int mapMaxZ = (pMap->m_sizeMap.cy-1) * pMap->m_fUnitDist;
+	int mapMaxX = static_cast<int>((pMap->m_sizeMap.cx - 1) * pMap->m_fUnitDist);
+	int mapMaxZ = static_cast<int>((pMap->m_sizeMap.cy - 1) * pMap->m_fUnitDist);
 	if (!pMap->IsValidPosition(m_fCurX, m_fCurZ))
 	{
 		spdlog::error("Npc::RandomMove: coordinates invalid [serial={} npcName={} x={} z={} destX={} destZ={} mapBounds=[x:{} z:{}]]",
@@ -2597,7 +2596,7 @@ float CNpc::FindEnemyExpand(int nRX, int nRZ, float fCompDis, int nType)
 				// 선공몹...
 				else
 				{
-					iLevelComprison = pUser->m_sLevel - m_sLevel;
+					iLevelComprison = pUser->m_byLevel - m_sLevel;
 
 					// 작업할 것 : 타입에 따른 공격성향으로..
 					//if(iLevelComprison > ATTACK_LIMIT_LEVEL)	continue;
@@ -3298,7 +3297,7 @@ int CNpc::GetTargetPath(int option)
 		if (m_byAttackPos > 0
 			&& m_byAttackPos < 9)
 		{
-			fDegree = (m_byAttackPos - 1) * 45;
+			fDegree = (m_byAttackPos - 1) * 45.0f;
 			fTargetDistance = 2.0f + m_fBulk;
 			vEnd22 = ComputeDestPos(vUser, 0.0f, fDegree, fTargetDistance);
 			fSurX = vEnd22.x - vUser.x;
@@ -3309,7 +3308,7 @@ int CNpc::GetTargetPath(int option)
 		}
 		else
 		{
-			vEnd22 = CalcAdaptivePosition(vNpc, vUser, 2.0 + m_fBulk);
+			vEnd22 = CalcAdaptivePosition(vNpc, vUser, 2.0f + m_fBulk);
 			m_fEndPoint_X = vEnd22.x;
 			m_fEndPoint_Y = vEnd22.z;
 		}
@@ -4284,13 +4283,13 @@ int CNpc::GetFinalDamage(CUser* pUser, int type)
 	Hit = m_sDamage;											// 공격자 Hit 		
 //	Ac = (short) pUser->m_sAC;									// 방어자 Ac 
 
-//	Ac = (short) pUser->m_sItemAC + (short) pUser->m_sLevel;	// 방어자 Ac 
-//	Ac = (short) pUser->m_sAC - (short) pUser->m_sLevel;		// 방어자 Ac. 잉...성래씨 미워 ㅜ.ㅜ
-	Ac = (short) pUser->m_sItemAC + (short) pUser->m_sLevel + (short) (pUser->m_sAC - pUser->m_sLevel - pUser->m_sItemAC);
+//	Ac = (short) pUser->m_sItemAC + (short) pUser->m_byLevel;	// 방어자 Ac 
+//	Ac = (short) pUser->m_sAC - (short) pUser->m_byLevel;		// 방어자 Ac. 잉...성래씨 미워 ㅜ.ㅜ
+	Ac = (short) pUser->m_sItemAC + (short) pUser->m_byLevel + (short) (pUser->m_sAC - pUser->m_byLevel - pUser->m_sItemAC);
 
 //	ASSERT(Ac != 0);
 //	short kk = (short) pUser->m_sItemAC;
-//	short tt = (short) pUser->m_sLevel;
+//	short tt = (short) pUser->m_byLevel;
 //	Ac = kk + tt;
 
 	HitB = (int) ((Hit * 200) / (Ac + 240));
@@ -4843,7 +4842,7 @@ go_result:
 
 	if (m_iHP <= 0)
 	{
-	//	m_ItemUserLevel = pUser->m_sLevel;
+	//	m_ItemUserLevel = pUser->m_byLevel;
 		m_iHP = 0;
 		Dead(pIOCP);
 		return false;
@@ -4861,7 +4860,7 @@ go_result:
 			&& m_NpcState != NPC_FAINTING)
 		{
 			// 확률 계산..
-			iLightningR = 10 + (40 - 40 * ((double) m_sLightningR / 80));
+			iLightningR = static_cast<int>(10 + (40 - 40 * (m_sLightningR / 80.0)));
 			if (COMPARE(iRandom, 0, iLightningR))
 			{
 				m_NpcState = NPC_FAINTING;
@@ -5058,7 +5057,7 @@ void CNpc::SendExpToUserList()
 								continue;
 
 							++nTotalMan;
-							nTotalLevel += pPartyUser->m_sLevel;
+							nTotalLevel += pPartyUser->m_byLevel;
 						}
 
 						nPartyExp = GetPartyExp(nTotalLevel, nTotalMan, nPartyExp);
@@ -5075,7 +5074,7 @@ void CNpc::SendExpToUserList()
 							if (!IsInExpRange(pPartyUser))
 								continue;
 
-							TempValue = (nPartyExp * (1 + 0.3 * (nTotalMan - 1))) * (double) pPartyUser->m_sLevel / (double) nTotalLevel;
+							TempValue = (nPartyExp * (1 + 0.3 * (nTotalMan - 1))) * (double) pPartyUser->m_byLevel / (double) nTotalLevel;
 							//TempValue = ( nPartyExp * ( 1+0.3*( nTotalMan-1 ) ) );
 							nExp = (int) TempValue;
 
@@ -5088,7 +5087,7 @@ void CNpc::SendExpToUserList()
 							}
 							else
 							{
-								TempValue = (nPartyLoyalty * (1 + 0.2 * (nTotalMan - 1))) * (double) pPartyUser->m_sLevel / (double) nTotalLevel;
+								TempValue = (nPartyLoyalty * (1 + 0.2 * (nTotalMan - 1))) * (double) pPartyUser->m_byLevel / (double) nTotalLevel;
 								nLoyalty = (int) TempValue;
 								if (TempValue > nLoyalty)
 									++nLoyalty;
@@ -5116,7 +5115,7 @@ void CNpc::SendExpToUserList()
 							continue;
 
 						++nTotalMan;
-						nTotalLevel += pPartyUser->m_sLevel;
+						nTotalLevel += pPartyUser->m_byLevel;
 					}
 
 					nPartyExp = GetPartyExp(nTotalLevel, nTotalMan, nPartyExp);
@@ -5133,7 +5132,7 @@ void CNpc::SendExpToUserList()
 						if (!IsInExpRange(pPartyUser))
 							continue;
 
-						TempValue = (nPartyExp * (1 + 0.3 * (nTotalMan - 1))) * (double) pPartyUser->m_sLevel / (double) nTotalLevel;
+						TempValue = (nPartyExp * (1 + 0.3 * (nTotalMan - 1))) * (double) pPartyUser->m_byLevel / (double) nTotalLevel;
 						//TempValue = ( nPartyExp * ( 1+0.3*( nTotalMan-1 ) ) );
 						nExp = (int) TempValue;
 
@@ -5146,7 +5145,7 @@ void CNpc::SendExpToUserList()
 						}
 						else
 						{
-							TempValue = (nPartyLoyalty * (1 + 0.2 * (nTotalMan - 1))) * (double) pPartyUser->m_sLevel / (double) nTotalLevel;
+							TempValue = (nPartyLoyalty * (1 + 0.2 * (nTotalMan - 1))) * (double) pPartyUser->m_byLevel / (double) nTotalLevel;
 							nLoyalty = (int) TempValue;
 							if (TempValue > nLoyalty)
 								++nLoyalty;
@@ -5529,12 +5528,12 @@ void CNpc::FindFriendRegion(int x, int z, MAP* pMap, _TargetHealer* pHealer, int
 					continue;
 
 				// HP상태를 체크
-				iHP = pNpc->m_iMaxHP * 0.9;
+				iHP = static_cast<int>(pNpc->m_iMaxHP * 0.9);
 
 				// HP 체크
 				if (pNpc->m_iHP <= iHP)
 				{
-					iCompValue = (pNpc->m_iMaxHP - pNpc->m_iHP) / (pNpc->m_iMaxHP * 0.01);
+					iCompValue = static_cast<int>((pNpc->m_iMaxHP - pNpc->m_iHP) / (pNpc->m_iMaxHP * 0.01));
 					if (iValue < iCompValue)
 					{
 						iValue = iCompValue;
@@ -5832,9 +5831,9 @@ void CNpc::NpcMoveEnd(CIOCPort* pIOCP)
 	Setfloat(pBuf, m_fCurY, index);
 	Setfloat(pBuf, 0, index);
 
-	int rx = m_fCurX / VIEW_DIST;
-	int rz = m_fCurZ / VIEW_DIST;
-	//TRACE(_T("NpcMoveEnd() --> nid = %d, x=%f, y=%f, rx=%d,rz=%d, frame=%d, speed = %d \n"), m_sNid, m_fCurX, m_fCurZ, rx,rz, m_iAniFrameCount, m_sSpeed);
+	// TRACE(_T("NpcMoveEnd() --> nid = %d, x=%f, y=%f, rx=%d,rz=%d, frame=%d, speed = %d \n"),
+	// m_sNid, m_fCurX, m_fCurZ, static_cast<int>(m_fCurX / VIEW_DIST), static_cast<int>(m_fCurZ / VIEW_DIST),
+	// m_iAniFrameCount, m_sSpeed);
 	SendAll(pIOCP, pBuf, index);   // thread 에서 send
 }
 
@@ -5957,7 +5956,7 @@ bool CNpc::GetUserInViewRange(int x, int z)
 	return false;
 }
 
-void CNpc::SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDamage, int nHP, BYTE byFlag, short sAttack_type)
+void CNpc::SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDamage, int nHP, BYTE byFlag, uint8_t byAttackType)
 {
 	int send_index = 0;
 	int sid = -1, tid = -1;
@@ -5978,7 +5977,7 @@ void CNpc::SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDa
 		SetShort(buff, tid, send_index);
 		SetShort(buff, sDamage, send_index);
 		SetDWORD(buff, nHP, send_index);
-		SetByte(buff, sAttack_type, send_index);
+		SetByte(buff, byAttackType, send_index);
 	}
 	else
 	{
@@ -5993,7 +5992,7 @@ void CNpc::SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDa
 		SetShort(buff, tid, send_index);
 		SetShort(buff, sDamage, send_index);
 		SetDWORD(buff, nHP, send_index);
-		SetByte(buff, sAttack_type, send_index);
+		SetByte(buff, byAttackType, send_index);
 	}
 
 	//TRACE(_T("Npc - SendAttackSuccess() : [sid=%d, tid=%d, result=%d], damage=%d, hp = %d\n"), sid, tid, byResult, sDamage, sHP);
@@ -7481,7 +7480,7 @@ void CNpc::NpcHealing(CIOCPort* pIOCP)
 		}
 
 		// 치료 체크여부 
-		iHP = pNpc->m_iMaxHP * 0.9;		// 90퍼센트의 HP
+		iHP = static_cast<int>(pNpc->m_iMaxHP * 0.9);		// 90퍼센트의 HP
 
 		// Heal 완료상태..
 		if (pNpc->m_iHP >= iHP)
@@ -7719,8 +7718,8 @@ bool CNpc::Teleport(CIOCPort* pIOCP)
 	Setfloat(buff, m_fCurY, send_index);
 	SendAll(pIOCP, buff, send_index);   // thread 에서 send
 
-	m_fCurX = nX;
-	m_fCurZ = nZ;
+	m_fCurX = static_cast<float>(nX);
+	m_fCurZ = static_cast<float>(nZ);
 
 	memset(buff, 0, sizeof(buff));
 	send_index = 0;

--- a/Server/AIServer/Npc.h
+++ b/Server/AIServer/Npc.h
@@ -438,7 +438,7 @@ public:
 
 	// Packet Send부분..
 	void SendAll(CIOCPort* pIOCP, const char* pBuf, int nLength);
-	void SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDamage, int nHP = 0, BYTE byFlag = 0, short sAttack_type = 1);
+	void SendAttackSuccess(CIOCPort* pIOCP, BYTE byResult, int tuid, short sDamage, int nHP = 0, BYTE byFlag = 0, uint8_t byAttackType = 1);
 	void SendNpcInfoAll(char* temp_send, int& index, int count);	// game server에 npc정보를 전부 전송...
 
 	// Inline Function

--- a/Server/AIServer/NpcMagicProcess.cpp
+++ b/Server/AIServer/NpcMagicProcess.cpp
@@ -524,9 +524,9 @@ short CNpcMagicProcess::GetMagicDamage(int tid, int total_hit, int attribute, in
 			bSign = false;
 		}
 
-		damage = (short) (total_hit - (0.7f * total_hit * total_r / 200));
+		damage = static_cast<short>(total_hit - (0.7f * total_hit * total_r / 200));
 		random = myrand(0, damage);
-		damage = (short) (0.7f * (total_hit - (0.9f * total_hit * total_r / 200))) + 0.2f * random;
+		damage = static_cast<short>((0.7f * (total_hit - (0.9f * total_hit * total_r / 200))) + 0.2f * random);
 	}
 	else
 	{

--- a/Server/AIServer/NpcThread.cpp
+++ b/Server/AIServer/NpcThread.cpp
@@ -60,7 +60,7 @@ UINT NpcThreadProc(LPVOID pParam /* NPC_THREAD_INFO ptr */)
 				continue;
 
 			fTime3 = fTime2 - pNpc->m_fDelayTime;
-			dwTickTime = fTime3 * 1000;
+			dwTickTime = static_cast<uint32_t>(fTime3 * 1000);
 
 			//if(i==0)
 			//TRACE(_T("thread time = %.2f, %.2f, %.2f, delay=%d, state=%d, nid=%d\n"), pNpc->m_fDelayTime, fTime2, fTime3, dwTickTime, pNpc->m_NpcState, pNpc->m_sNid+NPC_BAND);
@@ -87,7 +87,7 @@ UINT NpcThreadProc(LPVOID pParam /* NPC_THREAD_INFO ptr */)
 			}
 
 			fTime3 = fTime2 - pNpc->m_fHPChangeTime;
-			dwTickTime = fTime3 * 1000;
+			dwTickTime = static_cast<uint32_t>(fTime3 * 1000);
 
 			// 10초마다 HP를 회복 시켜준다
 			if (10000 < dwTickTime)

--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -2117,15 +2117,15 @@ bool CServerDlg::AddObjectEventNpc(_OBJECT_EVENT* pEvent, int zone_number)
 
 	pNpc->m_sCurZone = zone_number;
 
-	pNpc->m_byGateOpen = pEvent->sStatus;
+	pNpc->m_byGateOpen = static_cast<uint8_t>(pEvent->sStatus);
 	pNpc->m_fCurX = pEvent->fPosX;
 	pNpc->m_fCurY = pEvent->fPosY;
 	pNpc->m_fCurZ = pEvent->fPosZ;
 
-	pNpc->m_nInitMinX = pEvent->fPosX - 1;
-	pNpc->m_nInitMinY = pEvent->fPosZ - 1;
-	pNpc->m_nInitMaxX = pEvent->fPosX + 1;
-	pNpc->m_nInitMaxY = pEvent->fPosZ + 1;
+	pNpc->m_nInitMinX = static_cast<int>(pEvent->fPosX - 1);
+	pNpc->m_nInitMinY = static_cast<int>(pEvent->fPosZ - 1);
+	pNpc->m_nInitMaxX = static_cast<int>(pEvent->fPosX + 1);
+	pNpc->m_nInitMaxY = static_cast<int>(pEvent->fPosZ + 1);
 
 	pNpc->m_sRegenTime = 10000 * 1000;	// 초(DB)단위-> 밀리세컨드로
 	//pNpc->m_sRegenTime		= 30 * 1000;	// 초(DB)단위-> 밀리세컨드로

--- a/Server/AIServer/User.cpp
+++ b/Server/AIServer/User.cpp
@@ -79,7 +79,7 @@ void CUser::Initialize()
 	m_curZone = -1;								// 현재 존
 	m_sZoneIndex = -1;
 	m_bNation = 0;								// 소속국가
-	m_sLevel = 0;								// 레벨
+	m_byLevel = 0;								// 레벨
 	m_sHP = 0;									// HP
 	m_sMP = 0;									// MP
 	m_sSP = 0;									// SP
@@ -173,7 +173,7 @@ void CUser::Attack(int sid, int tid)
 	//	m_dwLastAttackTime = GetTickCount();
 }
 
-void CUser::SendAttackSuccess(int tuid, BYTE result, short sDamage, int nHP, short sAttack_type)
+void CUser::SendAttackSuccess(int tuid, BYTE result, short sDamage, int nHP, uint8_t byAttackType)
 {
 	int send_index = 0;
 	int sid = -1, tid = -1;
@@ -193,7 +193,7 @@ void CUser::SendAttackSuccess(int tuid, BYTE result, short sDamage, int nHP, sho
 	SetShort(buff, tid, send_index);
 	SetShort(buff, sDamage, send_index);
 	SetDWORD(buff, nHP, send_index);
-	SetByte(buff, sAttack_type, send_index);
+	SetByte(buff, byAttackType, send_index);
 
 	//TRACE(_T("User - SendAttackSuccess() : [sid=%d, tid=%d, result=%d], damage=%d, hp = %d\n"), sid, tid, bResult, sDamage, sHP);
 
@@ -386,7 +386,7 @@ void CUser::SetExp(int iNpcExp, int iLoyalty, int iLevel)
 	int nLoyalty = 0;
 	int nLevel = 0;
 	double TempValue = 0;
-	nLevel = iLevel - m_sLevel;
+	nLevel = iLevel - m_byLevel;
 
 	if (nLevel <= -14)
 	{
@@ -477,8 +477,8 @@ void CUser::SetPartyExp(int iNpcExp, int iLoyalty, int iPartyLevel, int iMan)
 	int nPercent = 0, nLevelPercent = 0, nExpPercent = 0;
 	double TempValue = 0;
 
-	TempValue = (double) iPartyLevel / 100.0;
-	nExpPercent = iNpcExp * TempValue;
+	TempValue = iPartyLevel / 100.0;
+	nExpPercent = static_cast<int>(iNpcExp * TempValue);
 
 	//TRACE(_T("$$ User - SetPartyExp Level : %hs, exp=%d->%d, loy=%d->%d, mylevel=%d, iPartyLevel=%d $$\n"), m_strUserID, iNpcExp, nExpPercent, iLoyalty, nLoyalty, m_sLevel, iPartyLevel);
 
@@ -577,7 +577,7 @@ short CUser::GetDamage(int tid, int magicid)
 				Hit = HitB * (pType1->DamageMod / 100.0f);
 			}
 */
-			Hit = HitB * (pType1->DamageMod / 100.0f);
+			Hit = static_cast<short>(HitB * (pType1->DamageMod / 100.0f));
 		}
 		// ARROW HIT!
 		else if (pTable->Type1 == 2)
@@ -608,12 +608,12 @@ short CUser::GetDamage(int tid, int magicid)
 			if (pType2->HitType == 1
 				/*|| pType2->HitType == 2*/)
 			{
-				Hit = m_sHitDamage * (pType2->DamageMod / 100.0f);
+				Hit = static_cast<short>(m_sHitDamage * (pType2->DamageMod / 100.0f));
 			}
 			else
 			{
 //				Hit = (m_sHitDamage - pNpc->m_sDefense) * (pType2->DamageMod / 100.0f);
-				Hit = HitB * (pType2->DamageMod / 100.0f);
+				Hit = static_cast<short>(HitB * (pType2->DamageMod / 100.0f));
 			}
 		}
 	}
@@ -978,8 +978,8 @@ bool CUser::IsOpIDCheck(const char* szName)
 
 void CUser::HealMagic()
 {
-	int region_x = m_curx / VIEW_DIST;
-	int region_z = m_curz / VIEW_DIST;
+	int region_x = static_cast<int>(m_curx / VIEW_DIST);
+	int region_z = static_cast<int>(m_curz / VIEW_DIST);
 
 	MAP* pMap = m_pMain->GetMapByIndex(m_sZoneIndex);
 	if (pMap == nullptr)

--- a/Server/AIServer/User.h
+++ b/Server/AIServer/User.h
@@ -46,7 +46,7 @@ public:
 	short			m_sZoneIndex;		// 현재 존의 index 번호..
 
 	BYTE	m_bNation;						// 소속국가
-	short	m_sLevel;						// 레벨
+	uint8_t	m_byLevel;						// 레벨
 
 	short	m_sHP;							// HP
 	short	m_sMP;							// MP
@@ -108,7 +108,7 @@ public:
 	void HealMagic();
 	void HealAreaCheck(int rx, int rz);
 
-	void SendAttackSuccess(int tuid, BYTE result, short sDamage, int nHP = 0, short sAttack_type = 1);  // 공격 성공
+	void SendAttackSuccess(int tuid, BYTE result, short sDamage, int nHP = 0, uint8_t sAttack_type = 1);  // 공격 성공
 	void SendMagicAttackResult(int tuid, BYTE result, short sDamage, short sHP = 0);  // 공격 성공
 	void SendHP();												// user의 HP
 	void SendExp(int iExp, int iLoyalty, int tType = 1);

--- a/Server/Aujard/Aujard.vcxproj
+++ b/Server/Aujard/Aujard.vcxproj
@@ -54,6 +54,7 @@
       <AdditionalIncludeDirectories>$(DependencyDir);.;..;..\..\Server;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <PreprocessorDefinitions>__SAMMA;_3DSERVER;_REPENT;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Server/Ebenezer/Ebenezer.vcxproj
+++ b/Server/Ebenezer/Ebenezer.vcxproj
@@ -57,6 +57,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(DependencyDir);.;..;..\..;..\..\Client;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -378,7 +378,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 						if (pMagic->Type1 == 3)
 						{
 //
-							total_magic_damage += ((pRightHand->Damage * 0.8f) + (pRightHand->Damage * m_pSrcUser->m_pUserData->m_bLevel) / 60);
+							total_magic_damage += static_cast<int>(((pRightHand->Damage * 0.8f) + (pRightHand->Damage * m_pSrcUser->m_pUserData->m_bLevel) / 60));
 //
 
 							model::MagicType3* pType3 = m_pMain->m_MagicType3TableMap.GetData(magicid);     // Get magic skill table type 4.
@@ -388,7 +388,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 							if (m_pSrcUser->m_bMagicTypeRightHand == pType3->Attribute)
 							{
 //								total_magic_damage += pRightHand->Damage;
-								total_magic_damage += ((pRightHand->Damage * 0.8f) + (pRightHand->Damage * m_pSrcUser->m_pUserData->m_bLevel) / 30);
+								total_magic_damage += static_cast<int>(((pRightHand->Damage * 0.8f) + (pRightHand->Damage * m_pSrcUser->m_pUserData->m_bLevel) / 30));
 							}
 //
 							// Remember what Sunglae told ya!
@@ -1137,7 +1137,7 @@ BYTE CMagicProcess::ExecuteType2(int magicid, int sid, int tid, int data1, int d
 	char send_buff[128] = {};	// For the packet. 
 
 	int total_range = 0;	// These variables are used for range verification!
-	int sx, sz, tx, tz;
+	float sx, sz, tx, tz;
 
 	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
@@ -1164,7 +1164,7 @@ BYTE CMagicProcess::ExecuteType2(int magicid, int sid, int tid, int data1, int d
 		goto packet_send;
 	}
 
-	total_range = pow(((pType->RangeMod * pTable->Range) / 100), 2);     // Range verification procedure.
+	total_range = static_cast<int>(pow(((pType->RangeMod * pTable->Range) / 100), 2));     // Range verification procedure.
 //	total_range = pow(((pType->RangeMod / 100) * pTable->Range), 2) ;     // Range verification procedure.
 
 	sx = m_pSrcUser->m_pUserData->m_curx;
@@ -1587,7 +1587,6 @@ void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int d
 //
 		}
 
-	packet_send:
 		if (pMagic->Type2 == 0
 			|| pMagic->Type2 == 3)
 		{
@@ -1787,11 +1786,11 @@ void CMagicProcess::ExecuteType4(int magicid, int sid, int tid, int data1, int d
 				break;
 
 			case 7:
-				pTUser->m_bStrAmount = pType->Strength;
-				pTUser->m_bStaAmount = pType->Stamina;
-				pTUser->m_bDexAmount = pType->Dexterity;
-				pTUser->m_bIntelAmount = pType->Intelligence;
-				pTUser->m_bChaAmount = pType->Charisma;
+				pTUser->m_sStrAmount = pType->Strength;
+				pTUser->m_sStaAmount = pType->Stamina;
+				pTUser->m_sDexAmount = pType->Dexterity;
+				pTUser->m_sIntelAmount = pType->Intelligence;
+				pTUser->m_sChaAmount = pType->Charisma;
 				pTUser->m_sDuration7 = pType->Duration;
 				pTUser->m_fStartTime7 = TimeGet();
 				break;
@@ -2080,11 +2079,11 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 			{
 				pTUser->m_sDuration7 = 0;
 				pTUser->m_fStartTime7 = 0.0f;
-				pTUser->m_bStrAmount = 0;
-				pTUser->m_bStaAmount = 0;
-				pTUser->m_bDexAmount = 0;
-				pTUser->m_bIntelAmount = 0;
-				pTUser->m_bChaAmount = 0;
+				pTUser->m_sStrAmount = 0;
+				pTUser->m_sStaAmount = 0;
+				pTUser->m_sDexAmount = 0;
+				pTUser->m_sIntelAmount = 0;
+				pTUser->m_sChaAmount = 0;
 				pTUser->m_bType4Buff[6] = 0;
 
 				SendType4BuffRemove(tid, 7);
@@ -2261,28 +2260,6 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 			m_pMain->Send_Region(send_buff, send_index, pTUser->m_pUserData->m_bZone, pTUser->m_RegionX, pTUser->m_RegionZ, nullptr, false);
 		}
 	}
-
-	return;
-
-fail_return:
-	if (sid >= 0
-		&& sid < MAX_USER)
-	{
-		memset(send_buff, 0, sizeof(send_buff));
-		send_index = 0;
-		SetByte(send_buff, WIZ_MAGIC_PROCESS, send_index);		// In case of failure!!!
-		SetByte(send_buff, MAGIC_FAIL, send_index);
-		SetDWORD(send_buff, magicid, send_index);
-		SetShort(send_buff, sid, send_index);
-		SetShort(send_buff, tid, send_index);
-		SetShort(send_buff, 0, send_index);
-		SetShort(send_buff, 0, send_index);
-		SetShort(send_buff, 0, send_index);
-		SetShort(send_buff, 0, send_index);
-		SetShort(send_buff, 0, send_index);
-		SetShort(send_buff, 0, send_index);
-		m_pSrcUser->Send(send_buff, send_index);
-	}
 }
 
 void CMagicProcess::ExecuteType6(int magicid)
@@ -2445,8 +2422,8 @@ void CMagicProcess::ExecuteType8(int magicid, int sid, int tid, int data1, int d
 //						m_pUserData->m_curx = m_fWill_x = (float)852.0 + x;
 //						m_pUserData->m_curz = m_fWill_z = (float)164.0 + z;
 
-						SetShort(send_buff, 852 + x, send_index);
-						SetShort(send_buff, 164 + z, send_index);
+						SetShort(send_buff, static_cast<short>(852 + x), send_index);
+						SetShort(send_buff, static_cast<short>(164 + z), send_index);
 						pTUser->Warp(send_buff);
 					}
 					// Land of Elmorad
@@ -2456,8 +2433,8 @@ void CMagicProcess::ExecuteType8(int magicid, int sid, int tid, int data1, int d
 //						m_pUserData->m_curx = m_fWill_x = (float)177.0 + x;
 //						m_pUserData->m_curz = m_fWill_z = (float)923.0 + z;
 
-						SetShort(send_buff, 177 + x, send_index);
-						SetShort(send_buff, 923 + z, send_index);
+						SetShort(send_buff, static_cast<short>(177 + x), send_index);
+						SetShort(send_buff, static_cast<short>(923 + z), send_index);
 						pTUser->Warp(send_buff);
 					}
 				}
@@ -2606,18 +2583,22 @@ void CMagicProcess::ExecuteType8(int magicid, int sid, int tid, int data1, int d
 				float warp_x, warp_z;		// Variable Initialization.
 				float temp_warp_x, temp_warp_z;
 
-				warp_x = pTUser->m_pUserData->m_curx;	// Get current locations.
+				// Get current locations.
+				warp_x = pTUser->m_pUserData->m_curx;
 				warp_z = pTUser->m_pUserData->m_curz;
 
-				temp_warp_x = myrand(0, 20);	// Get random positions (within 20 meters)
-				temp_warp_z = myrand(0, 20);
+				// Get random positions (within 20 meters)
+				temp_warp_x = static_cast<float>(myrand(0, 20));
+				temp_warp_z = static_cast<float>(myrand(0, 20));
 
-				if (temp_warp_x > 10)	// Get new x-position.
+				// Get new x-position.
+				if (temp_warp_x > 10)
 					warp_x = warp_x + (temp_warp_x - 10);
 				else
 					warp_x = warp_x - temp_warp_x;
 
-				if (temp_warp_z > 10)	// Get new z-position.
+				// Get new z-position.
+				if (temp_warp_z > 10)
 					warp_z = warp_z + (temp_warp_z - 10);
 				else
 					warp_z = warp_z - temp_warp_z;
@@ -2706,7 +2687,7 @@ short CMagicProcess::GetMagicDamage(int sid, int tid, int total_hit, int attribu
 			|| pMon->m_NpcState == NPC_DEAD)
 			return 0;
 
-		result = m_pSrcUser->GetHitRate(pMon->m_sHitRate / pTUser->m_sTotalEvasionrate);
+		result = m_pSrcUser->GetHitRate(pMon->m_sHitRate / pTUser->m_fTotalEvasionRate);
 	}
 	// If the source is another player.
 	else
@@ -2782,9 +2763,9 @@ short CMagicProcess::GetMagicDamage(int sid, int tid, int total_hit, int attribu
 			}
 		}
 
-		damage = (short) (total_hit - ((0.7 * total_hit * total_r) / 200));
+		damage = static_cast<short>(total_hit - ((0.7 * total_hit * total_r) / 200));
 		random = myrand(0, damage);
-		damage = (short) (0.7 * (total_hit - ((0.9 * total_hit * total_r) / 200))) + 0.2 * random;
+		damage = static_cast<short>((0.7 * (total_hit - ((0.9 * total_hit * total_r) / 200))) + 0.2 * random);
 //	
 		if (sid >= NPC_BAND)
 		{
@@ -2795,7 +2776,7 @@ short CMagicProcess::GetMagicDamage(int sid, int tid, int total_hit, int attribu
 			// Only if the staff has an attribute.
 			if (attribute != 4)
 			{
-				damage = damage - ((righthand_damage * 0.8f) + (righthand_damage * m_pSrcUser->m_pUserData->m_bLevel) / 60) - ((attribute_damage * 0.8f) + (attribute_damage * m_pSrcUser->m_pUserData->m_bLevel) / 30);
+				damage = static_cast<short>(damage - ((righthand_damage * 0.8f) + (righthand_damage * m_pSrcUser->m_pUserData->m_bLevel) / 60) - ((attribute_damage * 0.8f) + (attribute_damage * m_pSrcUser->m_pUserData->m_bLevel) / 30));
 			}
 		}
 //
@@ -2917,10 +2898,10 @@ final_test:
 				if (radius != 0)
 				{
 					// Y-AXIS DISABLED TEMPORARILY!!!
-					int temp_x = pTUser->m_pUserData->m_curx - mousex;
-					int temp_z = pTUser->m_pUserData->m_curz - mousez;
-					int distance = pow(temp_x, 2) + pow(temp_z, 2);
-					if (distance > pow(radius, 2))
+					float temp_x = pTUser->m_pUserData->m_curx - mousex;
+					float temp_z = pTUser->m_pUserData->m_curz - mousez;
+					float distance = pow(temp_x, 2.0f) + pow(temp_z, 2.0f);
+					if (distance > pow(radius, 2.0f))
 						return false;
 				}
 
@@ -2942,10 +2923,10 @@ final_test:
 				// Radius check! ( ...in case there is one :(  )
 				if (radius != 0)
 				{
-					int temp_x = pTUser->m_pUserData->m_curx - pMon->m_fCurX;
-					int temp_z = pTUser->m_pUserData->m_curz - pMon->m_fCurZ;
-					int distance = pow(temp_x, 2) + pow(temp_z, 2);
-					if (distance > pow(radius, 2))
+					float temp_x = pTUser->m_pUserData->m_curx - pMon->m_fCurX;
+					float temp_z = pTUser->m_pUserData->m_curz - pMon->m_fCurZ;
+					float distance = pow(temp_x, 2.0f) + pow(temp_z, 2.0f);
+					if (distance > pow(radius, 2.0f))
 						return false;
 				}
 
@@ -3044,19 +3025,19 @@ void CMagicProcess::Type4Cancel(int magicid, short tid)
 			break;
 
 		case 7:
-			if ((pTUser->m_bStrAmount
-				+ pTUser->m_bStaAmount
-				+ pTUser->m_bDexAmount
-				+ pTUser->m_bIntelAmount
-				+ pTUser->m_bChaAmount) > 0)
+			if ((pTUser->m_sStrAmount
+				+ pTUser->m_sStaAmount
+				+ pTUser->m_sDexAmount
+				+ pTUser->m_sIntelAmount
+				+ pTUser->m_sChaAmount) > 0)
 			{
 				pTUser->m_sDuration7 = 0;
 				pTUser->m_fStartTime7 = 0.0f;
-				pTUser->m_bStrAmount = 0;
-				pTUser->m_bStaAmount = 0;
-				pTUser->m_bDexAmount = 0;
-				pTUser->m_bIntelAmount = 0;
-				pTUser->m_bChaAmount = 0;
+				pTUser->m_sStrAmount = 0;
+				pTUser->m_sStaAmount = 0;
+				pTUser->m_sDexAmount = 0;
+				pTUser->m_sIntelAmount = 0;
+				pTUser->m_sChaAmount = 0;
 				buff = true;
 			}
 			break;

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -53,8 +53,8 @@ void CUser::Initialize()
 	m_sBodyAc = 0;
 	m_sTotalHit = 0;
 	m_sTotalAc = 0;
-	m_sTotalHitrate = 0;
-	m_sTotalEvasionrate = 0;
+	m_fTotalHitRate = 0;
+	m_fTotalEvasionRate = 0;
 
 	m_sItemMaxHp = 0;
 	m_sItemMaxMp = 0;
@@ -1448,8 +1448,8 @@ void CUser::Attack(char* pBuf)
 //	sid = GetShort(pBuf, index);
 	tid = GetShort(pBuf, index);
 // 비러머글 해킹툴 유저 --;
-	delaytime = GetShort(pBuf, index);
-	distance = GetShort(pBuf, index);
+	delaytime = static_cast<float>(GetShort(pBuf, index));
+	distance = static_cast<float>(GetShort(pBuf, index));
 //
 
 //	delaytime = delaytime / 100.0f;
@@ -1642,8 +1642,8 @@ void CUser::Attack(char* pBuf)
 			SetShort(send_buff, tid, send_index);
 			SetShort(send_buff, m_sTotalHit * m_bAttackAmount / 100, send_index);   // 표시
 			SetShort(send_buff, m_sTotalAc + m_sACAmount, send_index);   // 표시
-			Setfloat(send_buff, m_sTotalHitrate, send_index);
-			Setfloat(send_buff, m_sTotalEvasionrate, send_index);
+			Setfloat(send_buff, m_fTotalHitRate, send_index);
+			Setfloat(send_buff, m_fTotalEvasionRate, send_index);
 			SetShort(send_buff, m_sItemAc, send_index);
 			SetByte(send_buff, m_bMagicTypeLeftHand, send_index);
 			SetByte(send_buff, m_bMagicTypeRightHand, send_index);
@@ -1749,8 +1749,8 @@ void CUser::SendMyInfo(int type)
 			}
 		}
 
-		m_pUserData->m_curx = x;
-		m_pUserData->m_curz = z;
+		m_pUserData->m_curx = static_cast<float>(x);
+		m_pUserData->m_curz = static_cast<float>(z);
 	}
 
 	SetByte(send_buff, WIZ_MYINFO, send_index);
@@ -1882,8 +1882,8 @@ void CUser::SendMyInfo(int type)
 	SetShort(ai_send_buff, m_pUserData->m_sMp, ai_send_index);
 	SetShort(ai_send_buff, m_sTotalHit * m_bAttackAmount / 100, ai_send_index);  // 표시
 	SetShort(ai_send_buff, m_sTotalAc + m_sACAmount, ai_send_index);  // 표시
-	Setfloat(ai_send_buff, m_sTotalHitrate, ai_send_index);
-	Setfloat(ai_send_buff, m_sTotalEvasionrate, ai_send_index);
+	Setfloat(ai_send_buff, m_fTotalHitRate, ai_send_index);
+	Setfloat(ai_send_buff, m_fTotalEvasionRate, ai_send_index);
 
 // Yookozuna
 	SetShort(ai_send_buff, m_sItemAc, ai_send_index);
@@ -2015,7 +2015,7 @@ void CUser::SetMaxHp(int iFlag)
 		return;
 
 	int temp_sta = 0;
-	temp_sta = m_pUserData->m_bSta + m_sItemSta + m_bStaAmount;
+	temp_sta = m_pUserData->m_bSta + m_sItemSta + m_sStaAmount;
 //	if (temp_sta > 255)
 //		temp_sta = 255;
 
@@ -2056,11 +2056,11 @@ void CUser::SetMaxMp()
 		return;
 
 	int temp_intel = 0, temp_sta = 0;
-	temp_intel = m_pUserData->m_bIntel + m_sItemIntel + m_bIntelAmount + 30;
+	temp_intel = m_pUserData->m_bIntel + m_sItemIntel + m_sIntelAmount + 30;
 //	if (temp_intel > 255)
 //		temp_intel = 255;
 
-	temp_sta = m_pUserData->m_bSta + m_sItemSta + m_bStaAmount;
+	temp_sta = m_pUserData->m_bSta + m_sItemSta + m_sStaAmount;
 //	if (temp_sta > 255)
 //		temp_sta = 255;
 
@@ -2161,8 +2161,8 @@ void CUser::Regene(char* pBuf, int magicid)
 			// Frontier Zone...
 			if (m_pUserData->m_bZone > 200)
 			{
-				x = pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX);
-				z = pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ);
+				x = static_cast<float>(pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX));
+				z = static_cast<float>(pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ));
 			}
 //
 			// Battle Zone...
@@ -2175,21 +2175,21 @@ void CUser::Regene(char* pBuf, int magicid)
 				KickOutZoneUser();	// Go back to your own zone!
 				return;
 */
-				x = pHomeInfo->BattleZoneX + myrand(0, pHomeInfo->BattleZoneLX);
-				z = pHomeInfo->BattleZoneZ + myrand(0, pHomeInfo->BattleZoneLZ);
+				x = static_cast<float>(pHomeInfo->BattleZoneX + myrand(0, pHomeInfo->BattleZoneLX));
+				z = static_cast<float>(pHomeInfo->BattleZoneZ + myrand(0, pHomeInfo->BattleZoneLZ));
 // 비러머글 개척존 바꾸어치기 >.<
 				if (m_pUserData->m_bZone == ZONE_SNOW_BATTLE)
 				{
-					x = pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX);
-					z = pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ);
+					x = static_cast<float>(pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX));
+					z = static_cast<float>(pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ));
 				}
 //
 			}
 // 비러머글 뉴존 >.<
 			else if (m_pUserData->m_bZone > 10 && m_pUserData->m_bZone < 20)
 			{
-				x = 527 + myrand(0, 10);
-				z = 543 + myrand(0, 10);
+				x = static_cast<float>(527 + myrand(0, 10));
+				z = static_cast<float>(543 + myrand(0, 10));
 			}
 //
 			// Specific Lands...
@@ -2197,13 +2197,13 @@ void CUser::Regene(char* pBuf, int magicid)
 			{
 				if (m_pUserData->m_bNation == KARUS)
 				{
-					x = pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX);
-					z = pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ);
+					x = static_cast<float>(pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX));
+					z = static_cast<float>(pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ));
 				}
 				else if (m_pUserData->m_bNation == ELMORAD)
 				{
-					x = pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX);
-					z = pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ);
+					x = static_cast<float>(pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX));
+					z = static_cast<float>(pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ));
 				}
 				else return;
 			}
@@ -2216,13 +2216,13 @@ void CUser::Regene(char* pBuf, int magicid)
 		{
 			if (m_pUserData->m_bNation == KARUS)
 			{
-				x = pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX);
-				z = pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ);
+				x = static_cast<float>(pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX));
+				z = static_cast<float>(pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ));
 			}
 			else if (m_pUserData->m_bNation == ELMORAD)
 			{
-				x = pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX);
-				z = pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ);
+				x = static_cast<float>(pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX));
+				z = static_cast<float>(pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ));
 			}
 			else
 			{
@@ -3030,7 +3030,7 @@ void CUser::SetSlotItemValue()
 			if ((m_pUserData->m_sClass == BERSERKER
 				|| m_pUserData->m_sClass == BLADE))
 	//			m_sItemHit += item_hit * (double) (m_pUserData->m_bstrSkill[PRO_SKILL1] / 60.0);    // 성래씨 요청 ^^;
-				m_sItemHit += item_hit * 0.5f;
+				m_sItemHit += static_cast<short>(item_hit * 0.5f);
 		}
 
 		m_sItemMaxHp += pTable->MaxHpBonus;
@@ -3242,10 +3242,10 @@ short CUser::GetDamage(short tid, int magicid)
 			// Relative hit.
 			else
 			{
-				result = GetHitRate((m_sTotalHitrate / pTUser->m_sTotalEvasionrate) * (pType1->HitRateMod / 100.0f));
+				result = GetHitRate((m_fTotalHitRate / pTUser->m_fTotalEvasionRate) * (pType1->HitRateMod / 100.0f));
 			}
 
-			temp_hit = temp_hit_B * (pType1->DamageMod / 100.0f);
+			temp_hit = static_cast<short>(temp_hit_B * (pType1->DamageMod / 100.0f));
 		}
 		// ARROW HIT!
 		else if (pTable->Type1 == 2)
@@ -3268,21 +3268,21 @@ short CUser::GetDamage(short tid, int magicid)
 			// Relative hit/Arc hit.
 			else
 			{
-				result = GetHitRate((m_sTotalHitrate / pTUser->m_sTotalEvasionrate) * (pType2->HitRateMod / 100.0f));
+				result = GetHitRate((m_fTotalHitRate / pTUser->m_fTotalEvasionRate) * (pType2->HitRateMod / 100.0f));
 			}
 
 			if (pType2->HitType == 1
 				/*|| pType2->HitType == 2*/)
-				temp_hit = m_sTotalHit * m_bAttackAmount * (pType2->DamageMod / 100.0f) / 100;   // 표시
+				temp_hit = static_cast<short>(m_sTotalHit * m_bAttackAmount * (pType2->DamageMod / 100.0f) / 100);   // 표시
 			else
-				temp_hit = temp_hit_B * (pType2->DamageMod / 100.0f);
+				temp_hit = static_cast<short>(temp_hit_B * (pType2->DamageMod / 100.0f));
 		}
 	}
 	// Normal Hit.
 	else
 	{
 		temp_hit = m_sTotalHit * m_bAttackAmount / 100;	// 표시
-		result = GetHitRate(m_sTotalHitrate / pTUser->m_sTotalEvasionrate);
+		result = GetHitRate(m_fTotalHitRate / pTUser->m_fTotalEvasionRate);
 	}
 
 	// 1. Magical item damage....
@@ -3837,8 +3837,8 @@ void CUser::Send2AI_UserUpdateInfo()
 	SetShort(send_buff, m_pUserData->m_sMp, send_index);
 	SetShort(send_buff, m_sTotalHit * m_bAttackAmount / 100, send_index); // 표시
 	SetShort(send_buff, m_sTotalAc + m_sACAmount, send_index);  // 표시
-	Setfloat(send_buff, m_sTotalHitrate, send_index);
-	Setfloat(send_buff, m_sTotalEvasionrate, send_index);
+	Setfloat(send_buff, m_fTotalHitRate, send_index);
+	Setfloat(send_buff, m_fTotalEvasionRate, send_index);
 
 //
 	SetShort(send_buff, m_sItemAc, send_index);
@@ -3861,7 +3861,7 @@ void CUser::SetUserAbility()
 	if (p_TableCoefficient == nullptr)
 		return;
 
-	float hitcoefficient = 0.0f;
+	double hitcoefficient = 0.0;
 	if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 	{
 		pItem = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
@@ -3905,7 +3905,7 @@ void CUser::SetUserAbility()
 	}
 
 	if (m_pUserData->m_sItemArray[LEFTHAND].nNum != 0
-		&& hitcoefficient == 0.0f)
+		&& hitcoefficient == 0.0)
 	{
 		// 왼손 무기 : 활 적용을 위해
 		pItem = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
@@ -3926,11 +3926,11 @@ void CUser::SetUserAbility()
 
 	int temp_str = 0, temp_dex = 0;
 
-	temp_str = m_pUserData->m_bStr + m_bStrAmount + m_sItemStr;
+	temp_str = m_pUserData->m_bStr + m_sStrAmount + m_sItemStr;
 //	if (temp_str > 255)
 //		temp_str = 255;
 
-	temp_dex = m_pUserData->m_bDex + m_bDexAmount + m_sItemDex;
+	temp_dex = m_pUserData->m_bDex + m_sDexAmount + m_sItemDex;
 //	if (temp_dex > 255)
 //		temp_dex = 255;
 
@@ -3942,18 +3942,18 @@ void CUser::SetUserAbility()
 */
 	if (bHaveBow)
 	{
-		m_sTotalHit = (short) ((((0.005 * pItem->Damage * (temp_dex + 40)) + (hitcoefficient * pItem->Damage * m_pUserData->m_bLevel * temp_dex)) + 3));
+		m_sTotalHit = static_cast<short>(((0.005 * pItem->Damage * (temp_dex + 40)) + (hitcoefficient * pItem->Damage * m_pUserData->m_bLevel * temp_dex)) + 3);
 	}
 	else
 	{
-		m_sTotalHit = (short) ((((0.005f * m_sItemHit * (temp_str + 40)) + (hitcoefficient * m_sItemHit * m_pUserData->m_bLevel * temp_str)) + 3));
+		m_sTotalHit = static_cast<short>(((0.005f * m_sItemHit * (temp_str + 40)) + (hitcoefficient * m_sItemHit * m_pUserData->m_bLevel * temp_str)) + 3);
 	}
 
 	// 토탈 AC = 테이블 코에피션트 * (레벨 + 아이템 AC + 테이블 4의 AC)
-	m_sTotalAc = (short) (p_TableCoefficient->Armor * (m_sBodyAc + m_sItemAc));
-	m_sTotalHitrate = ((1 + p_TableCoefficient->HitRate * m_pUserData->m_bLevel * temp_dex) * m_sItemHitrate / 100) * (m_bHitRateAmount / 100);
+	m_sTotalAc = static_cast<short>(p_TableCoefficient->Armor * (m_sBodyAc + m_sItemAc));
+	m_fTotalHitRate = static_cast<float>(((1 + p_TableCoefficient->HitRate * m_pUserData->m_bLevel * temp_dex) * m_sItemHitrate / 100) * (m_bHitRateAmount / 100));
 
-	m_sTotalEvasionrate = ((1 + p_TableCoefficient->Evasionrate * m_pUserData->m_bLevel * temp_dex) * m_sItemEvasionrate / 100) * (m_sAvoidRateAmount / 100);
+	m_fTotalEvasionRate = static_cast<float>((1 + p_TableCoefficient->Evasionrate * m_pUserData->m_bLevel * temp_dex) * m_sItemEvasionrate / 100) * (m_sAvoidRateAmount / 100);
 
 	SetMaxHp();
 	SetMaxMp();
@@ -4460,11 +4460,11 @@ void CUser::ItemMove(char* pBuf)
 	SetShort(send_buff, GetMaxWeightForClient(), send_index);
 	SetShort(send_buff, m_iMaxHp, send_index);
 	SetShort(send_buff, m_iMaxMp, send_index);
-	SetShort(send_buff, m_sItemStr + m_bStrAmount, send_index);
-	SetShort(send_buff, m_sItemSta + m_bStaAmount, send_index);
-	SetShort(send_buff, m_sItemDex + m_bDexAmount, send_index);
-	SetShort(send_buff, m_sItemIntel + m_bIntelAmount, send_index);
-	SetShort(send_buff, m_sItemCham + m_bChaAmount, send_index);
+	SetShort(send_buff, m_sItemStr + m_sStrAmount, send_index);
+	SetShort(send_buff, m_sItemSta + m_sStaAmount, send_index);
+	SetShort(send_buff, m_sItemDex + m_sDexAmount, send_index);
+	SetShort(send_buff, m_sItemIntel + m_sIntelAmount, send_index);
+	SetShort(send_buff, m_sItemCham + m_sChaAmount, send_index);
 	SetShort(send_buff, m_bFireR, send_index);
 	SetShort(send_buff, m_bColdR, send_index);
 	SetShort(send_buff, m_bLightningR, send_index);
@@ -5330,7 +5330,7 @@ void CUser::ItemGet(char* pBuf)
 						if (pUser == nullptr)
 							continue;
 
-						money = count * (float) (pUser->m_pUserData->m_bLevel / (float) levelsum);
+						money = static_cast<int>(count * (float) (pUser->m_pUserData->m_bLevel / (float) levelsum));
 						pUser->m_pUserData->m_iGold += money;
 
 						send_index = 0;
@@ -6598,7 +6598,8 @@ bool CUser::ExecuteExchange()
 	model::Item* pTable = nullptr;
 	CUser* pUser = nullptr;
 	DWORD money = 0;
-	short weight = 0, i = 0;
+	short weight = 0;
+	uint8_t i = 0;
 
 	if (m_sExchangeUser < 0
 		|| m_sExchangeUser >= MAX_USER)
@@ -6842,7 +6843,7 @@ void CUser::ClassChange(char* pBuf)
 	{
 		sub_type = GetByte(pBuf, index);
 
-		money = pow((m_pUserData->m_bLevel * 2), 3.4);
+		money = static_cast<int>(pow((m_pUserData->m_bLevel * 2), 3.4));
 		money = (money / 100) * 100;
 
 		if (m_pUserData->m_bLevel < 30)
@@ -7070,8 +7071,8 @@ void CUser::SendUserInfo(char* temp_send, int& index)
 	SetShort(temp_send, m_pUserData->m_sMp, index);
 	SetShort(temp_send, m_sTotalHit * m_bAttackAmount / 100, index);    // 표시
 	SetShort(temp_send, m_sTotalAc + m_sACAmount, index);	// 표시
-	Setfloat(temp_send, m_sTotalHitrate, index);
-	Setfloat(temp_send, m_sTotalEvasionrate, index);
+	Setfloat(temp_send, m_fTotalHitRate, index);
+	Setfloat(temp_send, m_fTotalEvasionRate, index);
 	SetShort(temp_send, m_sPartyIndex, index);
 	SetByte(temp_send, m_pUserData->m_bAuthority, index);
 }
@@ -7337,7 +7338,7 @@ void CUser::Dead()
 void CUser::ItemWoreOut(int type, int damage)
 {
 	model::Item* pTable = nullptr;
-	int worerate = sqrt(damage / 10.0);
+	int worerate = static_cast<int>(sqrt(damage / 10.0));
 	if (worerate == 0)
 		return;
 
@@ -7488,11 +7489,11 @@ void CUser::ItemDurationChange(int slot, int maxvalue, int curvalue, int amount)
 		SetShort(send_buff, GetCurrentWeightForClient(), send_index);
 		SetShort(send_buff, m_iMaxHp, send_index);
 		SetShort(send_buff, m_iMaxMp, send_index);
-		SetShort(send_buff, m_sItemStr + m_bStrAmount, send_index);
-		SetShort(send_buff, m_sItemSta + m_bStaAmount, send_index);
-		SetShort(send_buff, m_sItemDex + m_bDexAmount, send_index);
-		SetShort(send_buff, m_sItemIntel + m_bIntelAmount, send_index);
-		SetShort(send_buff, m_sItemCham + m_bChaAmount, send_index);
+		SetShort(send_buff, m_sItemStr + m_sStrAmount, send_index);
+		SetShort(send_buff, m_sItemSta + m_sStaAmount, send_index);
+		SetShort(send_buff, m_sItemDex + m_sDexAmount, send_index);
+		SetShort(send_buff, m_sItemIntel + m_sIntelAmount, send_index);
+		SetShort(send_buff, m_sItemCham + m_sChaAmount, send_index);
 		SetShort(send_buff, m_bFireR, send_index);
 		SetShort(send_buff, m_bColdR, send_index);
 		SetShort(send_buff, m_bLightningR, send_index);
@@ -7503,8 +7504,8 @@ void CUser::ItemDurationChange(int slot, int maxvalue, int curvalue, int amount)
 		return;
 	}
 
-	curpercent = (curvalue / (double) maxvalue) * 100;
-	beforepercent = ((curvalue + amount) / (double) maxvalue) * 100;
+	curpercent = static_cast<int>((curvalue / (double) maxvalue) * 100);
+	beforepercent = static_cast<int>(((curvalue + amount) / (double) maxvalue) * 100);
 
 	curbasis = curpercent / 5;
 	beforebasis = beforepercent / 5;
@@ -7786,7 +7787,7 @@ void CUser::ItemRepair(char* pBuf)
 	else if (pos == 2)
 		quantity = pTable->Durability - m_pUserData->m_sItemArray[SLOT_MAX + slot].sDuration;
 
-	money = (int) (((pTable->BuyPrice - 10) / 10000.0f) + pow(pTable->BuyPrice, 0.75)) * quantity / (double) durability;
+	money = static_cast<int>((((pTable->BuyPrice - 10) / 10000.0f) + pow(pTable->BuyPrice, 0.75)) * quantity / (double) durability);
 	if (money > m_pUserData->m_iGold)
 		goto fail_return;
 
@@ -7901,11 +7902,11 @@ void CUser::Type4Duration(float currenttime)
 		{
 			m_sDuration7 = 0;
 			m_fStartTime7 = 0.0f;
-			m_bStrAmount = 0;
-			m_bStaAmount = 0;
-			m_bDexAmount = 0;
-			m_bIntelAmount = 0;
-			m_bChaAmount = 0;
+			m_sStrAmount = 0;
+			m_sStaAmount = 0;
+			m_sDexAmount = 0;
+			m_sIntelAmount = 0;
+			m_sChaAmount = 0;
 			buff_type = 7;
 		}
 	}
@@ -8027,23 +8028,23 @@ BYTE CUser::ItemCountChange(int itemid, int type, int amount)
 		if (m_pUserData->m_sItemArray[i].nNum != itemid)
 			continue;
 
-		if (pTable->RequiredDexterity > (m_pUserData->m_bDex + m_sItemDex + m_bDexAmount)
+		if (pTable->RequiredDexterity > (m_pUserData->m_bDex + m_sItemDex + m_sDexAmount)
 			&& pTable->RequiredDexterity != 0)
 			return result;
 
-		if (pTable->RequiredStrength > (m_pUserData->m_bStr + m_sItemStr + m_bStrAmount)
+		if (pTable->RequiredStrength > (m_pUserData->m_bStr + m_sItemStr + m_sStrAmount)
 			&& pTable->RequiredStrength != 0)
 			return result;
 
-		if (pTable->RequiredStamina > (m_pUserData->m_bSta + m_sItemSta + m_bStaAmount)
+		if (pTable->RequiredStamina > (m_pUserData->m_bSta + m_sItemSta + m_sStaAmount)
 			&& pTable->RequiredStamina != 0)
 			return result;
 
-		if (pTable->RequiredIntelligence > (m_pUserData->m_bIntel + m_sItemIntel + m_bIntelAmount)
+		if (pTable->RequiredIntelligence > (m_pUserData->m_bIntel + m_sItemIntel + m_sIntelAmount)
 			&& pTable->RequiredIntelligence != 0)
 			return result;
 
-		if (pTable->RequiredCharisma > (m_pUserData->m_bCha + m_sItemCham + m_bChaAmount)
+		if (pTable->RequiredCharisma > (m_pUserData->m_bCha + m_sItemCham + m_sChaAmount)
 			&& pTable->RequiredCharisma != 0)
 			return result;
 
@@ -8647,11 +8648,11 @@ void CUser::InitType4()
 	m_sMaxHPAmount = 0;
 	m_bHitRateAmount = 100;
 	m_sAvoidRateAmount = 100;
-	m_bStrAmount = 0;
-	m_bStaAmount = 0;
-	m_bDexAmount = 0;
-	m_bIntelAmount = 0;
-	m_bChaAmount = 0;
+	m_sStrAmount = 0;
+	m_sStaAmount = 0;
+	m_sDexAmount = 0;
+	m_sIntelAmount = 0;
+	m_sChaAmount = 0;
 	m_bFireRAmount = 0;
 	m_bColdRAmount = 0;
 	m_bLightningRAmount = 0;
@@ -8965,7 +8966,7 @@ void CUser::AllSkillPointChange()
 	BYTE type = 0;    // 0:돈이 부족, 1:성공, 2:초기화할 스킬이 없을때..
 	char send_buff[128] = {};
 
-	temp_value = pow((m_pUserData->m_bLevel * 2), 3.4);
+	temp_value = static_cast<int>(pow((m_pUserData->m_bLevel * 2), 3.4));
 	temp_value = (temp_value / 100) * 100;
 
 	if (m_pUserData->m_bLevel < 30)	
@@ -9052,7 +9053,7 @@ void CUser::AllPointChange()
 	if (m_pUserData->m_bLevel > 80)
 		goto fail_return;
 
-	temp_money = pow((m_pUserData->m_bLevel * 2), 3.4);
+	temp_money = static_cast<int>(pow((m_pUserData->m_bLevel * 2), 3.4));
 	temp_money = (temp_money / 100) * 100;
 	if (m_pUserData->m_bLevel < 30)
 		temp_money = static_cast<int>(temp_money * 0.4);
@@ -9339,7 +9340,7 @@ void CUser::GoldChange(short tid, int gold)
 					if (pUser == nullptr)
 						continue;
 
-					money = count * (float) (pUser->m_pUserData->m_bLevel / (float) levelsum);
+					money = static_cast<int>(count * (float) (pUser->m_pUserData->m_bLevel / (float) levelsum));
 					pUser->m_pUserData->m_iGold += money;
 
 					// Now the party members...
@@ -12334,11 +12335,11 @@ void CUser::KickOutZoneUser(bool home)
 
 		//TRACE(_T("KickOutZoneUser - user=%hs, regene_event=%d\n"), m_pUserData->m_id, regene_event);
 
-		int delta_x = myrand(0, pRegene->fRegeneAreaX);
-		int delta_z = myrand(0, pRegene->fRegeneAreaZ);
+		int delta_x = myrand(0, static_cast<int>(pRegene->fRegeneAreaX));
+		int delta_z = myrand(0, static_cast<int>(pRegene->fRegeneAreaZ));
 
-		int x = pRegene->fRegenePosX + delta_x;
-		int y = pRegene->fRegenePosZ + delta_z;
+		float x = pRegene->fRegenePosX + delta_x;
+		float y = pRegene->fRegenePosZ + delta_z;
 
 		ZoneChange(pMap->m_nZoneNumber, x, y);
 	}
@@ -12385,13 +12386,13 @@ void CUser::NativeZoneReturn()
 
 	if (m_pUserData->m_bNation == KARUS)
 	{
-		m_pUserData->m_curx = pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX);
-		m_pUserData->m_curz = pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ);
+		m_pUserData->m_curx = static_cast<float>(pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX));
+		m_pUserData->m_curz = static_cast<float>(pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ));
 	}
 	else
 	{
-		m_pUserData->m_curx = pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX);
-		m_pUserData->m_curz = pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ);
+		m_pUserData->m_curx = static_cast<float>(pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX));
+		m_pUserData->m_curz = static_cast<float>(pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ));
 	}
 }
 

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -44,8 +44,8 @@ public:
 
 	short	m_sTotalHit;					// 총 타격공격력	
 	short	m_sTotalAc;						// 총 방어력
-	float	m_sTotalHitrate;				// 총 공격성공 민첩성
-	float	m_sTotalEvasionrate;			// 총 방어 민첩성
+	float	m_fTotalHitRate;				// 총 공격성공 민첩성
+	float	m_fTotalEvasionRate;			// 총 방어 민첩성
 
 	short   m_sItemMaxHp;                   // 아이템 총 최대 HP Bonus
 	short   m_sItemMaxMp;                   // 아이템 총 최대 MP Bonus
@@ -127,11 +127,11 @@ public:
 	short	m_sMaxHPAmount;
 	BYTE	m_bHitRateAmount;
 	short	m_sAvoidRateAmount;
-	BYTE	m_bStrAmount;
-	BYTE	m_bStaAmount;
-	BYTE	m_bDexAmount;
-	BYTE	m_bIntelAmount;
-	BYTE	m_bChaAmount;
+	short	m_sStrAmount;
+	short	m_sStaAmount;
+	short	m_sDexAmount;
+	short	m_sIntelAmount;
+	short	m_sChaAmount;
 	BYTE	m_bFireRAmount;
 	BYTE	m_bColdRAmount;
 	BYTE	m_bLightningRAmount;

--- a/Server/ItemManager/ItemManager.vcxproj
+++ b/Server/ItemManager/ItemManager.vcxproj
@@ -55,6 +55,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>.\;..\;..\..\Server\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Server/VersionManager/VersionManager.vcxproj
+++ b/Server/VersionManager/VersionManager.vcxproj
@@ -57,6 +57,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(DependencyDir);.;..;..\..\Server;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Server/shared/DebugUtils.h
+++ b/Server/shared/DebugUtils.h
@@ -18,6 +18,6 @@ void FormattedDebugString(const char* fmt, ...);
 #	endif
 
 #else
-#	define ASSERT 
-#	define TRACE 
+#	define ASSERT(...)
+#	define TRACE(...)
 #endif

--- a/Server/shared/shared.vcxproj
+++ b/Server/shared/shared.vcxproj
@@ -72,6 +72,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;VC_EXTRALEAN;WIN32;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <PreBuildEvent>
       <Command>

--- a/deps/ZipArchive/ZipArchive.cpp
+++ b/deps/ZipArchive/ZipArchive.cpp
@@ -914,7 +914,7 @@ DWORD CZipArchive::RemovePackedFile(DWORD uStartOffset, DWORD uEndOffset)
 {
 	uStartOffset += m_centralDir.m_uBytesBeforeZip;
 	uEndOffset += m_centralDir.m_uBytesBeforeZip;
-	DWORD BytesToCopy = m_storage.m_pFile->GetLength() - uEndOffset;
+	DWORD BytesToCopy = static_cast<DWORD>(m_storage.m_pFile->GetLength()) - uEndOffset;
 	DWORD uTotalToWrite = BytesToCopy;
 	
 	char* buf = (char*)m_info.m_pBuffer;
@@ -1052,7 +1052,7 @@ bool CZipArchive::AddNewFile(LPCTSTR lpszFilePath,
 		if (!bRet)
 			return false;
 		
-		DWORD iRead, iFileLength = pCallback ? f.GetLength() : 0, iSoFar = 0;
+		DWORD iRead, iFileLength = pCallback ? static_cast<DWORD>(f.GetLength()) : 0, iSoFar = 0;
 		CZipAutoBuffer buf(nBufSize);
 		do
 		{

--- a/deps/ZipArchive/ZipArchive.vcxproj
+++ b/deps/ZipArchive/ZipArchive.vcxproj
@@ -43,6 +43,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(DependencyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/deps/ZipArchive/ZipCentralDir.cpp
+++ b/deps/ZipArchive/ZipCentralDir.cpp
@@ -135,7 +135,7 @@ DWORD CZipCentralDir::Locate()
 
 	// maximum size of end of central dir record
 	long uMaxRecordSize = 0xffff + ZIPCENTRALDIRSIZE;
-	DWORD uFileSize = m_pStorage->m_pFile->GetLength();
+	DWORD uFileSize = static_cast<DWORD>(m_pStorage->m_pFile->GetLength());
 
 	if ((DWORD)uMaxRecordSize > uFileSize)
 		uMaxRecordSize = uFileSize;
@@ -476,12 +476,12 @@ void CZipCentralDir::RemoveFile(WORD uIndex)
 	{
 		int i = FindFileNameIndex(pHeader->GetFileName(), true);
 		ASSERT(i != -1);
-		int uIndex = m_findarray[i].m_uIndex;
+		int uSubIndex = m_findarray[i].m_uIndex;
 		m_findarray.RemoveAt(i);
 		// shift down the indexes
 		for (int j = 0; j < m_findarray.GetSize(); j++)
 		{
-			if (m_findarray[j].m_uIndex > uIndex)
+			if (m_findarray[j].m_uIndex > uSubIndex)
 				m_findarray[j].m_uIndex--;
 		}
 	}
@@ -515,8 +515,8 @@ bool CZipCentralDir::RemoveDataDescr(bool bFromBuffer)
 	}
 	else
 	{
-		uSize = m_pStorage->m_pFile->GetLength();
-		if (!ah.CreateMapping((HANDLE)m_pStorage->m_pFile->m_hFile))
+		uSize = static_cast<DWORD>(m_pStorage->m_pFile->GetLength());
+		if (!ah.CreateMapping(m_pStorage->m_pFile->m_hFile))
 			return false;
 		pFile = (char*)ah.m_pFileMap;
 	}

--- a/deps/ZipArchive/ZipStorage.cpp
+++ b/deps/ZipArchive/ZipStorage.cpp
@@ -432,7 +432,7 @@ void CZipStorage::Flush()
 
 DWORD CZipStorage::GetPosition()
 {
-	return m_pFile->GetPosition() + m_uBytesInWriteBuffer;
+	return static_cast<DWORD>(m_pFile->GetPosition()) + m_uBytesInWriteBuffer;
 }
 
 


### PR DESCRIPTION
Fix all warnings across the server projects.

Note that ZipArchive is a bit ugly with continuing to downcast the ULONGLONG to a DWORD, but this is its existing behaviour
and it's considerably more effort to restructure the entire ZipArchive project to support 64-bit filesizes.