### PR TITLE
[Client] Fix the screen capture processes

### DIFF
--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -379,14 +379,19 @@ void CGameProcedure::Tick()
 
 	CN3Base::s_SndMgr.Tick(); // Sound Engine...
 
-	// 스크린 캡쳐 키..
-	if(s_pLocalInput->IsKeyPress(DIK_NUMPADMINUS)) // 키패드의 마이너스 키를 누르면..
+	// Screen capture key handling
+	if (s_pLocalInput->IsKeyPress(DIK_NUMPADMINUS)) // When the numpad minus key is pressed...
 	{
 		SYSTEMTIME st;
+
+		// Retrieve current local time
 		::GetLocalTime(&st);
 
-		std::string szFN = fmt::format("{}_{}_{}_{}.{}.{}.ksc",
+		// Build a filename based on timestamp (Year_Month_Day_Hour_Minute_Second.lss)
+		std::string szFN = fmt::format("{}_{}_{}_{}_{}_{}.ksc",
 			st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+
+		// Capture the current screen and save it to the file
 		CaptureScreenAndSaveToFile(szFN);
 	}
 


### PR DESCRIPTION
## Pull request type

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
Screenshot capture was always returning true, so it looked successful but no image was saved.

## What is the new behaviour?
Screenshots are now properly saved in the right format and orientation.

## Why and how did I change this?
Removed the forced return, fixed the capture pipeline to use the correct DIB data, and flipped the image so it shows up correctly.

## Was AI used at some point for any part of this change? If so, what?
no, it was not used

## Checklist

- [X] I have performed a self-review of my own code.
- [X] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [X] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
