### PR TITLE
Avoid duplicate clang-format-check workflow runs

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,16 @@
 name: clang-format
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+    branches:
+    - master
+
+  merge_group: 
+  workflow_dispatch:
 
 jobs:
   formatting-check:


### PR DESCRIPTION
Currently this is invoked on every push and every pull request. As with the others, this should (primarily to address this) invoke only on pushes *to master* (and pull requests).

It will continue to invoke on the pull_request -> synchronize otherwise, so we don't need the duplicate events.