### PR TITLE
build: Minor tweaks and fixes

### DIFF
--- a/.github/workflows/build_cmake_all.yml
+++ b/.github/workflows/build_cmake_all.yml
@@ -60,24 +60,25 @@ jobs:
     - uses: lukka/get-cmake@latest
 
     - name: Configure CMake
-      shell: bash
+      shell: pwsh
       run: |
-        cmake -S . \
-          -B build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }} \
-          -G "Visual Studio 17 2022" \
-          -A ${{ matrix.BUILD_PLATFORM }} \
-          -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_CONFIGURATION }} \
+        cmake -S . `
+          -B build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }} `
+          -G "Visual Studio 17 2022" `
+          -A ${{ matrix.BUILD_PLATFORM }} `
+          -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_CONFIGURATION }} `
           -DOPENKO_FETCH_CLIENT_ASSETS=FALSE
 
     - name: Build all
-      shell: bash
+      shell: pwsh
       run: |
-        cmake \
-          --build build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }} \
-          --config ${{ matrix.BUILD_CONFIGURATION }}
+        cmake `
+          --build build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }} `
+          --config ${{ matrix.BUILD_CONFIGURATION }} `
+          --parallel
 
     - name: Run tests
-      shell: bash
+      shell: pwsh
       working-directory: build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }}
       run: |
         ctest -C "${{ matrix.BUILD_CONFIGURATION }}" --verbose
@@ -134,7 +135,8 @@ jobs:
         run: |
           cmake \
             --build build-${{ matrix.COMPILER }}-${{ matrix.BUILD_CONFIGURATION }} \
-            --config ${{ matrix.BUILD_CONFIGURATION }}
+            --config ${{ matrix.BUILD_CONFIGURATION }} \
+            --parallel
 
       - name: Run tests
         shell: bash
@@ -179,7 +181,8 @@ jobs:
         run: |
           cmake \
             --build build-${{ matrix.COMPILER }}-${{ matrix.BUILD_CONFIGURATION }} \
-            --config ${{ matrix.BUILD_CONFIGURATION }}
+            --config ${{ matrix.BUILD_CONFIGURATION }} \
+            --parallel
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/build_msbuild_all.yml
+++ b/.github/workflows/build_msbuild_all.yml
@@ -72,22 +72,22 @@ jobs:
 
     # NOTE: We could simply run All.sln, but it makes it far more obvious in the Github output when it's broken up across its solutions.
     - name: Build third party dependencies
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ThirdParty.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ThirdParty.slnx
 
     - name: Build client
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.slnx
 
     - name: Build server
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Server.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Server.slnx
 
     - name: Build tools
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tools.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tools.slnx
 
     - name: Build client tools
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ClientTools.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ClientTools.slnx
 
     - name: Build tests
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tests.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tests.slnx
 
     - name: Run tests - FileIO
       shell: cmd

--- a/.github/workflows/build_msbuild_client.yml
+++ b/.github/workflows/build_msbuild_client.yml
@@ -45,4 +45,4 @@ jobs:
 
     - name: Build client
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.slnx

--- a/.github/workflows/build_msbuild_client_tools.yml
+++ b/.github/workflows/build_msbuild_client_tools.yml
@@ -45,4 +45,4 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Build tools
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" ClientTools.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" ClientTools.slnx

--- a/.github/workflows/build_msbuild_server.yml
+++ b/.github/workflows/build_msbuild_server.yml
@@ -44,4 +44,4 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Build server
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" Server.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" Server.slnx

--- a/.github/workflows/build_msbuild_tools.yml
+++ b/.github/workflows/build_msbuild_tools.yml
@@ -44,4 +44,4 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Build tools
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" Tools.slnx
+      run: msbuild /m /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" Tools.slnx

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -5,9 +5,21 @@ on:
     branches:
     - master
 
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.inl'
+      
   pull_request:
     branches:
     - master
+
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.inl'
 
   merge_group: 
   workflow_dispatch:

--- a/Server.slnx
+++ b/Server.slnx
@@ -32,7 +32,9 @@
     </Project>
   </Folder>
   <Folder Name="/_deps/fetch wrappers/">
