### PR TITLE
Server: Strip _MSC_VER checks

### DIFF
--- a/Server/AIServer/MagicProcess.h
+++ b/Server/AIServer/MagicProcess.h
@@ -1,20 +1,10 @@
-﻿// MagicProcess.h: interface for the CMagicProcess class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_MAGICPROCESS_H__9FE02686_F482_4C68_849A_130DE441D38D__INCLUDED_)
-#define AFX_MAGICPROCESS_H__9FE02686_F482_4C68_849A_130DE441D38D__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "Extern.h"
 
 class AIServerApp;
 class CUser;
 class CNpc;
-
 class CMagicProcess
 {
 public:
@@ -43,7 +33,4 @@ public:
 
 	model::Magic* IsAvailable(int magicid, int tid, uint8_t type);
 	void MagicPacket(char* pBuf);
-
 };
-
-#endif // !defined(AFX_MAGICPROCESS_H__9FE02686_F482_4C68_849A_130DE441D38D__INCLUDED_)

--- a/Server/AIServer/Map.h
+++ b/Server/AIServer/Map.h
@@ -1,13 +1,4 @@
-﻿// MAP.h: interface for the MAP class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_MAP_H__BCC14687_C38F_4597_8522_2170ED077037__INCLUDED_)
-#define AFX_MAP_H__BCC14687_C38F_4597_8522_2170ED077037__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include <shared-server/N3ShapeMgr.h>
 #include <shared-server/STLMap.h>
@@ -101,6 +92,3 @@ public:
 protected:
 	void RemoveMapData();
 };
-
-#endif // !defined(AFX_MAP_H__BCC14687_C38F_4597_8522_2170ED077037__INCLUDED_)
-

--- a/Server/AIServer/Npc.h
+++ b/Server/AIServer/Npc.h
@@ -1,13 +1,4 @@
-﻿// Npc.h: interface for the CNpc class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_NPC_H__6077F7AF_6166_463A_AA80_FBF218781BC6__INCLUDED_)
-#define AFX_NPC_H__6077F7AF_6166_463A_AA80_FBF218781BC6__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "Map.h"
 #include "PathFind.h"
@@ -479,5 +470,3 @@ public:
 	void ChangeAbility(int iChangeType);
 	bool Teleport();
 };
-
-#endif // !defined(AFX_NPC_H__6077F7AF_6166_463A_AA80_FBF218781BC6__INCLUDED_)

--- a/Server/AIServer/NpcItem.h
+++ b/Server/AIServer/NpcItem.h
@@ -1,18 +1,8 @@
-﻿// NpcItem.h: interface for the CNpcItem class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_NPCITEM_H__56D8779F_271E_4B39_92CF_3DA33366FBA8__INCLUDED_)
-#define AFX_NPCITEM_H__56D8779F_271E_4B39_92CF_3DA33366FBA8__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 class CNpcItem
 {
 public:
-
 	int** m_ppItem;
 	int m_nRow;
 	int m_nField;
@@ -20,5 +10,3 @@ public:
 	CNpcItem();
 	~CNpcItem();
 };
-
-#endif // !defined(AFX_NPCITEM_H__56D8779F_271E_4B39_92CF_3DA33366FBA8__INCLUDED_)

--- a/Server/AIServer/NpcMagicProcess.h
+++ b/Server/AIServer/NpcMagicProcess.h
@@ -1,13 +1,4 @@
-﻿// NpcMagicProcess.h: interface for the CNpcMagicProcess class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_NPCMAGICPROCESS_H__7C457180_E271_45E6_BEFC_912BCCAB0604__INCLUDED_)
-#define AFX_NPCMAGICPROCESS_H__7C457180_E271_45E6_BEFC_912BCCAB0604__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "Extern.h"
 
@@ -38,7 +29,4 @@ public:
 
 	model::Magic* IsAvailable(int magicid, int tid, uint8_t type);
 	void MagicPacket(char* pBuf, int len);
-
 };
