### PR TITLE
CUIImageTooltipDlg: Add description & grade

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -239,13 +239,6 @@ enum e_ItemAttrib	{
 						ITEM_ATTRIB_UPGRADE_REVERSE = 12,
 						ITEM_ATTRIB_UNKNOWN = 0xffffffff };	
 
-enum e_ItemGrade
-{
-	ITEM_GRADE_LOW_CLASS = 1,
-	ITEM_GRADE_MIDDLE_CLASS = 2,
-	ITEM_GRADE_HIGH_CLASS = 3
-};
-
 enum e_ItemClass	{	ITEM_CLASS_DAGGER = 11, // dagger
 						ITEM_CLASS_SWORD = 21, // onehandsword
 						ITEM_CLASS_SWORD_2H = 22, // 3 : twohandsword
@@ -286,6 +279,13 @@ enum e_ItemClass	{	ITEM_CLASS_DAGGER = 11, // dagger
 						ITEM_CLASS_CONSUMABLE = 255, // Consumable items with 'charges' that use the durability/duration instead of stacks
 
 						ITEM_CLASS_UNKNOWN = 0xffffffff }; // 
+
+enum e_ItemGrade
+{
+	ITEM_GRADE_LOW_CLASS = 1,
+	ITEM_GRADE_MIDDLE_CLASS = 2,
+	ITEM_GRADE_HIGH_CLASS = 3
+};
 
 enum e_Nation { NATION_NOTSELECTED = 0, NATION_KARUS, NATION_ELMORAD, NATION_UNKNOWN = 0xffffffff };
 
@@ -740,7 +740,7 @@ struct __TABLE_ITEM_BASIC
 
 	uint8_t		bySellGroup;			// 36 Selling group associated with vendor NPC
 
-	uint8_t		byIDK3;					// 37
+	uint8_t		byGrade;				// 37
 };
 
 constexpr int MAX_ITEM_EXTENSION	= 24; // Number of item extension tables. (Item_Ext_0..23.tbl is a total of 24)

--- a/Client/WarFare/UIImageTooltipDlg.cpp
+++ b/Client/WarFare/UIImageTooltipDlg.cpp
@@ -1057,25 +1057,33 @@ int	CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill* spItem, bo
 	{
 		const std::string& szRemark = spItem->pItemBasic->szRemark;
 	
-		size_t strSize = spItem->pItemBasic->szRemark.size();
-		if (strSize > 0)
+		if (!szRemark.empty())
 		{
-			int splitPos = 0;
-			int spaceCount = 0;
-			for (size_t i = 0; i < strSize; i++)
+			size_t totalWords = 1;
+			for (char c : szRemark)
 			{
-				// Official client: split only on spaces (no '(' split). It only applies the split after 4 words.
-				if (szRemark[i] == ' ')
-					++spaceCount;
-
-				if (szRemark[i] == '(' || (szRemark[i] == ' ' && spaceCount > MAX_WORDS_COUNT))
-				{
-					splitPos = i;
-					break;
-				}
+				if (c == ' ')
+					++totalWords;
 			}
-			if (splitPos > 0)
+
+			if (totalWords >= MIN_WORDS_TO_SPLIT_DESC)
 			{
+				size_t wordsInFirstHalf = (totalWords + 1) / 2;
+				size_t wordsSeen = 1, splitPos = std::string::npos;
+				for (size_t i = 0; i < szRemark.size(); i++)
+				{
+					if (szRemark[i] != ' ')
+						continue;
+
+					if (++wordsSeen > wordsInFirstHalf)
+					{
+						splitPos = i;
+						break;
+					}
+				}
+
+				_ASSERT(splitPos != std::string::npos);
+
 				m_pStr[iIndex]->SetColor(m_CWhite);
 				m_pstdstr[iIndex] = fmt::format("*{}", std::string_view(szRemark.data(), splitPos));
 				m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNCENTER);
@@ -1083,8 +1091,11 @@ int	CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill* spItem, bo
 				iIndex++;
 				ERROR_EXCEPTION
 
+				// NOTE: This doesn't perfectly match official's behaviour; they rebuild the lines, always appending a space.
+				// This means that there's a guaranteed space after the word here, before the '*'
+				// To replicate this behaviour, we can manually add a space in the format string, but it's not really necessary.
 				m_pStr[iIndex]->SetColor(m_CWhite);
-				m_pstdstr[iIndex] = fmt::format("{}*", std::string_view(szRemark.data() + splitPos, strSize - splitPos));
+				m_pstdstr[iIndex] = fmt::format("{}*", std::string_view(szRemark.data() + splitPos, szRemark.size() - splitPos));
 				m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNCENTER);
 
 				iIndex++;
@@ -1112,18 +1123,20 @@ int	CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill* spItem, bo
 				m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNCENTER);
 				iIndex++;
 				break;
+
 			case ITEM_ATTRIB_UPGRADE:
 				if (spItem->pItemBasic != nullptr && spItem->pItemExt != nullptr)
 				{
-					const int itemGrade = spItem->pItemBasic->byIDK3 + spItem->pItemExt->bySoulBind;
-					if (itemGrade == ITEM_GRADE_LOW_CLASS)
+					const int iItemGrade = (std::min)(3, spItem->pItemBasic->byGrade + spItem->pItemExt->bySoulBind);
+					if (iItemGrade == ITEM_GRADE_LOW_CLASS)
 						m_pstdstr[iIndex] = fmt::format_text_resource(IDS_TOOLTIP_LOW_CLASS);
-					else if (itemGrade == ITEM_GRADE_MIDDLE_CLASS)
+					else if (iItemGrade == ITEM_GRADE_MIDDLE_CLASS)
 						m_pstdstr[iIndex] = fmt::format_text_resource(IDS_TOOLTIP_MIDDLE_CLASS);
-					else if (itemGrade == ITEM_GRADE_HIGH_CLASS)
+					else if (iItemGrade == ITEM_GRADE_HIGH_CLASS)
 						m_pstdstr[iIndex] = fmt::format_text_resource(IDS_TOOLTIP_HIGH_CLASS);
 					else
 						break;
+
 					m_pStr[iIndex]->SetColor(m_CGreen);
 					m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNLEFT);
 					iIndex++;

--- a/Client/WarFare/UIImageTooltipDlg.h
+++ b/Client/WarFare/UIImageTooltipDlg.h
@@ -15,11 +15,11 @@
 
 //////////////////////////////////////////////////////////////////////
 
-#define MAX_TOOLTIP_COUNT 30
-static constexpr int MAX_WORDS_COUNT = 3;
-
 class CUIImageTooltipDlg : public CN3UIBase
 {
+	static constexpr int MAX_TOOLTIP_COUNT			= 30;
+	static constexpr int MIN_WORDS_TO_SPLIT_DESC	= 5;
+
 	const D3DCOLOR		m_CYellow;	// 레어...
 	const D3DCOLOR		m_CBlue;	// 매직...	
 	const D3DCOLOR		m_CGold;	// 유니크...


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ✓] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
Item description, and item grade/class are not visible.

## What is the new behaviour?
It is displayed correctly like the original client 1298.


## Checklist
- [ ✓] I have performed a self-review of my own code.
- [ ✓] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [✓ ] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