-    <Project Path="deps/fetch-and-build-wrappers/fetch-argparse.vcxproj" Id="61a124fb-035e-4560-8499-198c6299b7da" />
+    <Project Path="deps/fetch-and-build-wrappers/fetch-argparse.vcxproj" Id="61a124fb-035e-4560-8499-198c6299b7da">
+      <BuildDependency Project="deps/fetch-and-build-wrappers/sync-submodules.vcxproj" />
+    </Project>
     <Project Path="deps/fetch-and-build-wrappers/fetch-asio.vcxproj" Id="98f92112-9ec7-4f20-a6c3-a0346acb271c">
       <BuildDependency Project="deps/fetch-and-build-wrappers/sync-submodules.vcxproj" />
     </Project>

--- a/ThirdParty.slnx
+++ b/ThirdParty.slnx
@@ -4,6 +4,9 @@
     <Platform Name="x64" />
   </Configurations>
   <Folder Name="/fetch wrappers/">
+    <Project Path="deps/fetch-and-build-wrappers/fetch-argparse.vcxproj" Id="61a124fb-035e-4560-8499-198c6299b7da">
+      <BuildDependency Project="deps/fetch-and-build-wrappers/sync-submodules.vcxproj" />
+    </Project>
     <Project Path="deps/fetch-and-build-wrappers/fetch-asio.vcxproj" Id="98f92112-9ec7-4f20-a6c3-a0346acb271c">
       <BuildDependency Project="deps/fetch-and-build-wrappers/sync-submodules.vcxproj" />
     </Project>

--- a/src/Client/WarFare/StdAfx.h
+++ b/src/Client/WarFare/StdAfx.h
@@ -5,7 +5,6 @@
 
 #include <WinSock2.h>
 #include <N3Base/My_3DStruct.h>
-#include <filesystem>
 
 #if __has_include(<warfare_config.h>)
 #include <warfare_config.h>

--- a/src/N3Base/My_3DStruct.h
+++ b/src/N3Base/My_3DStruct.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <d3dx9.h>
-#include <string>
+
 #include <cinttypes>
 #include <cmath>
+#include <filesystem>
+#include <memory>
+#include <string>
 
 #include <spdlog/fmt/bundled/format.h>
 

--- a/src/N3Base/N3BaseFileAccess.h
+++ b/src/N3Base/N3BaseFileAccess.h
@@ -32,10 +32,12 @@ public:
 	int m_iLOD; // 로딩할때 쓸 LOD
 
 public:
+	// Full Path
 	const std::string& FileName() const
 	{
 		return m_szFileName;
-	} // Full Path
+	}
+
 	void FileNameSet(const std::string& szFileName);
 
 	bool LoadFromFile();                                                      // 파일에서 읽어오기.

--- a/src/N3Base/StdAfxBase.h
+++ b/src/N3Base/StdAfxBase.h
@@ -4,6 +4,5 @@
 #pragma once
 
 #include "My_3DStruct.h"
-#include <filesystem>
 
 #endif // N3BASE_STDAFX_H

--- a/src/Server/AIServer/pch.h
+++ b/src/Server/AIServer/pch.h
@@ -5,6 +5,8 @@
 
 #include <cassert>
 #include <filesystem>
+#include <memory>
+#include <string>
 
 #include <asio.hpp>
 

--- a/src/Server/Aujard/pch.h
+++ b/src/Server/Aujard/pch.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <filesystem>
 #include <memory>
 #include <string>

--- a/src/Server/Ebenezer/pch.h
+++ b/src/Server/Ebenezer/pch.h
@@ -3,10 +3,15 @@
 
 #pragma once
 
-#include <asio.hpp>
+#include <cassert>
+#include <filesystem>
+#include <memory>
+#include <string>
 
 #include <shared-server/server_config.h>
 #include <shared-server/utilities.h>
+
+#include <asio.hpp>
 
 #define myrand myrand_generic
 

--- a/src/Server/ItemManager/pch.h
+++ b/src/Server/ItemManager/pch.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#include <cassert>
+#include <filesystem>
+#include <memory>
+#include <string>
+
 #include <shared-server/server_config.h>
 #include <shared-server/utilities.h>
 

--- a/src/Server/VersionManager/pch.h
+++ b/src/Server/VersionManager/pch.h
@@ -3,9 +3,14 @@
 
 #pragma once
 
