### PR TITLE
CMake: Add .gitignore to build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.vcxproj.user
+*.user
 *.tlog
 *.idb
 *.res
@@ -53,12 +53,9 @@ lib/
 warfare_config.h
 server_config.h
 *.idea
-All.sln.DotSettings.user
 *.txt
 last-build-states/
-module-output/
 .env
-build/
 
 # Do not ignore CMakeLists.txt
 !CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,13 @@ set(OPENKO_SERVER_MAP_DST_DIR "${OPENKO_BIN_DIR}/MAP")
 set(OPENKO_SERVER_QUESTS_SRC_DIR "${CMAKE_SOURCE_DIR}/Server/bin/QUESTS")
 set(OPENKO_SERVER_QUESTS_DST_DIR "${OPENKO_BIN_DIR}/QUESTS")
 
-# Set the default solution folder to place targets/projects in
-set(CMAKE_FOLDER "_deps")
+# Generate .gitignore in build directory
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  file(WRITE "${PROJECT_BINARY_DIR}/.gitignore" "*")
+endif()
 
 # Add dependencies
+set(CMAKE_FOLDER "_deps")
 add_subdirectory(deps/asio-cmake)
 add_subdirectory(deps/spdlog-cmake)
 


### PR DESCRIPTION
We can thus remove build/ from .gitignore (and do some minor cleanup there)