### PR TITLE
CMake: Use Ninja for Windows/MSVC builds

### DIFF
--- a/.github/workflows/build_cmake_all.yml
+++ b/.github/workflows/build_cmake_all.yml
@@ -13,7 +13,7 @@ on:
     # This specifically builds when anything relating to a build changes.
     # Everything else can be ignored.
     paths:
-      - '.github/workflows/build_cmake.yml'
+      - '.github/workflows/build_cmake_all.yml'
       - '**/CMakeLists.txt'
       - '**/*.cmake'
       - '**/*.cpp'
@@ -28,7 +28,7 @@ on:
     # This specifically builds when anything relating to a build changes.
     # Everything else can be ignored.
     paths:
-      - '.github/workflows/build_cmake.yml'
+      - '.github/workflows/build_cmake_all.yml'
       - '**/CMakeLists.txt'
       - '**/*.cmake'
       - '**/*.cpp'
@@ -57,6 +57,8 @@ jobs:
       with:
         submodules: 'false'
 
+    - uses: ilammy/msvc-dev-cmd@v1
+
     - uses: lukka/get-cmake@latest
 
     - name: Configure CMake
@@ -64,8 +66,7 @@ jobs:
       run: |
         cmake -S . `
           -B build-windows-${{ matrix.BUILD_CONFIGURATION }}-${{ matrix.BUILD_PLATFORM }} `
-          -G "Visual Studio 17 2022" `
-          -A ${{ matrix.BUILD_PLATFORM }} `
+          -G "Ninja" `
           -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_CONFIGURATION }} `
           -DOPENKO_FETCH_CLIENT_ASSETS=FALSE
 

--- a/src/Client/KscViewer/CMakeLists.txt
+++ b/src/Client/KscViewer/CMakeLists.txt
@@ -20,10 +20,6 @@ add_executable(KscViewer
 if(WIN32)
   set_target_properties(KscViewer PROPERTIES WIN32_EXECUTABLE TRUE)
   target_sources(KscViewer PRIVATE KscViewer.rc)
-  target_compile_definitions(KscViewer PRIVATE
-    "_UNICODE"
-    "UNICODE"
-  )
 endif()
 
 # Enable warnings as errors

--- a/src/Client/Launcher/CMakeLists.txt
+++ b/src/Client/Launcher/CMakeLists.txt
@@ -36,10 +36,6 @@ if(WIN32)
     Launcher.rc
     res/Launcher.rc2
     res/Launcher.ico)
-  target_compile_definitions(Launcher PRIVATE
-    "_UNICODE"
-    "UNICODE"
-  )
 endif()
 
 # Enable warnings as errors

--- a/src/Client/Launcher/Launcher.vcxproj
+++ b/src/Client/Launcher/Launcher.vcxproj
@@ -25,7 +25,6 @@
   <Import Project="..\..\..\props\platform_root.props" />
   <PropertyGroup Label="Configuration">
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Client/Launcher/LauncherDlg.cpp
+++ b/src/Client/Launcher/LauncherDlg.cpp
@@ -141,24 +141,20 @@ BOOL CLauncherDlg::OnInitDialog()
 	}
 
 	// 소켓 접속..
-	TCHAR szIniPath[_MAX_PATH] {};
-	::GetCurrentDirectory(_MAX_PATH, szIniPath);
-	lstrcat(szIniPath, _T("\\Server.Ini"));
-	int iServerCount = GetPrivateProfileInt(_T("Server"), _T("Count"), 0, szIniPath);
+	char szIniPath[_MAX_PATH] {};
+	::GetCurrentDirectoryA(_MAX_PATH, szIniPath);
+	lstrcatA(szIniPath, "\\Server.Ini");
+	int iServerCount = GetPrivateProfileIntA("Server", "Count", 0, szIniPath);
 
 	std::vector<std::string> ips;
 	ips.reserve(iServerCount);
 	for (int i = 0; i < iServerCount; i++)
 	{
-		TCHAR szKey[32] {}, szIP[128] {};
-		char szIPA[128] {};
+		char szKey[32] {}, szIP[128] {};
 
-		_stprintf(szKey, _T("IP%d"), i);
-		GetPrivateProfileString(_T("Server"), szKey, _T(""), szIP, _countof(szIP), szIniPath);
-
-		// Just a hack for now; we should be able to trust IPs and hostnames to not be too special.
-		sprintf(szIPA, "%ls", szIP);
-		ips.push_back(szIPA);
+		snprintf(szKey, sizeof(szKey), "IP%d", i);
+		GetPrivateProfileStringA("Server", szKey, "", szIP, sizeof(szIP), szIniPath);
+		ips.push_back(szIP);
 	}
 
 	if (iServerCount > 0)