-#include <asio.hpp>
+#include <cassert>
+#include <filesystem>
+#include <memory>
+#include <string>
 
 #include <shared-server/server_config.h>
 #include <shared-server/utilities.h>
+
+#include <asio.hpp>
 
 #endif // SERVER_VERSIONMANAGER_PCH_H

--- a/src/Server/shared-server/pch.h
+++ b/src/Server/shared-server/pch.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cinttypes>
+#include <memory>
 
 #include <shared/globals.h>
 

--- a/src/Tools/N3CE/StdAfx.h
+++ b/src/Tools/N3CE/StdAfx.h
@@ -20,7 +20,6 @@
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
 #include <N3Base/My_3DStruct.h>
-#include <filesystem>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/Tools/N3FXE/StdAfx.h
+++ b/src/Tools/N3FXE/StdAfx.h
@@ -18,7 +18,7 @@
 #include <afxcmn.h>   // MFC support for Windows Common Controls
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
-#include <filesystem>
+#include <N3Base/My_3DStruct.h>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/Tools/N3ME/N3ME.vcxproj.filters
+++ b/src/Tools/N3ME/N3ME.vcxproj.filters
@@ -5,20 +5,14 @@
       <UniqueIdentifier>{ead71091-bc3a-4472-ac8b-4b4c56c3dd85}</UniqueIdentifier>
       <Extensions>ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe</Extensions>
     </Filter>
-    <Filter Include="N3Base">
-      <UniqueIdentifier>{42c09b20-dd07-49df-abad-1e9ce8b2e10d}</UniqueIdentifier>
+    <Filter Include="Controls">
+      <UniqueIdentifier>{4c9d7631-9a18-4f36-a4db-d12801456768}</UniqueIdentifier>
     </Filter>
-    <Filter Include="N3ME">
-      <UniqueIdentifier>{179c7f07-3ab0-4ac4-b46e-8bd0e8997937}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="N3ME\Frames">
-      <UniqueIdentifier>{da0a99d8-7b6c-4edc-9435-476582022933}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="N3ME\Dialogs">
+    <Filter Include="Dialogs">
       <UniqueIdentifier>{c5998c26-5519-4b59-9732-fc362f62c0f4}</UniqueIdentifier>
     </Filter>
-    <Filter Include="N3ME\Controls">
-      <UniqueIdentifier>{4c9d7631-9a18-4f36-a4db-d12801456768}</UniqueIdentifier>
+    <Filter Include="Frames">
+      <UniqueIdentifier>{da0a99d8-7b6c-4edc-9435-476582022933}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -37,455 +31,337 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MainFrm.cpp">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClCompile>
     <ClCompile Include="N3ME.cpp">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClCompile>
     <ClCompile Include="N3MEDoc.cpp">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClCompile>
     <ClCompile Include="N3MEView.cpp">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClCompile>
     <ClCompile Include="StdAfx.cpp">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClCompile>
     <ClCompile Include="BrushDlg.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgAddDTex.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgAddSoundGroup.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgBar.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgBase.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgBrowsePath.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgCtrlHeightScale.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgDelGroup.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgDTexGroupView.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgEditEvent.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgEditEventAttr.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgEditWarp.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgInputAttr.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgInputGroup.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgLight.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgLoadEvt.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgLoadNPCPath.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgLoadTileSet.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgMakeNPCPath.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgMakeWall.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgModifyDTex.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgPondProperty.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgRegenUser.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgRiverProperty.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSaveDivision.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSaveEvt.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSaveNewTileSet.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSaveNPCPath.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSceneGraph.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSetDTex.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSetLightMap.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSetSound.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgShapeList.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgSowSeed.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgTerrainSize.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="DlgUnusedFiles.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="..\Common Control\PropertyList.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="ShellTree.cpp">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="ProgressBar.cpp">
-      <Filter>N3ME\Controls</Filter>
+      <Filter>Controls</Filter>
     </ClCompile>
