### PR TITLE
Improve thread shutdown logic

### DIFF
--- a/Server/AIServer/NpcThread.cpp
+++ b/Server/AIServer/NpcThread.cpp
@@ -26,7 +26,7 @@ void CNpcThread::thread_loop()
 	double	fTime2 = 0.0, fTime3 = 0.0;
 	int		duration_damage = 0;
 
-	while (_running)
+	while (_canTick)
 	{
 		fTime2 = TimeGet();
 

--- a/Server/AIServer/SendThreadMain.h
+++ b/Server/AIServer/SendThreadMain.h
@@ -10,7 +10,7 @@ class SendThreadMain : public Thread
 {
 public:
 	SendThreadMain(AISocketManager* socketManager);
-	bool shutdown(bool join = true) override;
+	void shutdown(bool waitForShutdown = true) override;
 	void queue(_SEND_DATA* sendData);
 	~SendThreadMain() override;
 

--- a/Server/AIServer/ZoneEventThread.cpp
+++ b/Server/AIServer/ZoneEventThread.cpp
@@ -11,7 +11,7 @@ ZoneEventThread::ZoneEventThread(CServerDlg* main)
 
 void ZoneEventThread::thread_loop()
 {
-	while (_running)
+	while (_canTick)
 	{
 		double fCurrentTime = TimeGet();
 		for (MAP* pMap : _main->m_ZoneArray)

--- a/Server/Ebenezer/SendWorkerThread.cpp
+++ b/Server/Ebenezer/SendWorkerThread.cpp
@@ -13,13 +13,13 @@ SendWorkerThread::SendWorkerThread(EbenezerSocketManager* socketManager)
 
 void SendWorkerThread::thread_loop()
 {
-	while (_running)
+	while (_canTick)
 	{
 		{
 			std::unique_lock<std::mutex> lock(_mutex);
 			std::cv_status status = _cv.wait_for(lock, std::chrono::milliseconds(200));
 
-			if (!_running)
+			if (!_canTick)
 				break;
 
 			// Only tick every 200ms as per official, ignore spurious wakeups

--- a/Server/shared-server/ReadQueueThread.cpp
+++ b/Server/shared-server/ReadQueueThread.cpp
@@ -12,7 +12,7 @@ void ReadQueueThread::thread_loop()
 	char buffer[SharedMemoryQueue::MAX_MSG_SIZE] = {};
 	int len;
 
-	while (_running)
+	while (_canTick)
 	{
 		len = _sharedMemoryQueue.GetData(buffer);
 		if (len >= SMQ_ERROR_RANGE)
@@ -20,7 +20,7 @@ void ReadQueueThread::thread_loop()
 			std::unique_lock<std::mutex> lock(_mutex);
 			std::cv_status status = _cv.wait_for(lock, std::chrono::milliseconds(100));
 
-			if (!_running)
+			if (!_canTick)
 				break;
 
 			continue;

--- a/shared/Thread.h
+++ b/shared/Thread.h
@@ -7,17 +7,25 @@
 class Thread
 {
 public:
-	bool IsRunning() const
+	bool CanTick() const
 	{
-		return _running;
+		return _canTick;
+	}
+
+	bool IsShutdown() const
+	{
+		return _isShutdown;
 	}
 
 	Thread();
 	virtual void start();
-	virtual bool shutdown(bool join = true);
+	virtual void shutdown(bool waitForShutdown = true);
+	void join();
 	virtual ~Thread();
 
 protected:
+	void thread_loop_wrapper();
+
 	virtual void thread_loop() = 0;
 	virtual void before_shutdown() {}
 
@@ -25,5 +33,6 @@ protected:
 	std::mutex				_mutex;
 	std::condition_variable	_cv;
 	std::thread				_thread;
-	bool					_running;
+	bool					_canTick;
+	bool					_isShutdown;
 };

--- a/shared/TimerThread.cpp
+++ b/shared/TimerThread.cpp
@@ -10,13 +10,13 @@ TimerThread::TimerThread(std::chrono::milliseconds tickDelay, TickCallback_t&& t
 
 void TimerThread::thread_loop()
 {
-	while (_running)
+	while (_canTick)
 	{
 		{
 			std::unique_lock<std::mutex> lock(_mutex);
 			std::cv_status status = _cv.wait_for(lock, _tickDelay);
 
-			if (!_running)
+			if (!_canTick)
 				break;
 
 			// Only tick every _tickDelay, ignore spurious wakeups


### PR DESCRIPTION
Rename `_running` to `_canTick` and add` _isShutdown` to explicitly separate behaviour. That is, before, a thread could no longer be running, but not yet be shutdown (i.e. the thread is technically still running). Now a thread can continue to tick for as long as `_canTick` is set, but it's not until `_isShutdown` is set that the thread has actually finally finished running.

Additionally, ensure we always `join()` (when requested) on shutdown(). This ensures that if the thread was externally shutdown, we still wait for it to do so, rather than just immediately returning.

Finally, expose and add some error handling for `join()`.