### PR TITLE
MSBuild: Guard git access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,48 +1,61 @@
 [submodule "deps/dx9sdk"]
 	path = deps/dx9sdk
 	url = https://github.com/Open-KO/microsoft-directx-sdk
+	shallow = true
 [submodule "Client/Data"]
 	path = Client/Data
 	url = https://github.com/Open-KO/ko-client-assets
 	branch = openko-1298
+	shallow = true
 [submodule "deps/zlib"]
 	path = deps/zlib
 	url = https://github.com/madler/zlib.git
 	branch = master
+	shallow = true
 [submodule "deps/libjpeg-turbo"]
 	path = deps/libjpeg-turbo
 	url = https://github.com/libjpeg-turbo/libjpeg-turbo
 	branch = main
+	shallow = true
 [submodule "deps/db-models"]
 	path = deps/db-models
 	url = https://github.com/Open-KO/OpenKO-db-models
 	branch = main
+	shallow = true
 [submodule "deps/nanodbc"]
 	path = deps/nanodbc
 	url = https://github.com/Open-KO/nanodbc.git
 	branch = OpenKO
+	shallow = true
 [submodule "deps/db-library"]
 	path = deps/db-library
 	url = https://github.com/Open-KO/OpenKO-db-library.git
 	branch = main
+	shallow = true
 [submodule "deps/spdlog"]
 	path = deps/spdlog
 	url = https://github.com/Open-KO/spdlog.git
 	branch = v1.x
+	shallow = true
 [submodule "deps/mpg123"]
 	path = deps/mpg123
 	url = https://github.com/madebr/mpg123.git
 	branch = master-with-github-ci
+	shallow = true
 [submodule "deps/djb2"]
 	path = deps/djb2
 	url = https://github.com/Open-KO/djb2
+	shallow = true
 [submodule "deps/asio"]
 	path = deps/asio
 	url = https://github.com/chriskohlhoff/asio
 	branch = asio-1-36-0
+	shallow = true
 [submodule "deps/boost"]
 	path = deps/boost
 	url = https://github.com/Open-KO/OpenKO-boost
+	shallow = true
 [submodule "deps/FTXUI"]
 	path = deps/FTXUI
 	url = https://github.com/ArthurSonzogni/FTXUI
+	shallow = true

--- a/build_scripts/build_lock_acquire.cmd
+++ b/build_scripts/build_lock_acquire.cmd
@@ -1,0 +1,40 @@
+@ECHO OFF
+SETLOCAL
+
+REM The idea behind this is that MKDIR is atomic.
+REM As such, it can be used as an arbitrary locking mechanism.
+
+REM Validate arguments
+IF "%~1"=="" (
+	ECHO Usage: %~nx0 GIT_LOCK_DIR
+	ECHO Example: %~nx0 "deps\fetch-and-build-wrappers\last-build-states\Win32\Release\git_lock"
+	EXIT /B 1
+)
+
+SET "GIT_LOCK_DIR=%~1"
+
+REM Config
+SET MAX_WAIT_TIME=300
+SET SECONDS_ELAPSED=0
+
+REM Try to acquire the "lock"
+:acquire_lock
+MKDIR "%GIT_LOCK_DIR%" 2>NUL
+IF %ERRORLEVEL%==0 (
+	REM Lock acquired
+	ECHO git lock acquired
+	EXIT /B 0
+)
+
+REM Lock already exists, so we should wait.
+SET /a SECONDS_ELAPSED+=1
+
+REM We've waited longer than our maximum (30s), so we should give up.
+IF %SECONDS_ELAPSED% GEQ %MAX_WAIT_TIME% (
+	ECHO ERROR: Could not acquire lock after %MAX_WAIT_TIME% seconds.
+	EXIT /B 1
+)
+
+REM ECHO Waiting for lock... (%SECONDS_ELAPSED%s)
+ping 127.0.0.1 -n 2 -w 1000 >NUL
+GOTO acquire_lock