-
-#endif // !defined(AFX_NPCMAGICPROCESS_H__7C457180_E271_45E6_BEFC_912BCCAB0604__INCLUDED_)

--- a/Server/AIServer/Party.h
+++ b/Server/AIServer/Party.h
@@ -1,20 +1,10 @@
-﻿// Party.h: interface for the CParty class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_PARTY_H__4F806B4E_F764_4983_9A47_46254233A7BA__INCLUDED_)
-#define AFX_PARTY_H__4F806B4E_F764_4983_9A47_46254233A7BA__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 //#include "PartyUser.h"
 //#include "STLMap.h"
 
 //typedef CSTLMap <CPartyUser>			PartyUserArray;
 class AIServerApp;
-
 class CParty
 {
 public:
@@ -33,7 +23,4 @@ public:
 	void PartyInsert(char* pBuf);
 	void PartyCreate(char* pBuf);
 	void PartyProcess(char* pBuf);
-
 };
-
-#endif // !defined(AFX_PARTY_H__4F806B4E_F764_4983_9A47_46254233A7BA__INCLUDED_)

--- a/Server/AIServer/PartyUser.h
+++ b/Server/AIServer/PartyUser.h
@@ -1,24 +1,12 @@
-﻿// PartyUser.h: interface for the CPartyUser class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_PARTYUSER_H__3B9E7175_1970_4C1B_BF20_DB6A728AF1AA__INCLUDED_)
-#define AFX_PARTYUSER_H__3B9E7175_1970_4C1B_BF20_DB6A728AF1AA__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 class CPartyUser
 {
 public:
 	char    m_strUserID[MAX_ID_SIZE + 1];	// 캐릭터의 이름
 	int		m_iUserId;					// User의 번호
-public:
 
+public:
 	CPartyUser();
 	virtual ~CPartyUser();
-
 };
-
-#endif // !defined(AFX_PARTYUSER_H__3B9E7175_1970_4C1B_BF20_DB6A728AF1AA__INCLUDED_)

--- a/Server/AIServer/PathFind.h
+++ b/Server/AIServer/PathFind.h
@@ -1,17 +1,9 @@
-﻿// PathFind.h: interface for the CPathFind class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_PATHFIND_H__395FDD6E_C35A_43A2_BBB2_FCDCD17E8CE8__INCLUDED_)
-#define AFX_PATHFIND_H__395FDD6E_C35A_43A2_BBB2_FCDCD17E8CE8__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include <shared-server/GeometricStructs.h>
 
-class _PathNode {
+class _PathNode
+{
 public:
 	int f;
 	int h;
@@ -23,14 +15,14 @@ public:
 	_PathNode* NextNode;
 };
 
-class STACK {
+class STACK
+{
 public:
 	_PathNode* NodePtr;
 	STACK* NextStackPtr;
 };
 
 class AIServerApp;
-
 class CPathFind
 {
 public:
@@ -61,5 +53,3 @@ protected:
 
 	AIServerApp*	m_pMain;
 };
-
-#endif // !defined(AFX_PATHFIND_H__395FDD6E_C35A_43A2_BBB2_FCDCD17E8CE8__INCLUDED_)

--- a/Server/AIServer/Region.h
+++ b/Server/AIServer/Region.h
@@ -1,19 +1,9 @@
-﻿// Region.h: interface for the CRegion class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_REGION_H__F79F27E6_C1E6_4ED5_904A_934AA8163C88__INCLUDED_)
-#define AFX_REGION_H__F79F27E6_C1E6_4ED5_904A_934AA8163C88__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include <shared-server/STLMap.h>
 
 class CUser;
 class CNpc;
-
 
 typedef CSTLMap <int>			ZoneUserArray;
 typedef CSTLMap <int>			ZoneNpcArray;
@@ -34,7 +24,4 @@ protected:
 public:
 	CRegion();
 	virtual ~CRegion();
-
 };
-
-#endif // !defined(AFX_REGION_H__F79F27E6_C1E6_4ED5_904A_934AA8163C88__INCLUDED_)

--- a/Server/AIServer/RoomEvent.h
+++ b/Server/AIServer/RoomEvent.h
@@ -1,13 +1,4 @@
-﻿// RoomEvent.h: interface for the CRoomEvent class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_ROOMEVENT_H__70001CA8_64B8_422F_B0F4_ED0F2FA95E0E__INCLUDED_)
-#define AFX_ROOMEVENT_H__70001CA8_64B8_422F_B0F4_ED0F2FA95E0E__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include <shared-server/STLMap.h>
 
@@ -55,7 +46,6 @@ public:
 private:
 	uint8_t    m_byLogicNumber;	// 현재의 조건문 검사 번호 (조건번호는 1부터 시작됨) (m_byCheck와 m_byLogicNumber이 같다면 클리어 상태)
 
-
 public:
 	CRoomEvent();
 	virtual ~CRoomEvent();
@@ -70,7 +60,4 @@ private:
 	bool CheckMonsterCount(int sid, int count, int type);
 	CNpc* GetNpcPtr(int sid);
 	void EndEventSay(int option1, int option2);
-
 };
