### PR TITLE
CMake: Expose server project include paths for tests

### DIFF
--- a/src/Server/AIServer/CMakeLists.txt
+++ b/src/Server/AIServer/CMakeLists.txt
@@ -75,6 +75,11 @@ target_link_libraries(AIServer PRIVATE
   AIServer.Core
 )
 
+# Expose include path
+target_include_directories(AIServer.Core INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../" # so we can access <AIServer/...>
+)
+
 # Setup warning levels
 target_compile_options(AIServer.Core PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3>

--- a/src/Server/Aujard/CMakeLists.txt
+++ b/src/Server/Aujard/CMakeLists.txt
@@ -40,6 +40,11 @@ target_link_libraries(Aujard PRIVATE
   Aujard.Core
 )
 
+# Expose include path
+target_include_directories(Aujard.Core INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../" # so we can access <Aujard/...>
+)
+
 # Setup warning levels
 target_compile_options(Aujard.Core PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3>

--- a/src/Server/Ebenezer/CMakeLists.txt
+++ b/src/Server/Ebenezer/CMakeLists.txt
@@ -88,6 +88,11 @@ target_link_libraries(Ebenezer PRIVATE
   Ebenezer.Core
 )
 
+# Expose include path
+target_include_directories(Ebenezer.Core INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../" # so we can access <Ebenezer/...>
+)
+
 # Setup warning levels
 target_compile_options(Ebenezer.Core PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3>

--- a/src/Server/ItemManager/CMakeLists.txt
+++ b/src/Server/ItemManager/CMakeLists.txt
@@ -39,6 +39,11 @@ target_link_libraries(ItemManager PRIVATE
   ItemManager.Core
 )
 
+# Expose include path
+target_include_directories(ItemManager.Core INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../" # so we can access <ItemManager/...>
+)
+
 # Setup warning levels
 target_compile_options(ItemManager.Core PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3>

--- a/src/Server/VersionManager/CMakeLists.txt
+++ b/src/Server/VersionManager/CMakeLists.txt
@@ -40,6 +40,11 @@ target_link_libraries(VersionManager PRIVATE
   VersionManager.Core
 )
 
+# Expose include path
+target_include_directories(VersionManager.Core INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../" # so we can access <VersionManager/...>
+)
+
 # Setup warning levels
 target_compile_options(VersionManager.Core PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3>


### PR DESCRIPTION
This will automatically expose the include paths to dependent projects. It's not really used by the main server apps, but will be used by test projects.

They'll be accessed like `<Ebenezer/...>`.