### PR TITLE
Share application thread logic under AppThread

### DIFF
--- a/Server/AIServer/AiServer.cpp
+++ b/Server/AIServer/AiServer.cpp
@@ -4,49 +4,8 @@
 #include "pch.h"
 #include "AiServerInstance.h"
 
-#include <signal.h>
-#include <spdlog/spdlog.h>
-
-AiServerInstance* _appThread = nullptr;
-
-void signalHandler(int signalNumber)
-{
-	spdlog::info("AiServer::signalHandler: Caught {}", signalNumber);
-	switch (signalNumber)
-	{
-	case SIGINT:
-	case SIGABRT:
-	case SIGTERM:
-		// Shutdown the application thread
-		if (_appThread != nullptr)
-		{
-			_appThread->shutdown(false);
-			_appThread = nullptr;
-		}
-		break;
-	}
-	
-	signal(signalNumber, signalHandler);
-}
-
 int main()
 {
 	AIServerLogger logger;
-
-	// catch interrupt signals for graceful shutdowns.
-	signal(SIGINT, signalHandler);
-	signal(SIGABRT, signalHandler);
-	signal(SIGTERM, signalHandler);
-
-	// Logger config/setup is handled by the server instance.
-	// We just instantiate it early for signal handling.
-	AiServerInstance appThread(logger);
-	_appThread = &appThread;
-	appThread.start();
-
-	// We keep the main() thread alive to catch interrupt signals and call shutdown
-	appThread.join();
-	_appThread = nullptr;
-
-	return EXIT_SUCCESS;
+	return AppThread::main<AiServerInstance>(logger);
 }

--- a/Server/AIServer/AiServerInstance.cpp
+++ b/Server/AIServer/AiServerInstance.cpp
@@ -37,14 +37,9 @@ import AIServerBinder;
 
 using namespace db;
 
-AiServerInstance* AiServerInstance::s_instance = nullptr;
-
 AiServerInstance::AiServerInstance(AIServerLogger& logger)
-	: _logger(logger)
+	: AppThread(logger)
 {
-	assert(s_instance == nullptr);
-	s_instance = this;
-
 	m_iYear = 0;
 	m_iMonth = 0;
 	m_iDate = 0;
@@ -146,9 +141,6 @@ AiServerInstance::~AiServerInstance()
 	spdlog::info("AiServerInstance::~AiServerInstance: All resources safely released.");
 
 	ConnectionManager::Destroy();
-
-	assert(s_instance != nullptr);
-	s_instance = nullptr;
 }
 
 bool AiServerInstance::OnStart()
@@ -344,18 +336,6 @@ bool AiServerInstance::OnStart()
 	spdlog::info("AiServerInstance::OnStart: AIServer successfully initialized");
 
 	return true;
-}
-
-void AiServerInstance::thread_loop()
-{
-	if (!OnStart())
-		return;
-		
-	while (_canTick)
-	{
-		std::unique_lock<std::mutex> lock(_mutex);
-		_cv.wait(lock);
-	}
 }
 
 /// \brief attempts to listen on the port associated with m_byZone

--- a/Server/AIServer/AiServerInstance.h
+++ b/Server/AIServer/AiServerInstance.h
@@ -10,8 +10,7 @@
 
 #include "Extern.h"			// 전역 객체
 
-#include <shared/Thread.h>
-
+#include <shared-server/AppThread.h>
 #include <shared-server/logger.h>
 #include <shared-server/STLMap.h>
 
@@ -55,12 +54,12 @@ typedef std::list <int>						ZoneNpcInfoList;
 typedef std::vector <MAP*>					ZoneArray;
 
 class TimerThread;
