### PR TITLE
Auto-cancel old GitHub workflows

### DIFF
--- a/.github/workflows/build_cmake_all.yml
+++ b/.github/workflows/build_cmake_all.yml
@@ -39,7 +39,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build_msbuild_all.yml
+++ b/.github/workflows/build_msbuild_all.yml
@@ -46,7 +46,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_msbuild_client.yml
+++ b/.github/workflows/build_msbuild_client.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_msbuild_client_tools.yml
+++ b/.github/workflows/build_msbuild_client_tools.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 # These should really be moved into the one solution.

--- a/.github/workflows/build_msbuild_server.yml
+++ b/.github/workflows/build_msbuild_server.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_msbuild_tools.yml
+++ b/.github/workflows/build_msbuild_tools.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref || github.run_id }}"
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
On subsequent pushes, this will cancel existing running workflows, so only the latest will bother to be checked.