### PR TITLE
Server: Use the console sink by default

### DIFF
--- a/Server/shared-server/ftxui_sink_mt.h
+++ b/Server/shared-server/ftxui_sink_mt.h
@@ -55,7 +55,8 @@ namespace ftxui
 		std::deque<ReplayLog>					_replayLogBuffer;
 		std::mutex								_logBufferMutex;
 		ftxui::ScreenInteractive*				_screen;
-		bool									_useStdout;
+		bool									_useConsoleSink;
+		bool									_storeLogBuffer;
 		size_t									_backlogSize;
 		std::shared_ptr<spdlog::sinks::sink>	_consoleSink;
 	};


### PR DESCRIPTION
As OnStart() is what sets up the loggers, and rendering occurs afterwards, we have the ftxui sink just use the console logger to log on-demand as it's loading up until it's finished loading and it sets up the ftxui sink for rendering.

We rename `_useStdout` to `_useConsoleSink` to be more explicit, and add `_storeLogBuffer` as everything we're writing to console now should be swapped over to & rendered by ftxui.

This fixes logging awkwardness when it loads (and in particular when the server fails to load).