### PR TITLE
Remove unnecessary assertion on opt-in file format version

### DIFF
--- a/Client/N3Base/N3BaseFileAccess.cpp
+++ b/Client/N3Base/N3BaseFileAccess.cpp
@@ -48,8 +48,6 @@ void CN3BaseFileAccess::FileNameSet(const std::string& szFileName)
 
 bool CN3BaseFileAccess::Load(File& file)
 {
-	_ASSERT(m_iFileFormatVersion != N3FORMAT_VER_UNKN);
-
 	int nL = 0;
 	file.Read(&nL, 4);
 	if (nL > 0)


### PR DESCRIPTION
This isn't consistently set but also really shouldn't need to be.