### PR TITLE
MSBuild: Add 64-bit builds to workflows

### DIFF
--- a/.github/workflows/build_msbuild_all.yml
+++ b/.github/workflows/build_msbuild_all.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Debug, Release]
-        BUILD_PLATFORM: [Win32]
+        BUILD_PLATFORM: [Win32, x64]
 
     name: "All: ${{ matrix.BUILD_CONFIGURATION }} - ${{ matrix.BUILD_PLATFORM }}"
 

--- a/.github/workflows/build_msbuild_client.yml
+++ b/.github/workflows/build_msbuild_client.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Debug, Release]
-        BUILD_PLATFORM: [Win32]
+        BUILD_PLATFORM: [Win32, x64]
 
     name: "Client: ${{ matrix.BUILD_CONFIGURATION }} - ${{ matrix.BUILD_PLATFORM }}"
 

--- a/.github/workflows/build_msbuild_client_tools.yml
+++ b/.github/workflows/build_msbuild_client_tools.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Debug, Release]
-        BUILD_PLATFORM: [Win32]
+        BUILD_PLATFORM: [Win32, x64]
 
     name: "Client tools: ${{ matrix.BUILD_CONFIGURATION }} - ${{ matrix.BUILD_PLATFORM }}"
 

--- a/.github/workflows/build_msbuild_server.yml
+++ b/.github/workflows/build_msbuild_server.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Debug, Release]
-        BUILD_PLATFORM: [Win32]
+        BUILD_PLATFORM: [Win32, x64]
 
     name: "Server: ${{ matrix.BUILD_CONFIGURATION }} - ${{ matrix.BUILD_PLATFORM }}"
 

--- a/.github/workflows/build_msbuild_tools.yml
+++ b/.github/workflows/build_msbuild_tools.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Debug, Release]
-        BUILD_PLATFORM: [Win32]
+        BUILD_PLATFORM: [Win32, x64]
 
     name: "Tools: ${{ matrix.BUILD_CONFIGURATION }} - ${{ matrix.BUILD_PLATFORM }}"
 


### PR DESCRIPTION
GitHub workflows should include 64-bit builds now that we're slowly adopting it.