### PR TITLE
Server: Migrate critical sections to std::*mutex

### DIFF
--- a/Server/AIServer/GameSocket.cpp
+++ b/Server/AIServer/GameSocket.cpp
@@ -23,7 +23,7 @@ static char THIS_FILE[] = __FILE__;
 #define new DEBUG_NEW
 #endif
 
-extern CRITICAL_SECTION g_region_critical;
+extern std::mutex g_region_mutex;
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -1146,7 +1146,7 @@ void CGameSocket::RecvPartyInfoAllData(char* pBuf)
 		return;
 	}
 
-	EnterCriticalSection(&g_region_critical);
+	std::lock_guard<std::mutex> lock(g_region_mutex);
 
 	pParty = new _PARTY_GROUP;
 	pParty->wIndex = sPartyIndex;
@@ -1170,8 +1170,6 @@ void CGameSocket::RecvPartyInfoAllData(char* pBuf)
 	{
 		spdlog::debug("GameSocket::RecvPartyInfoAllData: created partyIndex={}", sPartyIndex);
 	}
-
-	LeaveCriticalSection(&g_region_critical);
 }
 
 void CGameSocket::RecvCheckAlive(char* pBuf)

--- a/Server/AIServer/MagicProcess.cpp
+++ b/Server/AIServer/MagicProcess.cpp
@@ -18,7 +18,7 @@ static char THIS_FILE[] = __FILE__;
 #define new DEBUG_NEW
 #endif
 
-extern CRITICAL_SECTION g_region_critical;
+extern std::mutex g_region_mutex;
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -958,20 +958,21 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 	int nid = 0, send_index = 0, result = 1, count = 0, total_mon = 0, attack_type = 0;
 	int* pNpcIDList = nullptr;
 
-	EnterCriticalSection(&g_region_critical);
-
-	auto Iter1 = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.begin();
-	auto Iter2 = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.end();
-
-	total_mon = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.GetSize();
-	pNpcIDList = new int[total_mon];
-	for (; Iter1 != Iter2; Iter1++)
 	{
-		nid = *((*Iter1).second);
-		pNpcIDList[count] = nid;
-		count++;
+		std::lock_guard<std::mutex> lock(g_region_mutex);
+
+		auto Iter1 = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.begin();
+		auto Iter2 = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.end();
+
+		total_mon = pMap->m_ppRegion[rx][rz].m_RegionNpcArray.GetSize();
+		pNpcIDList = new int[total_mon];
+		for (; Iter1 != Iter2; Iter1++)
+		{
+			nid = *((*Iter1).second);
+			pNpcIDList[count] = nid;
+			count++;
+		}
 	}
-	LeaveCriticalSection(&g_region_critical);
 
 	for (int i = 0; i < total_mon; i++)
 	{

--- a/Server/AIServer/Map.cpp
+++ b/Server/AIServer/Map.cpp
@@ -18,7 +18,7 @@
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-extern CRITICAL_SECTION g_region_critical;
+extern std::mutex g_region_mutex;
 
 CMapInfo::CMapInfo()
 {
@@ -280,12 +280,10 @@ void MAP::RegionUserAdd(int rx, int rz, int uid)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
-	
+	std::lock_guard<std::mutex> lock(g_region_mutex);
+
 	if (!region->m_RegionUserArray.PutData(uid, pInt))
 		delete pInt;
-
-	LeaveCriticalSection(&g_region_critical);
 }
 
 void MAP::RegionUserRemove(int rx, int rz, int uid)
@@ -298,11 +296,8 @@ void MAP::RegionUserRemove(int rx, int rz, int uid)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
-
+	std::lock_guard<std::mutex> lock(g_region_mutex);
 	region->m_RegionUserArray.DeleteData(uid);
-
-	LeaveCriticalSection(&g_region_critical);
 }
 
 void MAP::RegionNpcAdd(int rx, int rz, int nid)
@@ -318,7 +313,7 @@ void MAP::RegionNpcAdd(int rx, int rz, int nid)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
+	std::lock_guard<std::mutex> lock(g_region_mutex);
 
 	if (!region->m_RegionNpcArray.PutData(nid, pInt))
 	{
@@ -328,8 +323,6 @@ void MAP::RegionNpcAdd(int rx, int rz, int nid)
 
 	int nSize = m_ppRegion[rx][rz].m_RegionNpcArray.GetSize();
 	//TRACE(_T("+++ Map - RegionNpcAdd : x=%d,z=%d, nid=%d, total=%d \n"), rx,rz,nid, nSize);
-
-	LeaveCriticalSection(&g_region_critical);
 }
 
 void MAP::RegionNpcRemove(int rx, int rz, int nid)
@@ -342,11 +335,8 @@ void MAP::RegionNpcRemove(int rx, int rz, int nid)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
-
+	std::lock_guard<std::mutex> lock(g_region_mutex);
 	region->m_RegionNpcArray.DeleteData(nid);
