### PR TITLE
SqlBuilder: Fix WHERE clause when explicitly specified

### DIFF
--- a/src/db-library/SqlBuilder.h
+++ b/src/db-library/SqlBuilder.h
@@ -85,7 +85,8 @@ public:
 
 		if (!Where.empty())
 		{
-			query += " " + Where;
+			query += " WHERE ";
+			query += Where;
 		}
 		else if (IsWherePK && !ModelType::PrimaryKey().empty())
 		{


### PR DESCRIPTION
`WHERE` wasn't supplied here. Given we use it for one case and expect it to be supplied, we'll supply it in the builder for consistency.