### PR TITLE
Invoke solution-specific workflows when the solution is changed

### DIFF
--- a/.github/workflows/build_msbuild_client.yml
+++ b/.github/workflows/build_msbuild_client.yml
@@ -12,6 +12,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_client.yml'
+      - 'Client.slnx'
 
   pull_request:
     branches:
@@ -19,6 +20,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_client.yml'
+      - 'Client.slnx'
 
   workflow_dispatch:
 

--- a/.github/workflows/build_msbuild_client_tools.yml
+++ b/.github/workflows/build_msbuild_client_tools.yml
@@ -12,6 +12,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_client_tools.yml'
+      - 'ClientTools.slnx'
 
   pull_request:
     branches:
@@ -19,6 +20,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_client_tools.yml'
+      - 'ClientTools.slnx'
  
   workflow_dispatch:
 

--- a/.github/workflows/build_msbuild_server.yml
+++ b/.github/workflows/build_msbuild_server.yml
@@ -12,6 +12,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_server.yml'
+      - 'Server.slnx'
 
   pull_request:
     branches:
@@ -19,6 +20,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_server.yml'
+      - 'Server.slnx'
 
   workflow_dispatch:
 

--- a/.github/workflows/build_msbuild_tools.yml
+++ b/.github/workflows/build_msbuild_tools.yml
@@ -12,6 +12,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_tools.yml'
+      - 'Tools.slnx'
 
   pull_request:
     branches:
@@ -19,6 +20,7 @@ on:
 
     paths:
       - '.github/workflows/build_msbuild_tools.yml'
+      - 'Tools.slnx'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Presently they're only invoked when the workflow changes, since everything is already built anyway. However, we do still need to verify that each solution is still behaving when those are changed.