-class AiServerInstance : public Thread
+class AiServerInstance : public AppThread
 {
 public:
 	static AiServerInstance* instance()
 	{
-		return s_instance;
+		return static_cast<AiServerInstance*>(s_instance);
 	}
 
 	void GameServerAcceptThread();
@@ -135,10 +134,7 @@ public:
 protected:
 	/// \brief Loads config, database caches, then starts sockets and thread pools.
 	/// \returns true when successful, false otherwise
-	bool OnStart();
-
-	/// \brief The main thread loop for the server instance
-	void thread_loop() override;
+	bool OnStart() override;
 
 	/// \brief attempts to listen on the port associated with m_byZone
 	/// \see m_byZone
@@ -159,11 +155,7 @@ private:
 
 	uint8_t				m_byZone;
 
-	AIServerLogger&		_logger;
-
 	std::unique_ptr<TimerThread>	_checkAliveThread;
-
-	static AiServerInstance* s_instance;
 
 	void StartNpcThreads();
 	bool LoadNpcPosTable(std::vector<model::NpcPos*>& rows);

--- a/Server/VersionManager/VersionManager.cpp
+++ b/Server/VersionManager/VersionManager.cpp
@@ -4,49 +4,8 @@
 #include "pch.h"
 #include "VersionManagerInstance.h"
 
-#include <signal.h>
-#include <spdlog/spdlog.h>
-
-VersionManagerInstance* _appThread = nullptr;
-
-void signalHandler(int signalNumber)
-{
-	spdlog::info("VersionManager::signalHandler: Caught {}", signalNumber);
-	switch (signalNumber)
-	{
-		case SIGINT:
-		case SIGABRT:
-		case SIGTERM:
-			// Shutdown the application thread
-			if (_appThread != nullptr)
-			{
-				_appThread->shutdown(false);
-				_appThread = nullptr;
-			}
-			break;
-	}
-
-	signal(signalNumber, signalHandler);
-}
-
 int main()
 {
 	logger::Logger logger(logger::VersionManager);
-
-	// catch interrupt signals for graceful shutdowns.
-	signal(SIGINT, signalHandler);
-	signal(SIGABRT, signalHandler);
-	signal(SIGTERM, signalHandler);
-
-	// Logger config/setup is handled by the server instance.
-	// We just instantiate it early for signal handling.
-	VersionManagerInstance appThread(logger);
-	_appThread = &appThread;
-	appThread.start();
-
-	// We keep the main() thread alive to catch interrupt signals and call shutdown
-	appThread.join();
-	_appThread = nullptr;
-
-	return EXIT_SUCCESS;
+	return AppThread::main<VersionManagerInstance>(logger);
 }

--- a/Server/VersionManager/VersionManagerInstance.h
+++ b/Server/VersionManager/VersionManagerInstance.h
@@ -3,9 +3,7 @@
 #include "Define.h"
 #include "DBProcess.h"
 
-#include <shared/Thread.h>
-
-#include <shared-server/logger.h>
+#include <shared-server/AppThread.h>
 #include <shared-server/SocketManager.h>
 
 #include <vector>
@@ -17,14 +15,14 @@ namespace recordset_loader
 }
 
 class TimerThread;
-class VersionManagerInstance : public Thread
+class VersionManagerInstance : public AppThread
 {
 	using ServerInfoList = std::vector<_SERVER_INFO*>;
 
 public:
 	static VersionManagerInstance* instance()
 	{
-		return s_instance;
+		return static_cast<VersionManagerInstance*>(s_instance);
 	}
 
 	const char* FtpUrl() const
@@ -57,10 +55,7 @@ public:
 protected:
 	/// \brief Loads config, database caches, then starts sockets and thread pools.
 	/// \returns true when successful, false otherwise
-	bool OnStart();
-
-	/// \brief The main thread loop for the server instance
-	void thread_loop() override;
+	bool OnStart() override;
 
 protected:
 	char			_ftpUrl[256];
@@ -68,9 +63,5 @@ protected:
 
 	int				_lastVersion;
 
-	logger::Logger&	_logger;
-
 	std::unique_ptr<TimerThread>	_dbPoolCheckThread;
-
-	static VersionManagerInstance* s_instance;
 };