-    <ClCompile Include="DTex.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="DTexGroup.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="DTexGroupMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="DTexMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="EventCell.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="EventMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="LightObjMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="LyTerrain.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="MapMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="NPCPath.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="NPCPathMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="PondMesh.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="PondMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="PosDummy.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="QTNode.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="RegenUser.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="RiverMesh.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="RiverMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="RotDummy.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="ScaleDummy.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="SoundCell.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="SoundMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="TransDummy.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="VtxPosDummy.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="Wall.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="WallMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="WarpMgr.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="DlgMapView.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
-    <ClCompile Include="SowSeedMng.cpp">
-      <Filter>N3ME</Filter>
-    </ClCompile>
+    <ClCompile Include="DlgMapView.cpp" />
+    <ClCompile Include="DTex.cpp" />
+    <ClCompile Include="DTexGroup.cpp" />
+    <ClCompile Include="DTexGroupMng.cpp" />
+    <ClCompile Include="DTexMng.cpp" />
+    <ClCompile Include="EventCell.cpp" />
+    <ClCompile Include="EventMgr.cpp" />
+    <ClCompile Include="LightObjMgr.cpp" />
+    <ClCompile Include="LyTerrain.cpp" />
+    <ClCompile Include="MapMng.cpp" />
+    <ClCompile Include="NPCPath.cpp" />
+    <ClCompile Include="NPCPathMgr.cpp" />
+    <ClCompile Include="PondMesh.cpp" />
+    <ClCompile Include="PondMng.cpp" />
+    <ClCompile Include="PosDummy.cpp" />
+    <ClCompile Include="QTNode.cpp" />
+    <ClCompile Include="RegenUser.cpp" />
+    <ClCompile Include="RiverMesh.cpp" />
+    <ClCompile Include="RiverMng.cpp" />
+    <ClCompile Include="RotDummy.cpp" />
+    <ClCompile Include="ScaleDummy.cpp" />
+    <ClCompile Include="SoundCell.cpp" />
+    <ClCompile Include="SoundMgr.cpp" />
+    <ClCompile Include="SowSeedMng.cpp" />
+    <ClCompile Include="TransDummy.cpp" />
+    <ClCompile Include="VtxPosDummy.cpp" />
+    <ClCompile Include="Wall.cpp" />
+    <ClCompile Include="WallMgr.cpp" />
+    <ClCompile Include="WarpMgr.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MainFrm.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="N3ME.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="N3MEDoc.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="N3MEView.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="Resource.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="StdAfx.h">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ClInclude>
     <ClInclude Include="BrushDlg.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgAddDTex.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgAddSoundGroup.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgBar.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgBase.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgBrowsePath.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgCtrlHeightScale.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgDelGroup.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgDTexGroupView.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgEditEvent.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgEditEventAttr.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgEditWarp.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgInputAttr.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgInputGroup.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgLight.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgLoadEvt.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgLoadNPCPath.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgLoadTileSet.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgMakeNPCPath.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgMakeWall.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgModifyDTex.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgPondProperty.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgRegenUser.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgRiverProperty.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSaveDivision.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSaveEvt.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSaveNewTileSet.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSaveNPCPath.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSceneGraph.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSetDTex.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSetLightMap.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSetSound.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgShapeList.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgSowSeed.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgTerrainSize.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="DlgUnusedFiles.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="..\Common Control\PropertyList.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="ShellTree.h">
-      <Filter>N3ME\Dialogs</Filter>
+      <Filter>Dialogs</Filter>
     </ClInclude>
     <ClInclude Include="ProgressBar.h">
-      <Filter>N3ME\Controls</Filter>
+      <Filter>Controls</Filter>
     </ClInclude>