-
-#endif // !defined(AFX_ROOMEVENT_H__70001CA8_64B8_422F_B0F4_ED0F2FA95E0E__INCLUDED_)

--- a/Server/AIServer/User.h
+++ b/Server/AIServer/User.h
@@ -1,16 +1,6 @@
-﻿// User.h: interface for the CUser class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_USER_H__1CC8CB68_CF95_4849_8E89_134826B1FAC2__INCLUDED_)
-#define AFX_USER_H__1CC8CB68_CF95_4849_8E89_134826B1FAC2__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "MagicProcess.h"
-
 #include "Extern.h"
 
 #include <shared-server/STLMap.h>
@@ -70,7 +60,6 @@ public:
 	int16_t	m_sAC;						// 방어율
 	int16_t	m_sItemAC;                  // 아이템 방어률
 
-
 	int16_t	m_sSurroundNpcNumber[8];		// Npc 다굴~
 
 	uint8_t	m_byIsOP;					// 운영자인지를 판단..
@@ -110,5 +99,3 @@ public:
 	CUser();
 	virtual ~CUser();
 };
-
-#endif // !defined(AFX_USER_H__1CC8CB68_CF95_4849_8E89_134826B1FAC2__INCLUDED_)

--- a/Server/Ebenezer/EVENT.h
+++ b/Server/Ebenezer/EVENT.h
@@ -1,13 +1,4 @@
-﻿// EVENT.h: interface for the EVENT class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_EVENT_H__7514FC23_511B_11D3_BE41_00105A6B97E2__INCLUDED_)
-#define AFX_EVENT_H__7514FC23_511B_11D3_BE41_00105A6B97E2__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "EVENT_DATA.h"
 #include <shared-server/STLMap.h>
@@ -27,7 +18,4 @@ public:
 
 	EVENT();
 	virtual ~EVENT();
-
 };
-
-#endif // !defined(AFX_EVENT_H__7514FC23_511B_11D3_BE41_00105A6B97E2__INCLUDED_)

--- a/Server/Ebenezer/EVENT_DATA.h
+++ b/Server/Ebenezer/EVENT_DATA.h
@@ -1,22 +1,12 @@
-﻿// EVENT_DATA.h: interface for the EVENT_DATA class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_EVENT_DATA_H__7514FC26_511B_11D3_BE41_00105A6B97E2__INCLUDED_)
-#define AFX_EVENT_DATA_H__7514FC26_511B_11D3_BE41_00105A6B97E2__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "EXEC.h"
 #include "LOGIC_ELSE.h"
-#pragma warning(disable : 4786)
+
 #include <list>
 
 typedef	 std::list<EXEC*>				ExecArray;
 typedef	 std::list<LOGIC_ELSE*>			LogicElseArray;
-
 
 class EVENT_DATA
 {
@@ -28,5 +18,3 @@ public:
 	EVENT_DATA();
 	virtual ~EVENT_DATA();
 };
