### PR TITLE
Ebenezer: Remove redundant CUser::RunNpcEvent()

### DIFF
--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -11431,11 +11431,7 @@ void CUser::ClientEvent(char* pBuf)
 		return;
 
 	// Execute the 'E' events in Event #1
-	for (EXEC* pExec : pEventData->m_arExec)
-	{
-		if (!RunNpcEvent(pNpc, pExec))
-			return;
-	}
+	RunEvent(pEventData);
 }
 
 // This part reads all the 'A' parts and checks if the
@@ -11662,78 +11658,6 @@ bool CUser::CheckEventLogic(const EVENT_DATA* pEventData)
 	}
 
 	return bExact;
-}
-
-// This part executes all the 'E' lines!
-bool CUser::RunNpcEvent(CNpc* pNpc, const EXEC* pExec)
-{
-	switch (pExec->m_Exec)
-	{
-		case EXEC_SAY:
-			SendNpcSay(pExec);
-			break;
-
-		case EXEC_SELECT_MSG:
-			SelectMsg(pExec);
-			break;
-
-		case EXEC_RUN_EVENT:
-		{
-			EVENT* pEvent = nullptr;
-			EVENT_DATA* pEventData = nullptr;
-
-			pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);
-			if (pEvent == nullptr)
-				break;
-
-			pEventData = pEvent->m_arEvent.GetData(pExec->m_ExecInt[0]);
-			if (pEventData == nullptr)
-				break;
-
-			if (!CheckEventLogic(pEventData))
-				break;
-
-			for (EXEC* pExec : pEventData->m_arExec)
-			{
-				if (!RunNpcEvent(pNpc, pExec))
-					return false;
-			}
-		}
-		break;
-
-		case EXEC_GIVE_ITEM:
-			if (!GiveItem(pExec->m_ExecInt[0], pExec->m_ExecInt[1]))
-				return false;
-			break;
-
-		case EXEC_ROB_ITEM:
-			if (!RobItem(pExec->m_ExecInt[0], pExec->m_ExecInt[1]))
-				return false;
-			break;
-
-		//	비러머글 복권 >.<
-		case EXEC_OPEN_EDITBOX:
-			OpenEditBox(pExec->m_ExecInt[1], pExec->m_ExecInt[2]);
-			break;
-
-		case EXEC_GIVE_NOAH:
-			GoldGain(pExec->m_ExecInt[0]);
-			break;
-
-		case EXEC_LOG_COUPON_ITEM:
-			LogCoupon(pExec->m_ExecInt[0], pExec->m_ExecInt[1]);
-			break;
-	//
-	// 비러머글 엑셀 >.<
-		case EXEC_SAVE_COM_EVENT:
-			SaveComEvent(pExec->m_ExecInt[0]);
-			break;
-	//
-		case EXEC_RETURN:
-			return false;
-	}
-
-	return true;
 }
 
 bool CUser::RunEvent(const EVENT_DATA* pEventData)

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -263,7 +263,6 @@ public:
 	void ItemLogToAgent(const char* srcid, const char* tarid, int type, int64_t serial, int itemid, int count, int durability);
 	void TestPacket();
 	bool RunEvent(const EVENT_DATA* pEventData);
-	bool RunNpcEvent(CNpc* pNpc, const EXEC* pExec);
 	bool CheckEventLogic(const EVENT_DATA* pEventData);
 	void ClientEvent(char* pBuf);
 	void KickOut(char* pBuf);


### PR DESCRIPTION
RunNpcEvent() was basically just CUser::RunEvent() with the NPC pointer passed in (and unused). RunEvent() also handles the outer loop, where RunNpcEvent() is expected to be run in a loop.

Other than that, the only real difference is RunNpcEvent() doesn't handle EXEC_SAVE_COM_EVENT but there's no real functional reason for that.

Regardless, RunNpcEvent() isn't even a thing in the official 1.298 binaries; they're shared there.