### PR TITLE
Client: Restore screenshot code

### DIFF
--- a/Client/JpegFile/JpegFile.h
+++ b/Client/JpegFile/JpegFile.h
@@ -301,15 +301,15 @@ public:
 								int nSampsPerRow,
 								struct jpeg_compress_struct cinfo,
 								JSAMPARRAY jsmpPixels,
-								const char* pcsMsg);
+								const char** pcsMsg);
 	BOOL			JpegFromDib(HANDLE hDib,		//Handle to DIB
 								int nQuality,		//JPEG quality (0-100)
 								std::string csJpeg, //Pathname to jpeg file
-								const char* pcsMsg);		//Error msg to return
+								const char** pcsMsg);		//Error msg to return
 	virtual BOOL	EncryptJPEG(HANDLE hDib,		//Handle to DIB
 								int nQuality,		//JPEG quality (0-100)
 								std::string csJpeg, //Pathname to jpeg file
-								const char* pcsMsg);		//Error msg to return
+								const char** pcsMsg);		//Error msg to return
 
 	BOOL			SaveFromDecryptToJpeg(std::string csKsc, std::string csJpeg);
 	virtual BOOL	DecryptJPEG(std::string csJpeg);

--- a/Client/KscViewer/CMakeLists.txt
+++ b/Client/KscViewer/CMakeLists.txt
@@ -46,6 +46,12 @@ target_compile_options(KscViewer PRIVATE
   $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra>
 )
 
+if(MSVC)
+  set_property(TARGET KscViewer PROPERTY
+    VS_DEBUGGER_WORKING_DIRECTORY "${OPENKO_CLIENT_DIR}"
+  )
+endif()
+
 add_custom_command(TARGET KscViewer POST_BUILD
   COMMAND "${CMAKE_COMMAND}" -E echo "$<TARGET_FILE:KscViewer> has been built"
 )

--- a/Client/KscViewer/KscViewer.vcxproj
+++ b/Client/KscViewer/KscViewer.vcxproj
@@ -154,6 +154,10 @@
   <ItemGroup>
     <CustomBuild Include="res\KscViewer.rc2" />
   </ItemGroup>
+  <PropertyGroup Label="Debugger defaults">
+    <LocalDebuggerWorkingDirectory>$(RootDir)Client\Data\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Client/Launcher/Launcher.vcxproj
+++ b/Client/Launcher/Launcher.vcxproj
@@ -211,6 +211,10 @@
   <ItemGroup>
     <CustomBuild Include="res\Launcher.rc2" />
   </ItemGroup>
+  <PropertyGroup Label="Debugger defaults">
+    <LocalDebuggerWorkingDirectory>$(RootDir)Client\Data\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Client/Option/Option.vcxproj
+++ b/Client/Option/Option.vcxproj
@@ -187,6 +187,10 @@
   <ItemGroup>
     <CustomBuild Include="res\Option.rc2" />
   </ItemGroup>
+  <PropertyGroup Label="Debugger defaults">
+    <LocalDebuggerWorkingDirectory>$(RootDir)Client\Data\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -335,7 +335,7 @@
     <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
   <PropertyGroup Label="Debugger defaults">
-    <LocalDebuggerWorkingDirectory>..\Data\</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(RootDir)Client\Data\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
This was disabled very early on, presumably because of SDL. It was actually disabled in the initial commit, but it wasn't that way in the leaked source.

Additionally, fix the error message handling in JpegFile and set the VS debugger dir for all the client tools consistently; even the KscViewer has reason to be run from the client dir, since the KSCs are saved there.

Resolves #730