### PR TITLE
CUIManager::Tick() should always run every frame

### DIFF
--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -352,17 +352,20 @@ void CGameProcedure::Tick()
 	POINT ptCur = s_pLocalInput->MouseGetPos();
 
 	e_Nation eNation = s_pPlayer->m_InfoBase.eNation;
-	if(dwMouseFlags & MOUSE_LBCLICK) SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorClick1 : s_hCursorClick));
-	else if(dwMouseFlags & MOUSE_LBCLICKED) SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorNormal1 : s_hCursorNormal));
-	if(dwMouseFlags & MOUSE_RBCLICKED)
+	if (dwMouseFlags & MOUSE_LBCLICK)
+		SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorClick1 : s_hCursorClick));
+	else if (dwMouseFlags & MOUSE_LBCLICKED)
+		SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorNormal1 : s_hCursorNormal));
+	if (dwMouseFlags & MOUSE_RBCLICKED)
 	{
-		if(s_pPlayer->m_bAttackContinous && s_pProcActive == s_pProcMain) // 메인 프로시져 이면..
+		// 메인 프로시져 이면..
+		if (s_pPlayer->m_bAttackContinous && s_pProcActive == s_pProcMain)
 			SetGameCursor(s_hCursorAttack);
 		else
 			SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorNormal1 : s_hCursorNormal));
 	}
 
-	uint32_t dwRet = s_pMsgBoxMgr->MouseProcAndTick(dwMouseFlags, s_pLocalInput->MouseGetPos(), s_pLocalInput->MouseGetPosOld());
+	uint32_t dwRet = s_pMsgBoxMgr->MouseProcAndTick(dwMouseFlags, ptCur, ptPrev);
 	if (dwRet == 0)
 		dwRet = s_pUIMgr->MouseProc(dwMouseFlags, ptCur, ptPrev);
 


### PR DESCRIPTION
A messagebox UI registering as having done anything (including the mouse being in its region) should not prevent all other UIs from ticking.

This is observed very quickly and easily when loading up the client project without the server running.
At the login scene, if you move the cursor over the messagebox UI, it currently prevents the leaves from moving (because the login UI doesn't tick).