-
-#endif // !defined(AFX_EVENT_DATA_H__7514FC26_511B_11D3_BE41_00105A6B97E2__INCLUDED_)

--- a/Server/Ebenezer/GameEvent.h
+++ b/Server/Ebenezer/GameEvent.h
@@ -1,13 +1,4 @@
-﻿// GameEvent.h: interface for the CGameEvent class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_GAMEEVENT_H__1D5848E3_70D7_4278_9A89_A2A94AA20757__INCLUDED_)
-#define AFX_GAMEEVENT_H__1D5848E3_70D7_4278_9A89_A2A94AA20757__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 class CUser;
 class CGameEvent
@@ -22,5 +13,3 @@ public:
 
 	int		m_iExec[5];
 };
-
-#endif // !defined(AFX_GAMEEVENT_H__1D5848E3_70D7_4278_9A89_A2A94AA20757__INCLUDED_)

--- a/Server/Ebenezer/Knights.h
+++ b/Server/Ebenezer/Knights.h
@@ -1,16 +1,7 @@
-﻿// Knights.h: interface for the CKnights class.
-//
-//////////////////////////////////////////////////////////////////////
+﻿#pragma once
 
-#if !defined(AFX_KNIGHTS_H__741B63A3_F081_45B0_9918_012D2E88A8BC__INCLUDED_)
-#define AFX_KNIGHTS_H__741B63A3_F081_45B0_9918_012D2E88A8BC__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
-
-#include "define.h"
-#include "gamedefine.h"
+#include "Define.h"
+#include "GameDefine.h"
 
 class CUser;
 class EbenezerApp;
@@ -44,5 +35,3 @@ public:
 
 	void InitializeValue();
 };
-
-#endif // !defined(AFX_KNIGHTS_H__741B63A3_F081_45B0_9918_012D2E88A8BC__INCLUDED_)

--- a/Server/Ebenezer/KnightsManager.h
+++ b/Server/Ebenezer/KnightsManager.h
@@ -1,13 +1,4 @@
-﻿// KnightsManager.h: interface for the CKnightsManager class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_KNIGHTSMANAGER_H__B3BA0329_28DF_4E7F_BC19_101D7A69E896__INCLUDED_)
-#define AFX_KNIGHTSMANAGER_H__B3BA0329_28DF_4E7F_BC19_101D7A69E896__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 class CUser;
 class EbenezerApp;
@@ -44,8 +35,4 @@ public:
 
 	EbenezerApp* m_pMain;
 //	CDatabase	m_KnightsDB;
-private:
-
 };
-
-#endif // !defined(AFX_KNIGHTSMANAGER_H__B3BA0329_28DF_4E7F_BC19_101D7A69E896__INCLUDED_)

--- a/Server/Ebenezer/MagicProcess.h
+++ b/Server/Ebenezer/MagicProcess.h
@@ -1,13 +1,4 @@
-﻿// MagicProcess.h: interface for the CMagicProcess class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_MAGICPROCESS_H__C39F1966_3F41_47A9_B26A_77F311683A05__INCLUDED_)
-#define AFX_MAGICPROCESS_H__C39F1966_3F41_47A9_B26A_77F311683A05__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "GameDefine.h"
 
@@ -23,7 +14,6 @@
 
 class EbenezerApp;
 class CUser;
-
 class CMagicProcess
 {
 public:
@@ -54,5 +44,3 @@ public:
 	CUser*			m_pSrcUser;
 	uint8_t			m_bMagicState;
 };
-
-#endif // !defined(AFX_MAGICPROCESS_H__C39F1966_3F41_47A9_B26A_77F311683A05__INCLUDED_)

--- a/Server/Ebenezer/Map.h
+++ b/Server/Ebenezer/Map.h
@@ -1,13 +1,4 @@
-﻿// Map.h: interface for the CMap class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_3DMAP_H__986E02B6_E5A3_43CF_B1D7_A7135551933D__INCLUDED_)
-#define AFX_3DMAP_H__986E02B6_E5A3_43CF_B1D7_A7135551933D__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "Region.h"
 #include "GameEvent.h"
