### PR TITLE
Server: Word wrap log entries as best we can

### DIFF
--- a/Server/shared-server/AppThread.cpp
+++ b/Server/shared-server/AppThread.cpp
@@ -183,7 +183,7 @@ int AppThread::thread_loop_ftxui(CIni& iniFile)
 		auto logDisplay = vbox(logElements)
 			| focusPositionRelative(0, scrollPosition)
 			| vscroll_indicator
-			| frame
+			| yframe
 			| flex;
 
 		auto inputBox = hbox({

--- a/Server/shared-server/ftxui_sink_mt.cpp
+++ b/Server/shared-server/ftxui_sink_mt.cpp
@@ -134,7 +134,7 @@ namespace ftxui
 		auto logLine = hbox({
 			text(std::string(textBeforeColor)),
 			text(std::string(textColored)) | color(spdlog_level_to_fxtui_color(msg.level)),
-			text(std::string(textAfterColor))
+			paragraph(std::string(textAfterColor))
 		});
 
 		ReplayLog replayLog;

--- a/Server/shared-server/logger.h
+++ b/Server/shared-server/logger.h
@@ -110,7 +110,7 @@ namespace ini
 	static constexpr char DEFAULT_LOG_PATTERN[] = "[%H:%M:%S][%n][%7l] %v";
 
 	/// \brief default console logger line prefix ([12:59:59][AppName][  level] log line...)
-	static constexpr char DEFAULT_CONSOLE_LOG_PATTERN[] = "[%H:%M:%S][%n][%^%7l%$] %v";
+	static constexpr char DEFAULT_CONSOLE_LOG_PATTERN[] = "[%H:%M:%S][%n]%^[%7l] %$%v";
 }
 
 #endif // SERVER_SHAREDSERVER_LOGGER_H


### PR DESCRIPTION
Ideally, `paragraph()` needs to support colourisation. Since it doesn't, we're forced to use multiple `text()` calls, which it wraps on individually.

It also groups them horizontally, so it will only start wrapping from the point the previous elements end at.

It's *very* simple with just `paragraph(entireLogLine)`, but unfortunately we can't use colours that way.

That being the case, we tweak the console log default to colourise "[info] " so it "nicely" wraps after that.

Ideally I'd just have it wrap properly to the start of the next line, but short of writing our own element to handle this paragraph behaviour, I unfortunately don't think this is actually possible.

Resolves #665