--- a/Server/shared-server/AppThread.cpp
+++ b/Server/shared-server/AppThread.cpp
@@ -1,0 +1,69 @@
+﻿#include "pch.h"
+#include "AppThread.h"
+
+#include <signal.h>
+#include <stdlib.h>
+#include <spdlog/spdlog.h>
+
+AppThread* AppThread::s_instance = nullptr;
+bool AppThread::s_shutdown = false;
+
+AppThread::AppThread(logger::Logger& logger)
+	: _logger(logger), _exitCode(EXIT_SUCCESS)
+{
+	assert(s_instance == nullptr);
+	s_instance = this;
+}
+
+AppThread::~AppThread()
+{
+	assert(s_instance != nullptr);
+	s_instance = nullptr;
+}
+
+/// \brief The main thread loop for the server instance
+void AppThread::thread_loop()
+{
+	if (!OnStart())
+	{
+		_exitCode = EXIT_FAILURE;
+		return;
+	}
+
+	while (_canTick)
+	{
+		std::unique_lock<std::mutex> lock(_mutex);
+		_cv.wait(lock);
+	}
+
+	_exitCode = EXIT_SUCCESS;
+}
+
+void AppThread::catchInterruptSignals()
+{
+	// catch interrupt signals for graceful shutdowns.
+	signal(SIGINT, signalHandler);
+	signal(SIGABRT, signalHandler);
+	signal(SIGTERM, signalHandler);
+}
+
+void AppThread::signalHandler(int signalNumber)
+{
+	spdlog::info("AppThread::signalHandler: Caught {}", signalNumber);
+	switch (signalNumber)
+	{
+		case SIGINT:
+		case SIGABRT:
+		case SIGTERM:
+			// Shutdown the application thread
+			if (!s_shutdown
+				&& s_instance != nullptr)
+			{
+				s_instance->shutdown(false);
+				s_shutdown = true;
+			}
+			break;
+	}
+
+	signal(signalNumber, signalHandler);
+}

--- a/Server/shared-server/AppThread.h
+++ b/Server/shared-server/AppThread.h
@@ -1,0 +1,51 @@
+﻿#pragma once
+
+#include <shared/Thread.h>
+#include "logger.h"
+
+class AppThread : public Thread
+{
+public:
+	int exitCode() const
+	{
+		return _exitCode;
+	}
+
+	AppThread(logger::Logger& logger);
+	~AppThread();
+
+	/// \brief The main thread loop for the server instance
+	void thread_loop() override;
+
+	/// \brief Initializes the server, loading caches, socket managers, etc.
+	/// \returns true when successful, false otherwise
+	virtual bool OnStart() = 0;
+
+	template <typename AppThreadType, typename LoggerType>
+	static int main(LoggerType& logger)
+	{
+		// catch interrupt signals for graceful shutdowns.
+		catchInterruptSignals();
+
+		// Logger config/setup is handled by the server instance.
+		// We just instantiate it early for signal handling.
+		AppThreadType appThread(logger);
+		appThread.start();
+
+		// We keep the main() thread alive to catch interrupt signals and call shutdown
+		appThread.join();
+
+		return appThread.exitCode();
+	}
+
+private:
+	static void catchInterruptSignals();
+	static void signalHandler(int signalNumber);
+
+protected:
+	logger::Logger&		_logger;
+	int					_exitCode;
+
+	static AppThread*	s_instance;
+	static bool			s_shutdown;
+};

--- a/Server/shared-server/shared-server.vcxproj
+++ b/Server/shared-server/shared-server.vcxproj
@@ -141,6 +141,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AppThread.cpp" />
     <ClCompile Include="utilities.cpp" />
     <ClCompile Include="N3ShapeMgr.cpp" />
     <ClCompile Include="ReadQueueThread.cpp" />
@@ -156,6 +157,7 @@
     <ClCompile Include="TcpSocket.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AppThread.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="My_3DStruct.h" />
     <ClInclude Include="GeometricStructs.h" />

--- a/Server/shared-server/shared-server.vcxproj.filters
+++ b/Server/shared-server/shared-server.vcxproj.filters
@@ -28,6 +28,9 @@
       <Filter>Threads</Filter>
     </ClCompile>
     <ClCompile Include="utilities.cpp" />
+    <ClCompile Include="AppThread.cpp">
+      <Filter>Threads</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="server_config.h" />
@@ -63,6 +66,9 @@
     </ClInclude>
     <ClInclude Include="GeometricStructs.h" />
     <ClInclude Include="utilities.h" />
+    <ClInclude Include="AppThread.h">
+      <Filter>Threads</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="N3Base">


### PR DESCRIPTION
This logic is predominantly the same across servers. Rather than duplicate, we should share, so we'll make a class named AppThread to share this main logic.

`AppThread::main` ends up templated appropriately.