-    <ClInclude Include="DTex.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="DTexGroup.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="DTexGroupMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="DTexMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="EventCell.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="EventMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="LightObjMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="LyTerrain.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="LyTerrainDef.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="MapMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="NPCPath.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="NPCPathMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="PondMesh.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="PondMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="PosDummy.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="QTNode.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="RegenUser.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="RiverMesh.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="RiverMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="RotDummy.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="ScaleDummy.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="SoundCell.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="SoundMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="TransDummy.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="VtxPosDummy.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="Wall.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="WallMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="WarpMgr.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgMapView.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
-    <ClInclude Include="SowSeedMng.h">
-      <Filter>N3ME</Filter>
-    </ClInclude>
+    <ClInclude Include="DlgMapView.h" />
+    <ClInclude Include="DTex.h" />
+    <ClInclude Include="DTexGroup.h" />
+    <ClInclude Include="DTexGroupMng.h" />
+    <ClInclude Include="DTexMng.h" />
+    <ClInclude Include="EventCell.h" />
+    <ClInclude Include="EventMgr.h" />
+    <ClInclude Include="LightObjMgr.h" />
+    <ClInclude Include="LyTerrain.h" />
+    <ClInclude Include="LyTerrainDef.h" />
+    <ClInclude Include="MapMng.h" />
+    <ClInclude Include="NPCPath.h" />
+    <ClInclude Include="NPCPathMgr.h" />
+    <ClInclude Include="PondMesh.h" />
+    <ClInclude Include="PondMng.h" />
+    <ClInclude Include="PosDummy.h" />
+    <ClInclude Include="QTNode.h" />
+    <ClInclude Include="RegenUser.h" />
+    <ClInclude Include="RiverMesh.h" />
+    <ClInclude Include="RiverMng.h" />
+    <ClInclude Include="RotDummy.h" />
+    <ClInclude Include="ScaleDummy.h" />
+    <ClInclude Include="SoundCell.h" />
+    <ClInclude Include="SoundMgr.h" />
+    <ClInclude Include="SowSeedMng.h" />
+    <ClInclude Include="TransDummy.h" />
+    <ClInclude Include="VtxPosDummy.h" />
+    <ClInclude Include="Wall.h" />
+    <ClInclude Include="WallMgr.h" />
+    <ClInclude Include="WarpMgr.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="N3ME.rc">
-      <Filter>N3ME\Frames</Filter>
+      <Filter>Frames</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Tools/N3ME/StdAfx.h
+++ b/src/Tools/N3ME/StdAfx.h
@@ -19,7 +19,6 @@
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
 #include <N3Base/My_3DStruct.h>
-#include <filesystem>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/Tools/N3Viewer/StdAfx.h
+++ b/src/Tools/N3Viewer/StdAfx.h
@@ -19,7 +19,7 @@
 #include <afxcmn.h>   // MFC support for Windows Common Controls
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
-#include <filesystem>
+#include <N3Base/My_3DStruct.h>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/Tools/SkyViewer/StdAfx.h
+++ b/src/Tools/SkyViewer/StdAfx.h
@@ -18,7 +18,7 @@
 #include <afxcmn.h>   // MFC support for Windows Common Controls
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
-#include <filesystem>
+#include <N3Base/My_3DStruct.h>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/Tools/UIE/StdAfx.h
+++ b/src/Tools/UIE/StdAfx.h
@@ -19,7 +19,7 @@
 #include <afxcmn.h>   // MFC support for Windows Common Controls
 #endif                // _AFX_NO_AFXCMN_SUPPORT
 
-#include <filesystem>
+#include <N3Base/My_3DStruct.h>
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.


### PR DESCRIPTION
* Server.slnx: Ensure fetch-argparse depends on sync-submodules for the base lock

* ThirdParty.slnx: Add fetch-argparse here just to pre-emptively fetch it and not pollute build times. Ordinarily we add things here to have them excluded by CodeQL's scan, but this is header-only so it doesn't really matter here -- the only thing it's doing is inflating the build time associated with the server when it fetches the repo within the workflow.

* Restore parallel builds in workflows. I disabled this likely due to CPU starvation causing slower build times, but testing it now, it seems fine enough.

* Use Powershell for the Windows shell, not bash. bash can inherit paths that we don't intend.

* Only bother to apply the format check when we change source files that are checked (though we only roughly care about the extensions we actually use, not all that's checked).

* Tidy up N3ME's filters; this used to be one of the couple of tools that included N3Base source files directly. Only the empty folder remained - which has now been removed - and I shifted N3ME/* back up a level since there's no longer any need for separation.

* Ensure all tools add <N3Base/My_3DStruct.h> to their PCH for consistent PCH.

* Update server PCH to include common standard headers.

I avoid going too far with PCH, like adding N3UIBase.h for the client, even though most files reference it, simply because it starts to cause bad design issues (since it already exists in scope, we don't tend to think to include it, so anything that needs it and doesn't use PCH is confused because the original author never thought to include it directly).

It also just doesn't help that much more than it already is so it's generally not worth it.