--- a/src/Client/Option/CMakeLists.txt
+++ b/src/Client/Option/CMakeLists.txt
@@ -14,10 +14,6 @@ add_executable(Option
 if(WIN32)
   set_target_properties(Option PROPERTIES WIN32_EXECUTABLE TRUE)
   target_sources(Option PRIVATE Option.rc)
-  target_compile_definitions(Option PRIVATE
-    "_UNICODE"
-    "UNICODE"
-  )
 endif()
 
 # Enable warnings as errors

--- a/src/Client/Option/Option.vcxproj
+++ b/src/Client/Option/Option.vcxproj
@@ -25,7 +25,6 @@
   <Import Project="..\..\..\props\platform_root.props" />
   <PropertyGroup Label="Configuration">
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Client/ZipArchive/CMakeLists.txt
+++ b/src/Client/ZipArchive/CMakeLists.txt
@@ -20,13 +20,6 @@ add_library(ZipArchive STATIC
   ZipStorage.cpp
   ZipStorage.h)
 
-if(WIN32)
-  target_compile_definitions(ZipArchive PRIVATE
-    "_UNICODE"
-    "UNICODE"
-  )
-endif()
-
 # Enable warnings as errors
 if(OPENKO_COMPILE_WARNINGS_AS_ERROR)
   set_property(TARGET ZipArchive PROPERTY COMPILE_WARNING_AS_ERROR ON)

--- a/src/Client/ZipArchive/ZipArchive.vcxproj
+++ b/src/Client/ZipArchive/ZipArchive.vcxproj
@@ -26,22 +26,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/AIServer/AIServer.Core.vcxproj
+++ b/src/Server/AIServer/AIServer.Core.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <OutDir>$(StaticLibDir)\</OutDir>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/AIServer/AIServer.vcxproj
+++ b/src/Server/AIServer/AIServer.vcxproj
@@ -23,9 +23,6 @@
     <ProjectGuid>{7F0E559A-7F03-4AD8-B1BE-EFAFF6797178}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
-  <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/src/Server/Aujard/Aujard.Core.vcxproj
+++ b/src/Server/Aujard/Aujard.Core.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <OutDir>$(StaticLibDir)\</OutDir>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/Aujard/Aujard.vcxproj
+++ b/src/Server/Aujard/Aujard.vcxproj
@@ -23,9 +23,6 @@
     <ProjectGuid>{F0440138-6168-4EB6-B4D0-195BEFCDED40}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
-  <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/src/Server/Ebenezer/Ebenezer.Core.vcxproj
+++ b/src/Server/Ebenezer/Ebenezer.Core.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <OutDir>$(StaticLibDir)\</OutDir>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/Ebenezer/Ebenezer.vcxproj
+++ b/src/Server/Ebenezer/Ebenezer.vcxproj
@@ -23,9 +23,6 @@
     <ProjectGuid>{7025A37A-BD1F-432E-BBF7-05591DC159DA}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
-  <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/src/Server/ItemManager/ItemManager.Core.vcxproj
+++ b/src/Server/ItemManager/ItemManager.Core.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <OutDir>$(StaticLibDir)\</OutDir>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/ItemManager/ItemManager.vcxproj
+++ b/src/Server/ItemManager/ItemManager.vcxproj
@@ -23,9 +23,6 @@
     <ProjectGuid>{2F8D19F8-5AB6-4AEA-8C56-24C7B103E47E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
-  <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/src/Server/VersionManager/VersionManager.Core.vcxproj
+++ b/src/Server/VersionManager/VersionManager.Core.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <OutDir>$(StaticLibDir)\</OutDir>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Server/VersionManager/VersionManager.vcxproj
+++ b/src/Server/VersionManager/VersionManager.vcxproj
@@ -23,9 +23,6 @@
     <ProjectGuid>{B73A7541-1A9B-474C-A37B-725AC3CA7056}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
-  <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/src/Tools/TblEditor/CMakeLists.txt
+++ b/src/Tools/TblEditor/CMakeLists.txt
@@ -24,10 +24,6 @@ if(WIN32)
     TblEditor.rc
     res/TblEditor.rc2
     res/TblEditor.ico)
-  target_compile_definitions(TblEditor PRIVATE
-    "_UNICODE"
-    "UNICODE"
-  )
 endif()
 
 # Enable warnings as errors

--- a/src/Tools/TblEditor/TblEditor.vcxproj
+++ b/src/Tools/TblEditor/TblEditor.vcxproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
   <Import Project="..\..\..\props\platform_root.props" />
   <PropertyGroup Label="Configuration">
-    <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
The MSVC generator is very limited and doesn't support a lot of the global options. Ninja is a safer more consistent choice, and will still use MSVC underneath (with the build environment setup).

Unfortunately, the mixed Unicode/MultiByte usage confuses the Ninja builds. As such, we will keep the codebase consistently MultiByte as it makes up the core of the codebase, and the codebase is moving away from Windows anyway.