### PR TITLE
Add FileIO test runner to build_msbuild_all.yml

### DIFF
--- a/.github/workflows/build_msbuild_all.yml
+++ b/.github/workflows/build_msbuild_all.yml
@@ -87,6 +87,12 @@ jobs:
     - name: Build tests
       run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tests.slnx
 
+    - name: Run tests - FileIO
+      shell: cmd
+      working-directory: "bin/${{matrix.BUILD_PLATFORM}}/${{matrix.BUILD_CONFIGURATION}}/FileIO-tests"
+      run: |
+        FileIO-tests.exe --gtest_print_time=1 --gtest_catch_exceptions=1 --gtest_break_on_failure=0
+
     - name: Run tests - MathUtils
       shell: cmd
       working-directory: "bin/${{matrix.BUILD_PLATFORM}}/${{matrix.BUILD_CONFIGURATION}}/MathUtils-tests"


### PR DESCRIPTION
This was missed in the PR. It was always covered by CMake under its MSVC builds, just not by this specific workflow handling it manually.