-
-	LeaveCriticalSection(&g_region_critical);
 }
 
 void MAP::LoadMapTile(std::istream& fs)
@@ -429,11 +419,8 @@ int MAP::GetRegionUserSize(int rx, int rz)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
-	int nRet = region->m_RegionUserArray.GetSize();
-	LeaveCriticalSection(&g_region_critical);
-
-	return nRet;
+	std::lock_guard<std::mutex> lock(g_region_mutex);
+	return region->m_RegionUserArray.GetSize();
 }
 
 int  MAP::GetRegionNpcSize(int rx, int rz)
@@ -446,11 +433,8 @@ int  MAP::GetRegionNpcSize(int rx, int rz)
 
 	CRegion* region = &m_ppRegion[rx][rz];
 
-	EnterCriticalSection(&g_region_critical);
-	int nRet = region->m_RegionNpcArray.GetSize();
-	LeaveCriticalSection(&g_region_critical);
-
-	return nRet;
+	std::lock_guard<std::mutex> lock(g_region_mutex);
+	return region->m_RegionNpcArray.GetSize();
 }
 
 void MAP::LoadObjectEvent(std::istream& fs)

--- a/Server/AIServer/ServerDlg.h
+++ b/Server/AIServer/ServerDlg.h
@@ -78,7 +78,6 @@ public:
 	bool AddObjectEventNpc(_OBJECT_EVENT* pEvent, int zone_number);
 	void AllNpcInfo();			// ~sungyong 2002.05.23
 	CUser* GetUserPtr(int nid);
-	CUser* GetActiveUserPtr(int index);
 	CNpc* GetNpcPtr(const char* pNpcName);
 	int GetZoneIndex(int zoneId) const;
 	int GetServerNumber(int zoneId) const;

--- a/Server/Aujard/DBAgent.cpp
+++ b/Server/Aujard/DBAgent.cpp
@@ -34,8 +34,6 @@ import StoredProc;
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-extern CRITICAL_SECTION g_LogFileWrite;
-
 CDBAgent::CDBAgent()
 {
 }

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -27,8 +27,6 @@ static char THIS_FILE[] = __FILE__;
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-extern CRITICAL_SECTION g_LogFile_critical;
-
 CAISocket::CAISocket(SocketManager* socketManager, int zoneNum)
 	: TcpClientSocket(socketManager)
 {

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -369,6 +369,8 @@ private:
 	std::unique_ptr<TimerThread>		_packetCheckThread;
 
 	std::unique_ptr<ReadQueueThread>	_readQueueThread;
+
+	std::mutex							_serialMutex;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Server/Ebenezer/Npc.cpp
+++ b/Server/Ebenezer/Npc.cpp
@@ -17,7 +17,7 @@ static char THIS_FILE[] = __FILE__;
 #define new DEBUG_NEW
 #endif
 
-extern CRITICAL_SECTION g_region_critical;
+extern std::recursive_mutex g_region_mutex;
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -275,7 +275,7 @@ int CNpc::GetRegionNpcList(int region_x, int region_z, char* buff, int& t_count)
 
 	CRegion* region = &pMap->m_ppRegion[region_x][region_z];
 
-	EnterCriticalSection(&g_region_critical);
+	std::lock_guard<std::recursive_mutex> lock(g_region_mutex);
 
 	for (const auto& [_, pNid] : region->m_RegionNpcArray)
 	{
@@ -290,8 +290,6 @@ int CNpc::GetRegionNpcList(int region_x, int region_z, char* buff, int& t_count)
 			++t_count;
 		}
 	}
-
-	LeaveCriticalSection(&g_region_critical);
 
 	return buff_index;
 }

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -197,7 +197,6 @@ public:
 
 	// Game socket specific:
 	_REGION_BUFFER*		_regionBuffer;
-	std::mutex			_regionBufferMutex;
 
 	CJvCryption			_jvCryption;
 	bool				_jvCryptionEnabled;


### PR DESCRIPTION
Typically we default to std::mutex unless it's evident that recursion is necessary.
To keep things simple and behave closer to how it behaves officially, we drop `CUser::_regionBufferMutex`, making Ebenezer's g_region_mutex (formerly g_region_critical) a recursive mutex to allow for this case.

 I use `std::lock_guard` predominantly unless I absolutely "need" to preemptively unlock the mutex in cases which aren't typically solved by scoping (e.g. before logging in error cases).

Generally everything else is pretty much 1:1 how it was before.

Some other minor cases:
1. The party ID generator is now guarded.
2. AI: On game server disconnect, DeleteAllUserList() consistently guards parties, regions and users.
3. Simplified `DeleteAllData()` calls; these don't need to pre-check if the map is empty. It (already redundantly) does it itself.

Resolves #632