@@ -102,5 +93,3 @@ public:
 
 	uint32_t m_wBundle;	// Zone Item Max Count
 };
-
-#endif // !defined(AFX_3DMAP_H__986E02B6_E5A3_43CF_B1D7_A7135551933D__INCLUDED_)

--- a/Server/Ebenezer/Npc.h
+++ b/Server/Ebenezer/Npc.h
@@ -1,18 +1,8 @@
-﻿// Npc.h: interface for the CNpc class.
-//
-//////////////////////////////////////////////////////////////////////
+﻿#pragma once
 
-#if !defined(AFX_NPC_H__1DE71CDD_4040_4479_828D_E8EE07BD7A67__INCLUDED_)
-#define AFX_NPC_H__1DE71CDD_4040_4479_828D_E8EE07BD7A67__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
-
-#include "define.h"
+#include "Define.h"
 
 class EbenezerApp;
-
 class CNpc
 {
 public:
@@ -44,10 +34,10 @@ public:
 								// 1 : NPC
 								// 2 : 각 입구,출구 NPC
 								// 3 : 경비병
-	int		m_iSellingGroup;		// ItemGroup
+	int		m_iSellingGroup;	// ItemGroup
 
-	int16_t	m_sRegion_X;			// region x position
-	int16_t	m_sRegion_Z;			// region z position
+	int16_t	m_sRegion_X;		// region x position
+	int16_t	m_sRegion_Z;		// region z position
 	uint8_t	m_NpcState;			// NPC의 상태 - 살았다, 죽었다, 서있다 등등...
 	uint8_t	m_byGateOpen;		// Gate Npc Status -> 1 : open 0 : close
 	int16_t	m_sHitRate;			// 공격 성공률
@@ -70,9 +60,8 @@ public:
 	int GetRegionNpcList(int region_x, int region_z, char* buff, int& t_count);
 	void GetNpcInfo(char* buff, int& buff_index);
 
-	inline uint8_t GetState() const {
+	uint8_t GetState() const
+	{
 		return m_byState;
 	}
 };
-
-#endif // !defined(AFX_NPC_H__1DE71CDD_4040_4479_828D_E8EE07BD7A67__INCLUDED_)

--- a/Server/Ebenezer/UdpSocket.h
+++ b/Server/Ebenezer/UdpSocket.h
@@ -1,13 +1,4 @@
-﻿// UdpSocket.h: interface for the CUdpSocket class.
-//
-//////////////////////////////////////////////////////////////////////
-
-#if !defined(AFX_UDPSOCKET_H__E53802D9_5A8C_47B6_9B3B_12D2DDDACD92__INCLUDED_)
-#define AFX_UDPSOCKET_H__E53802D9_5A8C_47B6_9B3B_12D2DDDACD92__INCLUDED_
-
-#if _MSC_VER > 1000
-#pragma once
-#endif // _MSC_VER > 1000
+﻿#pragma once
 
 #include "Define.h"
 #include "RecvUDPThread.h"
@@ -37,7 +28,7 @@ public:
 	void RecvBattleZoneCurrentUsers(char* pBuf);
 
 protected:
-	static constexpr int UDP_SOCKET_BUFFER_SIZE	= (1024*32);
+	static constexpr int UDP_SOCKET_BUFFER_SIZE	= (1024 * 32);
 
 	RecvUDPThread			_recvUdpThread;
 	asio::io_context		_io;
@@ -47,5 +38,3 @@ protected:
 	char					_recvBuff[UDP_SOCKET_BUFFER_SIZE];
 	EbenezerApp*			_main;
 };
-
-#endif // !defined(AFX_UDPSOCKET_H__E53802D9_5A8C_47B6_9B3B_12D2DDDACD92__INCLUDED_)


### PR DESCRIPTION
As-is, they're not portable.
No real reason to not just use #pragma once directly; all modern compilers handle this just fine.