--- a/build_scripts/build_lock_release.cmd
+++ b/build_scripts/build_lock_release.cmd
@@ -1,0 +1,30 @@
+@ECHO OFF
+SETLOCAL
+
+REM The idea behind this is that MKDIR is atomic.
+REM As such, it can be used as an arbitrary locking mechanism.
+
+REM Validate arguments
+IF "%~1"=="" (
+	ECHO Usage: %~nx0 GIT_LOCK_DIR
+	ECHO Example: %~nx0 "deps\fetch-and-build-wrappers\last-build-states\Win32\Release\git_lock"
+	EXIT /B 1
+)
+
+REM Just a pre-safety check. This should definitely exist at this point.
+IF NOT EXIST "%GIT_LOCK_DIR%" (
+	ECHO WARNING: Lock directory does not exist - %GIT_LOCK_DIR%
+	EXIT /B 1
+)
+
+REM Attempt to remove it.
+RMDIR "%GIT_LOCK_DIR%" 2>nul
+
+REM Make sure we actually did...
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO WARNING: Failed to remove lock directory - %GIT_LOCK_DIR%
+	EXIT /B 1
+) ELSE (
+	ECHO git lock released
+	EXIT /B 0
+)

--- a/build_scripts/sync_submodules.cmd
+++ b/build_scripts/sync_submodules.cmd
@@ -1,11 +1,44 @@
 @ECHO OFF
 SETLOCAL
 
+REM Validate arguments
+IF "%~2"=="" (
+	ECHO Usage: %~nx0 BUILD_CONFIG BUILD_PLATFORM
+	ECHO Example: %~nx0 Release Win32
+	EXIT /B 1
+)
+
+SET "BUILD_CONFIG=%~1"
+SET "BUILD_PLATFORM=%~2"
+
 REM Setup environment
 CALL "%~dp0env_setup.cmd"
 IF ERRORLEVEL 1 EXIT /B 1
 
+SET "REPO_ROOT=%~dp0.."
+
+REM Ensure REPO_ROOT is an absolute path
+PUSHD "%~dp0\.."
+SET REPO_ROOT=%CD%
+POPD
+
+SET "BUILD_STATE_DIR=%REPO_ROOT%\deps\fetch-and-build-wrappers\last-build-states\%BUILD_PLATFORM%\%BUILD_CONFIG%"
+SET "GIT_LOCK_DIR=%BUILD_STATE_DIR%\git_lock"
+
+REM We sync submodules at the start of a build, so we can just reset the lock dir if it exists already.
+IF EXIST "%GIT_LOCK_DIR%" (
+	RMDIR "%GIT_LOCK_DIR%" 
+)
+
+REM Trigger build lock to force other projects to wait until git's done
+CALL "%~dp0build_lock_acquire.cmd" "%GIT_LOCK_DIR%"
+IF ERRORLEVEL 1 EXIT /B 1
+
 REM Sync submodules.
 "%GitPath%" submodule sync
+
+REM Release build lock
+CALL "%~dp0build_lock_release.cmd" "%GIT_LOCK_DIR%"
+IF ERRORLEVEL 1 EXIT /B 1
 
 EXIT /B 0

--- a/deps/fetch-and-build-wrappers/sync-submodules.vcxproj
+++ b/deps/fetch-and-build-wrappers/sync-submodules.vcxproj
@@ -33,8 +33,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup>
-    <NMakeBuildCommandLine>CALL "$(RootDir)build_scripts\sync_submodules.cmd"</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>CALL "$(RootDir)build_scripts\sync_submodules.cmd"</NMakeReBuildCommandLine>
+    <NMakeBuildCommandLine>CALL "$(RootDir)build_scripts\sync_submodules.cmd" "$(Configuration)" "$(Platform)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>CALL "$(RootDir)build_scripts\sync_submodules.cmd" "$(Configuration)" "$(Platform)"</NMakeReBuildCommandLine>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
Parallel builds can unintentionally use git at the same time. This causes it to hit git's internal lock, which occasionally fails builds. A rebuild usually fixes this, unless it was unlucky enough to corrupt the git index.

MKDIR is atomic, so we basically just guard it behind a created directory. The only annoying part is the delay; the ping trick is the only thing that really seems to behave in this environment. We could run it through Powershell but invoking that is slower, so I'd rather not.