### PR TITLE
Server: Wait for shared memory to start (Aujard, ItemManager)

### DIFF
--- a/Server/Aujard/AujardApp.h
+++ b/Server/Aujard/AujardApp.h
@@ -182,7 +182,19 @@ protected:
 	/// \returns true when successful, false otherwise
 	bool LoadConfig(CIni& iniFile) override;
 
+	/// \brief Initializes the server, loading caches, attempting to load shared memory etc.
+	/// \returns true when successful, false otherwise
 	bool OnStart() override;
+
+	/// \brief Attempts to open all shared memory queues & blocks that we've yet to open.
+	bool AttemptOpenSharedMemory();
+
+	/// \brief Thread tick attempting to open all shared memory queues & blocks that we've yet to open.
+	/// \see AttemptOpenSharedMemory
+	void AttemptOpenSharedMemoryThreadTick();
+
+	/// \brief Finishes server initialization and starts processing threads.
+	void OnSharedMemoryOpened();
 
 private:
 	time_t								_heartbeatReceivedTime;
@@ -190,6 +202,7 @@ private:
 	std::unique_ptr<TimerThread>		_heartbeatCheckThread;
 	std::unique_ptr<TimerThread>		_concurrentCheckThread;
 	std::unique_ptr<TimerThread>		_packetCheckThread;
-										
+	std::unique_ptr<TimerThread>		_smqOpenThread;
+
 	std::unique_ptr<ReadQueueThread>	_readQueueThread;
 };

--- a/Server/ItemManager/ItemManagerApp.h
+++ b/Server/ItemManager/ItemManagerApp.h
@@ -7,14 +7,18 @@
 
 #include <shared-server/AppThread.h>
 #include <shared-server/SharedMemoryQueue.h>
+#include <shared/TimerThread.h>
 
 class ItemManagerLogger;
 class ReadQueueThread;
 class ItemManagerApp : public AppThread
 {
 public:
-	SharedMemoryQueue m_LoggerRecvQueue;
-	std::unique_ptr<ReadQueueThread> _readQueueThread;
+	SharedMemoryQueue					LoggerRecvQueue;
+
+private:
+	std::unique_ptr<ReadQueueThread>	_readQueueThread;
+	std::unique_ptr<TimerThread>		_smqOpenThread;
 
 public:
 	static ItemManagerApp* instance()
@@ -30,6 +34,16 @@ protected:
 	std::filesystem::path ConfigPath() const override;
 
 	bool OnStart() override;
+
+	/// \brief Attempts to open shared memory queue.
+	bool AttemptOpenSharedMemory();
+
+	/// \brief Thread tick attempting to open shared memory queue.
+	/// \see AttemptOpenSharedMemory
+	void AttemptOpenSharedMemoryThreadTick();
+
+	/// \brief Finishes server initialization and starts processing threads.
+	void OnSharedMemoryOpened();
 
 public:
 	void ItemLogWrite(const char* pBuf);

--- a/Server/ItemManager/ItemManagerReadQueueThread.cpp
+++ b/Server/ItemManager/ItemManagerReadQueueThread.cpp
@@ -3,7 +3,7 @@
 #include "ItemManagerApp.h"
 
 ItemManagerReadQueueThread::ItemManagerReadQueueThread()
-	: ReadQueueThread(ItemManagerApp::instance()->m_LoggerRecvQueue)
+	: ReadQueueThread(ItemManagerApp::instance()->LoggerRecvQueue)
 {
 }
 

--- a/Server/shared-server/SharedMemoryBlock.cpp
+++ b/Server/shared-server/SharedMemoryBlock.cpp
@@ -70,7 +70,8 @@ char* SharedMemoryBlock::Open(const std::string& name)
 	}
 	catch (const interprocess_exception& ex)
 	{
-		spdlog::error("SharedMemoryBlock::Open: failed to open existing shared memory block. name='{}' ex={}", name, ex.what());
+		if (ex.get_error_code() != not_found_error)
+			spdlog::error("SharedMemoryBlock::Open: failed to open existing shared memory block. name='{}' ex={}", name, ex.what());
 	}
 
 	return nullptr;

--- a/Server/shared-server/SharedMemoryQueue.cpp
+++ b/Server/shared-server/SharedMemoryQueue.cpp
@@ -29,6 +29,7 @@ bool SharedMemoryQueue::Create(const char* name)
 	catch (const interprocess_exception& ex)
 	{
 		spdlog::error("SharedMemoryQueue::Create: failed to create shared memory. name='{}' ex='{}'", name, ex.what());
+		_queue.reset();
 	}
 
 	return false;
@@ -47,6 +48,7 @@ bool SharedMemoryQueue::OpenOrCreate(const char* name)
 	catch (const interprocess_exception& ex)
 	{
 		spdlog::error("SharedMemoryQueue::OpenOrCreate: failed to open or create shared memory. name='{}' ex='{}'", name, ex.what());
+		_queue.reset();
 	}
 
 	return false;
@@ -61,7 +63,10 @@ bool SharedMemoryQueue::Open(const char* name)
 	}
 	catch (const interprocess_exception& ex)
 	{
-		spdlog::error("SharedMemoryQueue::Open: failed to open existing shared memory. name='{}' ex='{}'", name, ex.what());
+		if (ex.get_error_code() != not_found_error)
+			spdlog::error("SharedMemoryQueue::Open: failed to open existing shared memory. name='{}' ex='{}'", name, ex.what());
+
+		_queue.reset();
 	}
 
 	return false;

--- a/Server/shared-server/SharedMemoryQueue.h
+++ b/Server/shared-server/SharedMemoryQueue.h
@@ -23,6 +23,11 @@ public:
 	static constexpr uint32_t MAX_MSG_SIZE	= 512;
 	static constexpr uint32_t MAX_NUM_MSG	= 4096;
 
+	bool IsOpen() const
+	{
+		return _queue != nullptr;
+	}
+
 	SharedMemoryQueue(int sendRetryCount = 0);
 	bool Create(const char* name);
 	bool OpenOrCreate(const char* name);


### PR DESCRIPTION
Aujard and ItemManager will now wait for shared memory, rather than failing outright.

This enables servers to be started concurrently.

Resolves #670