### PR TITLE
Server: Ensure 'client' (AI) socket IDs are set

### DIFF
--- a/Server/shared-server/SocketManager.cpp
+++ b/Server/shared-server/SocketManager.cpp
@@ -277,6 +277,7 @@ bool SocketManager::AcquireClientSocket(TcpClientSocket* tcpClientSocket)
 		return false;
 
 	_clientSocketArray[socketId] = tcpClientSocket;
+	tcpClientSocket->SetSocketID(socketId);
 	return true;
 }
 


### PR DESCRIPTION
Client (AI) sockets should have their socket IDs set as well.
Debug here is useless otherwise, but the bigger issue is they don't get properly detached - so on disconnect the old pointer will remain attached.

With it set correctly, it can detach from the array properly.