### PR TITLE
Green line under clan leaders name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ last-build-states/
 
 # Do not ignore CMakeLists.txt
 !CMakeLists.txt
+/deps/nanodbc
+/deps/zlib

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,3 @@ last-build-states/
 
 # Do not ignore CMakeLists.txt
 !CMakeLists.txt
-/deps/nanodbc
-/deps/zlib

--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -422,10 +422,11 @@ struct __InfoPlayerOther
 	int iFace;             // Face type
 	int iHair;             // Hair type
 
-	int iCity;             // Affiliated city
-	std::string szKnights; // Clan name
-	int iKnightsGrade;     // Clan grade
-	int iKnightsRank;      // Clan ranking
+	int iCity;					// Affiliated city
+	std::string szKnights;		// Clan name
+	int iKnightsGrade;			// Clan grade
+	int iKnightsRank;			// Clan ranking
+	e_KnightsDuty eKnightsDuty; // Clan role/duty
 
 	int iRank;             // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
 	int iTitle;            // Bitmask representing various titles/roles including:
@@ -443,6 +444,7 @@ struct __InfoPlayerOther
 		iCity         = 0;
 		iKnightsGrade = 0;
 		iKnightsRank  = 0;
+		eKnightsDuty  = KNIGHTS_DUTY_UNKNOWN;
 		iTitle        = 0;
 
 		szKnights.clear();
@@ -467,7 +469,6 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther
 	int64_t iExp;
 	int iRealmPoint;            // National Points
 	int iRealmPointMonthly;     // Monthly National Points
-	e_KnightsDuty eKnightsDuty; // Clan member position/role/duty
 	int iWeightMax;             // Max weight
 	int iWeight;                // Current weight
 	int iStrength;              // Strength
@@ -529,7 +530,6 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther
 		iExp                     = 0;
 		iRealmPoint              = 0;
 		iRealmPointMonthly       = 0;
-		eKnightsDuty             = KNIGHTS_DUTY_UNKNOWN;
 		iWeightMax               = 0;
 		iWeight                  = 0;
 		iStrength                = 0;

--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -419,18 +419,18 @@ struct __TABLE_PLAYER;
 
 struct __InfoPlayerOther
 {
-	int iFace;             // Face type
-	int iHair;             // Hair type
+	int iFace;                  // Face type
+	int iHair;                  // Hair type
 
-	int iCity;					// Affiliated city
-	std::string szKnights;		// Clan name
-	int iKnightsGrade;			// Clan grade
-	int iKnightsRank;			// Clan ranking
+	int iCity;                  // Affiliated city
+	std::string szKnights;      // Clan name
+	int iKnightsGrade;          // Clan grade
+	int iKnightsRank;           // Clan ranking
 	e_KnightsDuty eKnightsDuty; // Clan role/duty
 
-	int iRank;             // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
-	int iTitle;            // Bitmask representing various titles/roles including:
-						   // Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
+	int iRank;                  // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
+	int iTitle;                 // Bitmask representing various titles/roles including:
+								// Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
 
 	__InfoPlayerOther()
 	{
@@ -467,42 +467,42 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther
 	int iGold;
 	int64_t iExpNext;
 	int64_t iExp;
-	int iRealmPoint;            // National Points
-	int iRealmPointMonthly;     // Monthly National Points
-	int iWeightMax;             // Max weight
-	int iWeight;                // Current weight
-	int iStrength;              // Strength
-	int iStrength_Delta;        // Bonus strength
-	int iStamina;               // Stamina
-	int iStamina_Delta;         // Bonus stamina
-	int iDexterity;             // Dexterity
-	int iDexterity_Delta;       // Bonus dexterity
-	int iIntelligence;          // Intelligence
-	int iIntelligence_Delta;    // Bonus intelligence
-	int iMagicAttak;            // Charisma/Magic Power
-	int iMagicAttak_Delta;      // Bonus Charisma/Magic Power
+	int iRealmPoint;         // National Points
+	int iRealmPointMonthly;  // Monthly National Points
+	int iWeightMax;          // Max weight
+	int iWeight;             // Current weight
+	int iStrength;           // Strength
+	int iStrength_Delta;     // Bonus strength
+	int iStamina;            // Stamina
+	int iStamina_Delta;      // Bonus stamina
+	int iDexterity;          // Dexterity
+	int iDexterity_Delta;    // Bonus dexterity
+	int iIntelligence;       // Intelligence
+	int iIntelligence_Delta; // Bonus intelligence
+	int iMagicAttak;         // Charisma/Magic Power
+	int iMagicAttak_Delta;   // Bonus Charisma/Magic Power
 
-	int iAttack;                // Attack Power
-	int iAttack_Delta;          // Bonus Attack Power
-	int iGuard;                 // Defense
-	int iGuard_Delta;           // Bonus Defense
+	int iAttack;             // Attack Power
+	int iAttack_Delta;       // Bonus Attack Power
+	int iGuard;              // Defense
+	int iGuard_Delta;        // Bonus Defense
 
-	int iRegistFire;            // Fire resistance
-	int iRegistFire_Delta;      // Bonus fire resistance
-	int iRegistCold;            // Cold resistance
-	int iRegistCold_Delta;      // Bonus cold resistance
-	int iRegistLight;           // Lightning resistance
-	int iRegistLight_Delta;     // Bonus lightning resistance
-	int iRegistMagic;           // Magic resistance
-	int iRegistMagic_Delta;     // Bonus magic resistance
-	int iRegistCurse;           // Curse resistance
-	int iRegistCurse_Delta;     // Bonus curse resistance
-	int iRegistPoison;          // Poison resistance
-	int iRegistPoison_Delta;    // Bonus poison resistance
+	int iRegistFire;         // Fire resistance
+	int iRegistFire_Delta;   // Bonus fire resistance
+	int iRegistCold;         // Cold resistance
+	int iRegistCold_Delta;   // Bonus cold resistance
+	int iRegistLight;        // Lightning resistance
+	int iRegistLight_Delta;  // Bonus lightning resistance
+	int iRegistMagic;        // Magic resistance
+	int iRegistMagic_Delta;  // Bonus magic resistance
+	int iRegistCurse;        // Curse resistance
+	int iRegistCurse_Delta;  // Bonus curse resistance
+	int iRegistPoison;       // Poison resistance
+	int iRegistPoison_Delta; // Bonus poison resistance
 
-	int iZoneInit;              // Initial Zone ID received from the server
-	int iZoneCur;               // Current zone ID
-	int iVictoryNation;         // Last war outcome - 0: Draw, 1: El Morad victory, 2: Karus victory
+	int iZoneInit;           // Initial Zone ID received from the server
+	int iZoneCur;            // Current zone ID
+	int iVictoryNation;      // Last war outcome - 0: Draw, 1: El Morad victory, 2: Karus victory
 
 	e_ZoneAbilityType eZoneAbilityType;
 	bool bCanTradeWithOtherNation;

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -2538,7 +2538,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 
 	// 기사단 관련
 	int iKnightsID   = pkt.read<int16_t>();                               // 기사단 ID
-	/*e_KnightsDuty eKnightsDuty = (e_KnightsDuty)*/ pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
+	e_KnightsDuty eKnightsDuty = (e_KnightsDuty) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
 
 	/*int16_t sAllianceID      =*/pkt.read<int16_t>();
 
@@ -2632,6 +2632,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
 	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	pUPC->m_InfoExt.eKnightsDuty = eKnightsDuty;
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1884,7 +1884,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 	std::string szKnightsName               = "";
 	int iKnightsID                          = pkt.read<int16_t>();                 // 소속 기사단 ID
-	e_KnightsDuty eKnightsDuty              = (e_KnightsDuty) pkt.read<uint8_t>(); // 기사단에서의 권한..
+	e_KnightsDuty eKnightsDuty              = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 기사단에서의 권한..
 
 																				   // NOTE(srmeier): adding alliance ID and knight's byFlag
 	/*int iAllianceID                       =*/pkt.read<int16_t>();
@@ -1899,8 +1899,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	/*int16_t sCapeID                 =*/pkt.read<int16_t>();
 
 	// 기사단 관련 세팅..
-	s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
-	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	// s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
+	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank, eKnightsDuty);
 	m_pUIVar->UpdateKnightsInfo();
 
 	s_pPlayer->m_InfoBase.iHPMax             = pkt.read<int16_t>();
@@ -2538,7 +2538,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 
 	// 기사단 관련
 	int iKnightsID   = pkt.read<int16_t>();                               // 기사단 ID
-	e_KnightsDuty eKnightsDuty = (e_KnightsDuty) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
+	e_KnightsDuty eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 소속 국가. 0 이면 없다. 1
 
 	/*int16_t sAllianceID      =*/pkt.read<int16_t>();
 
@@ -2631,8 +2631,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->m_InfoBase.iAuthority = byAuthority;
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
-	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
-	pUPC->m_InfoExt.eKnightsDuty = eKnightsDuty;
+	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank, eKnightsDuty);
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);
@@ -6367,8 +6366,7 @@ void CGameProcMain::MsgRecv_Knights(Packet& pkt)
 					break;
 			}
 
-			s_pPlayer->m_InfoExt.eKnightsDuty = KNIGHTS_DUTY_UNKNOWN;
-			s_pPlayer->KnightsInfoSet(0, "", 0, 0);
+			s_pPlayer->KnightsInfoSet(0, "", 0, 0, KNIGHTS_DUTY_UNKNOWN);
 			m_pUIVar->UpdateKnightsInfo();
 		}
 		break;
@@ -6887,8 +6885,7 @@ void CGameProcMain::MsgRecv_Knights_Create(Packet& pkt)
 					m_pSubProcPerTrade->m_pUIPerTradeDlg->GoldUpdate();
 
 				//기사단(클랜)UI업데이트...해라...
-				s_pPlayer->m_InfoExt.eKnightsDuty = KNIGHTS_DUTY_CHIEF;
-				s_pPlayer->KnightsInfoSet(iID, szID, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szID, iGrade, iRank, KNIGHTS_DUTY_CHIEF);
 				m_pUIVar->UpdateKnightsInfo();
 
 				if (m_pUIVar->m_pPageKnights->IsVisible())
@@ -6946,7 +6943,7 @@ void CGameProcMain::MsgRecv_Knights_Withdraw(Packet& pkt)
 			if (s_pPlayer->IDNumber() == sid)
 			{
 				s_pPlayer->m_InfoBase.iKnightsID  = pkt.read<int16_t>();
-				s_pPlayer->m_InfoExt.eKnightsDuty = (e_KnightsDuty) pkt.read<uint8_t>();
+				s_pPlayer->m_InfoExt.eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
 				m_pUIVar->UpdateKnightsInfo();
 
 				s_pPlayer->KnightsInfoSet(s_pPlayer->m_InfoBase.iKnightsID, "", 0, 0);
@@ -7022,8 +7019,7 @@ void CGameProcMain::MsgRecv_Knights_Join(Packet& pkt)
 
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
-				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank, eDuty);
 				m_pUIVar->UpdateKnightsInfo();
 
 				szMsg = fmt::format_text_resource(IDS_CLAN_JOIN_SUCCESS);
@@ -7121,8 +7117,7 @@ void CGameProcMain::MsgRecv_Knights_Leave(Packet& pkt)
 
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
-				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank, eDuty);
 				m_pUIVar->UpdateKnightsInfo();
 
 				szMsg = fmt::format_text_resource(IDS_CLAN_JOIN_SUCCESS);
@@ -7344,7 +7339,7 @@ void CGameProcMain::MsgRecv_Knights_Duty_Change(Packet& pkt)
 		{
 			int sid             = pkt.read<int16_t>();
 			int iID             = pkt.read<int16_t>();
-			e_KnightsDuty eDuty = (e_KnightsDuty) pkt.read<uint8_t>();
+			e_KnightsDuty eDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
 
 			if (s_pPlayer->IDNumber() == sid)
 			{

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -504,7 +504,7 @@ void CGameProcMain::Tick()
 			CPlayerNPC* pNPC = it->second;
 
 			CLogWriter::Write("    ID({}) Name({}) Pos({:.1f}, {:.1f})", pNPC->IDNumber(), pNPC->IDString(), pNPC->m_vPosFromServer.x,
-				pNPC->m_vPosFromServer.z);
+							  pNPC->m_vPosFromServer.z);
 		}
 	}
 #endif
@@ -872,7 +872,8 @@ bool CGameProcMain::ProcessPacket(Packet& pkt)
 				fY = fYObject;
 			this->InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 			s_pFX->TriggerBundle(s_pPlayer->IDNumber(), -1,
-				s_pPlayer->m_InfoBase.eNation == NATION_KARUS ? FXID_WARP_KARUS : FXID_WARP_ELMORAD, s_pPlayer->IDNumber(), -1, 0);
+								 s_pPlayer->m_InfoBase.eNation == NATION_KARUS ? FXID_WARP_KARUS : FXID_WARP_ELMORAD, s_pPlayer->IDNumber(),
+								 -1, 0);
 		}
 			return true;
 		case WIZ_MOVE:
@@ -1460,14 +1461,14 @@ void CGameProcMain::MsgSend_Continous() // 특정 조건(?)하에서 서버에�
 //
 //////////////////////////////////////////////////////////////////////
 
-void CGameProcMain::MsgSend_Attack(
-	int iTargetID, float fInterval, float fDistance) // 공격 패킷 날리기 - 테이블의 공격 주기를 같이 줘서 해킹을 막는다.
+void CGameProcMain::MsgSend_Attack(int iTargetID, float fInterval,
+								   float fDistance) // 공격 패킷 날리기 - 테이블의 공격 주기를 같이 줘서 해킹을 막는다.
 {
 	if (s_pPlayer->m_fTimeAfterDeath > 0 || s_pPlayer->IsDead())
-		return;                                      // 죽은 넘이다..
+		return;                                     // 죽은 넘이다..
 
-	uint8_t byBuff[32];                              // 버퍼..
-	int iOffset       = 0;                           // 옵셋..
+	uint8_t byBuff[32];                             // 버퍼..
+	int iOffset       = 0;                          // 옵셋..
 
 	uint8_t bySuccess = true;
 
@@ -1671,8 +1672,9 @@ bool CGameProcMain::MsgSend_PartyOrForceCreate(const std::string& szID)
 	if (m_pUIPartyOrForce->MemberCount() <= 0) // 처음 생성하는 경우...
 	{
 		m_pUIPartyOrForce->MemberAdd(s_pPlayer->IDNumber(), s_pPlayer->IDString(), s_pPlayer->m_InfoBase.iLevel,
-			s_pPlayer->m_InfoBase.eClass, s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax, s_pPlayer->m_InfoExt.iMSP,
-			s_pPlayer->m_InfoExt.iMSPMax); // 내건 미리 넣어 놓는다..
+									 s_pPlayer->m_InfoBase.eClass, s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax,
+									 s_pPlayer->m_InfoExt.iMSP,
+									 s_pPlayer->m_InfoExt.iMSPMax); // 내건 미리 넣어 놓는다..
 	}
 
 	return true;
@@ -1862,7 +1864,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	if (pLooks == nullptr)
 	{
 		CLogWriter::Write("CGameProcMain::MsgRecv_MyInfo_All : failed find character resource data (Race : {})",
-			static_cast<int>(s_pPlayer->m_InfoBase.eRace));
+						  static_cast<int>(s_pPlayer->m_InfoBase.eRace));
 	}
 	__ASSERT(pLooks, "failed find character resource data");
 	s_pPlayer->InitChr(pLooks); // 관절 세팅..
@@ -1883,10 +1885,10 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	s_pPlayer->m_InfoExt.iCity              = pkt.read<uint8_t>();
 
 	std::string szKnightsName               = "";
-	int iKnightsID                          = pkt.read<int16_t>();                 // 소속 기사단 ID
+	int iKnightsID                          = pkt.read<int16_t>();                             // 소속 기사단 ID
 	e_KnightsDuty eKnightsDuty              = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 기사단에서의 권한..
 
-																				   // NOTE(srmeier): adding alliance ID and knight's byFlag
+	// NOTE(srmeier): adding alliance ID and knight's byFlag
 	/*int iAllianceID                       =*/pkt.read<int16_t>();
 	/*uint8_t byFlag                        =*/pkt.read<uint8_t>();
 
@@ -2033,8 +2035,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 		e_PartPosition ePart = PART_POS_UNKNOWN;
 		e_PlugPosition ePlug = PLUG_POS_UNKNOWN;
-		e_ItemType eType     = MakeResrcFileNameForUPC(
-            pItem, pItemExt, &szResrcFN, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType     = MakeResrcFileNameForUPC(pItem, pItemExt, &szResrcFN, &szIconFN, ePart, ePlug,
+													   s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
 		if (ITEM_TYPE_UNKNOWN == eType)
 			CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item Type");
@@ -2117,8 +2119,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 		e_PartPosition ePart = PART_POS_UNKNOWN;
 		e_PlugPosition ePlug = PLUG_POS_UNKNOWN;
-		e_ItemType eType     = MakeResrcFileNameForUPC(
-            pItem, pItemExt, nullptr, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType     = MakeResrcFileNameForUPC(pItem, pItemExt, nullptr, &szIconFN, ePart, ePlug,
+													   s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
 		if (ITEM_TYPE_UNKNOWN == eType)
 			CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
@@ -2534,10 +2536,10 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	int iNameLen = pkt.read<uint8_t>();
 	pkt.readString(szName, iNameLen);
 
-	e_Nation eNation = (e_Nation) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
+	e_Nation eNation           = (e_Nation) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
 
 	// 기사단 관련
-	int iKnightsID   = pkt.read<int16_t>();                               // 기사단 ID
+	int iKnightsID             = pkt.read<int16_t>();                             // 기사단 ID
 	e_KnightsDuty eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 소속 국가. 0 이면 없다. 1
 
 	/*int16_t sAllianceID      =*/pkt.read<int16_t>();
@@ -3492,8 +3494,8 @@ bool CGameProcMain::MsgRecv_UserLookChange(Packet& pkt)
 			__TABLE_PLAYER_LOOKS* pLooks = s_pTbl_UPC_Looks.Find(pUPC->m_InfoBase.eRace); // User Player Character Skin 구조체 포인터..
 			if (nullptr == pLooks)
 			{
-				CLogWriter::Write(
-					"CGameProcMain::MsgRecv_UserLookChange() - failed find table : Race ({})", static_cast<int>(pUPC->m_InfoBase.eRace));
+				CLogWriter::Write("CGameProcMain::MsgRecv_UserLookChange() - failed find table : Race ({})",
+								  static_cast<int>(pUPC->m_InfoBase.eRace));
 				__ASSERT(pLooks, "failed find table");
 			}
 			else
@@ -3810,8 +3812,8 @@ void CGameProcMain::MsgRecv_MyInfo_RealmPoint(Packet& pkt)
 
 		if (m_pUIVar->m_pPageState != nullptr)
 		{
-			m_pUIVar->m_pPageState->UpdateRealmPoint(
-				s_pPlayer->m_InfoExt.iRealmPoint, s_pPlayer->m_InfoExt.iRealmPointMonthly); // 국가 기여도는 10을 나누어서 표시
+			m_pUIVar->m_pPageState->UpdateRealmPoint(s_pPlayer->m_InfoExt.iRealmPoint,
+													 s_pPlayer->m_InfoExt.iRealmPointMonthly); // 국가 기여도는 10을 나누어서 표시
 		}
 	}
 	else if (opcode == LOYALTY_CHANGE_MANNER)
@@ -4452,7 +4454,7 @@ void CGameProcMain::InitZone(int iZone, const __Vector3& vPosPlayer)
 		CommandToggleMoveContinous();
 
 		CLogWriter::Write("CGameProcMain::InitZone -> Zone Change ({} -> {}) Position({:.1f}, {:.1f}, {:.1f})", iZonePrev, iZone,
-			vPosPlayer.x, vPosPlayer.y, vPosPlayer.z);
+						  vPosPlayer.x, vPosPlayer.y, vPosPlayer.z);
 
 		m_bLoadComplete = false; // 로딩 끝남..
 		m_pMagicSkillMng->ClearDurationalMagic();
@@ -6124,8 +6126,8 @@ void CGameProcMain::UpdateUI_PartyOrForceButtons()
 		m_pUICmd->UpdatePartyButtons(bIAmLeader, bIAmMemberOfParty, iMemberIndex, pTarget);
 }
 
-const __InfoPartyOrForce* CGameProcMain::PartyOrForceConditionGet(
-	bool& bIAmLeader, bool& bIAmMember, int& iMemberIndex, class CPlayerBase*& pTarget)
+const __InfoPartyOrForce* CGameProcMain::PartyOrForceConditionGet(bool& bIAmLeader, bool& bIAmMember, int& iMemberIndex,
+																  class CPlayerBase*& pTarget)
 {
 	// 파티 버튼 상태 바꾸기..
 	bIAmLeader   = false;
@@ -6289,7 +6291,7 @@ void CGameProcMain::UpdateCameraAndLight()
 	}
 
 	s_pEng->Tick(crDiffuses, crAmbients, ACT_WORLD->GetFogColorWithSky(), vPosPlayer, s_pPlayer->Rotation(), s_pPlayer->Height(),
-		ACT_WORLD->GetSunAngleByRadinWithSky());          // 캐릭터 위치와 해의 각도를 넣어준다..
+				 ACT_WORLD->GetSunAngleByRadinWithSky()); // 캐릭터 위치와 해의 각도를 넣어준다..
 	s_pEng->ApplyCameraAndLight();                        // 카메라와 라이트에 세팅된 값을 D3D Device 에 적용한다.
 }
 
@@ -7612,7 +7614,8 @@ bool CGameProcMain::OnMouseLBtnPress(POINT ptCur, POINT /*ptPrev*/)
 		return false;
 
 	_POINT ptPlayer = ::_Convert3D_To_2DCoordinate(s_pPlayer->Position(), CN3Base::s_CameraData.mtxView,
-		CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width, CN3Base::s_CameraData.vp.Height);
+												   CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width,
+												   CN3Base::s_CameraData.vp.Height);
 
 	__Vector3 vDir((float) (ptCur.x - ptPlayer.x), 0, (float) (ptPlayer.y - ptCur.y));
 	__Matrix44 mtxTmp;
@@ -7742,7 +7745,8 @@ bool CGameProcMain::OnMouseLbtnDown(POINT ptCur, POINT /*ptPrev*/)
 		return false;
 
 	_POINT ptPlayer = ::_Convert3D_To_2DCoordinate(s_pPlayer->Position(), CN3Base::s_CameraData.mtxView,
-		CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width, CN3Base::s_CameraData.vp.Height);
+												   CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width,
+												   CN3Base::s_CameraData.vp.Height);
 
 	__Vector3 vDir((float) (ptCur.x - ptPlayer.x), 0, (float) (ptPlayer.y - ptCur.y));
 	__Matrix44 mtxTmp;

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -504,7 +504,7 @@ void CGameProcMain::Tick()
 			CPlayerNPC* pNPC = it->second;
 
 			CLogWriter::Write("    ID({}) Name({}) Pos({:.1f}, {:.1f})", pNPC->IDNumber(), pNPC->IDString(), pNPC->m_vPosFromServer.x,
-							  pNPC->m_vPosFromServer.z);
+				pNPC->m_vPosFromServer.z);
 		}
 	}
 #endif
@@ -872,8 +872,7 @@ bool CGameProcMain::ProcessPacket(Packet& pkt)
 				fY = fYObject;
 			this->InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 			s_pFX->TriggerBundle(s_pPlayer->IDNumber(), -1,
-								 s_pPlayer->m_InfoBase.eNation == NATION_KARUS ? FXID_WARP_KARUS : FXID_WARP_ELMORAD, s_pPlayer->IDNumber(),
-								 -1, 0);
+				s_pPlayer->m_InfoBase.eNation == NATION_KARUS ? FXID_WARP_KARUS : FXID_WARP_ELMORAD, s_pPlayer->IDNumber(), -1, 0);
 		}
 			return true;
 		case WIZ_MOVE:
@@ -1462,13 +1461,13 @@ void CGameProcMain::MsgSend_Continous() // 특정 조건(?)하에서 서버에�
 //////////////////////////////////////////////////////////////////////
 
 void CGameProcMain::MsgSend_Attack(int iTargetID, float fInterval,
-								   float fDistance) // 공격 패킷 날리기 - 테이블의 공격 주기를 같이 줘서 해킹을 막는다.
+	float fDistance)       // 공격 패킷 날리기 - 테이블의 공격 주기를 같이 줘서 해킹을 막는다.
 {
 	if (s_pPlayer->m_fTimeAfterDeath > 0 || s_pPlayer->IsDead())
-		return;                                     // 죽은 넘이다..
+		return;            // 죽은 넘이다..
 
-	uint8_t byBuff[32];                             // 버퍼..
-	int iOffset       = 0;                          // 옵셋..
+	uint8_t byBuff[32];    // 버퍼..
+	int iOffset       = 0; // 옵셋..
 
 	uint8_t bySuccess = true;
 
@@ -1672,9 +1671,8 @@ bool CGameProcMain::MsgSend_PartyOrForceCreate(const std::string& szID)
 	if (m_pUIPartyOrForce->MemberCount() <= 0) // 처음 생성하는 경우...
 	{
 		m_pUIPartyOrForce->MemberAdd(s_pPlayer->IDNumber(), s_pPlayer->IDString(), s_pPlayer->m_InfoBase.iLevel,
-									 s_pPlayer->m_InfoBase.eClass, s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax,
-									 s_pPlayer->m_InfoExt.iMSP,
-									 s_pPlayer->m_InfoExt.iMSPMax); // 내건 미리 넣어 놓는다..
+			s_pPlayer->m_InfoBase.eClass, s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax, s_pPlayer->m_InfoExt.iMSP,
+			s_pPlayer->m_InfoExt.iMSPMax); // 내건 미리 넣어 놓는다..
 	}
 
 	return true;
@@ -1864,7 +1862,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	if (pLooks == nullptr)
 	{
 		CLogWriter::Write("CGameProcMain::MsgRecv_MyInfo_All : failed find character resource data (Race : {})",
-						  static_cast<int>(s_pPlayer->m_InfoBase.eRace));
+			static_cast<int>(s_pPlayer->m_InfoBase.eRace));
 	}
 	__ASSERT(pLooks, "failed find character resource data");
 	s_pPlayer->InitChr(pLooks); // 관절 세팅..
@@ -2036,7 +2034,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 		e_PartPosition ePart = PART_POS_UNKNOWN;
 		e_PlugPosition ePlug = PLUG_POS_UNKNOWN;
 		e_ItemType eType     = MakeResrcFileNameForUPC(pItem, pItemExt, &szResrcFN, &szIconFN, ePart, ePlug,
-													   s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
 		if (ITEM_TYPE_UNKNOWN == eType)
 			CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item Type");
@@ -2120,7 +2118,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 		e_PartPosition ePart = PART_POS_UNKNOWN;
 		e_PlugPosition ePlug = PLUG_POS_UNKNOWN;
 		e_ItemType eType     = MakeResrcFileNameForUPC(pItem, pItemExt, nullptr, &szIconFN, ePart, ePlug,
-													   s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
 		if (ITEM_TYPE_UNKNOWN == eType)
 			CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
@@ -3494,8 +3492,8 @@ bool CGameProcMain::MsgRecv_UserLookChange(Packet& pkt)
 			__TABLE_PLAYER_LOOKS* pLooks = s_pTbl_UPC_Looks.Find(pUPC->m_InfoBase.eRace); // User Player Character Skin 구조체 포인터..
 			if (nullptr == pLooks)
 			{
-				CLogWriter::Write("CGameProcMain::MsgRecv_UserLookChange() - failed find table : Race ({})",
-								  static_cast<int>(pUPC->m_InfoBase.eRace));
+				CLogWriter::Write(
+					"CGameProcMain::MsgRecv_UserLookChange() - failed find table : Race ({})", static_cast<int>(pUPC->m_InfoBase.eRace));
 				__ASSERT(pLooks, "failed find table");
 			}
 			else
@@ -3813,7 +3811,7 @@ void CGameProcMain::MsgRecv_MyInfo_RealmPoint(Packet& pkt)
 		if (m_pUIVar->m_pPageState != nullptr)
 		{
 			m_pUIVar->m_pPageState->UpdateRealmPoint(s_pPlayer->m_InfoExt.iRealmPoint,
-													 s_pPlayer->m_InfoExt.iRealmPointMonthly); // 국가 기여도는 10을 나누어서 표시
+				s_pPlayer->m_InfoExt.iRealmPointMonthly); // 국가 기여도는 10을 나누어서 표시
 		}
 	}
 	else if (opcode == LOYALTY_CHANGE_MANNER)
@@ -4454,7 +4452,7 @@ void CGameProcMain::InitZone(int iZone, const __Vector3& vPosPlayer)
 		CommandToggleMoveContinous();
 
 		CLogWriter::Write("CGameProcMain::InitZone -> Zone Change ({} -> {}) Position({:.1f}, {:.1f}, {:.1f})", iZonePrev, iZone,
-						  vPosPlayer.x, vPosPlayer.y, vPosPlayer.z);
+			vPosPlayer.x, vPosPlayer.y, vPosPlayer.z);
 
 		m_bLoadComplete = false; // 로딩 끝남..
 		m_pMagicSkillMng->ClearDurationalMagic();
@@ -6126,8 +6124,8 @@ void CGameProcMain::UpdateUI_PartyOrForceButtons()
 		m_pUICmd->UpdatePartyButtons(bIAmLeader, bIAmMemberOfParty, iMemberIndex, pTarget);
 }
 
-const __InfoPartyOrForce* CGameProcMain::PartyOrForceConditionGet(bool& bIAmLeader, bool& bIAmMember, int& iMemberIndex,
-																  class CPlayerBase*& pTarget)
+const __InfoPartyOrForce* CGameProcMain::PartyOrForceConditionGet(
+	bool& bIAmLeader, bool& bIAmMember, int& iMemberIndex, class CPlayerBase*& pTarget)
 {
 	// 파티 버튼 상태 바꾸기..
 	bIAmLeader   = false;
@@ -6291,7 +6289,7 @@ void CGameProcMain::UpdateCameraAndLight()
 	}
 
 	s_pEng->Tick(crDiffuses, crAmbients, ACT_WORLD->GetFogColorWithSky(), vPosPlayer, s_pPlayer->Rotation(), s_pPlayer->Height(),
-				 ACT_WORLD->GetSunAngleByRadinWithSky()); // 캐릭터 위치와 해의 각도를 넣어준다..
+		ACT_WORLD->GetSunAngleByRadinWithSky());          // 캐릭터 위치와 해의 각도를 넣어준다..
 	s_pEng->ApplyCameraAndLight();                        // 카메라와 라이트에 세팅된 값을 D3D Device 에 적용한다.
 }
 
@@ -7614,8 +7612,7 @@ bool CGameProcMain::OnMouseLBtnPress(POINT ptCur, POINT /*ptPrev*/)
 		return false;
 
 	_POINT ptPlayer = ::_Convert3D_To_2DCoordinate(s_pPlayer->Position(), CN3Base::s_CameraData.mtxView,
-												   CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width,
-												   CN3Base::s_CameraData.vp.Height);
+		CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width, CN3Base::s_CameraData.vp.Height);
 
 	__Vector3 vDir((float) (ptCur.x - ptPlayer.x), 0, (float) (ptPlayer.y - ptCur.y));
 	__Matrix44 mtxTmp;
@@ -7745,8 +7742,7 @@ bool CGameProcMain::OnMouseLbtnDown(POINT ptCur, POINT /*ptPrev*/)
 		return false;
 
 	_POINT ptPlayer = ::_Convert3D_To_2DCoordinate(s_pPlayer->Position(), CN3Base::s_CameraData.mtxView,
-												   CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width,
-												   CN3Base::s_CameraData.vp.Height);
+		CN3Base::s_CameraData.mtxProjection, CN3Base::s_CameraData.vp.Width, CN3Base::s_CameraData.vp.Height);
 
 	__Vector3 vDir((float) (ptCur.x - ptPlayer.x), 0, (float) (ptPlayer.y - ptCur.y));
 	__Matrix44 mtxTmp;

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -861,6 +861,33 @@ void CPlayerBase::Render(float fSunAngle)
 			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
 			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
 
+			// Draw green line under name if clan leader
+			if (KnightsDuty() == KNIGHTS_DUTY_CHIEF)
+			{
+				SIZE nameSize                     = m_pIDFont->GetSize();
+				float fLeft                       = static_cast<float>(pt.x - (nameSize.cx / 2));
+				float fRight                      = static_cast<float>(pt.x + (nameSize.cx / 2));
+				float fTop                        = static_cast<float>(pt.y + nameSize.cy + 1);
+				float fBottom                     = static_cast<float>(pt.y + nameSize.cy + 2);
+
+				__VertexTransformedColor vLine[4] = {
+					{ fLeft, fTop, 0.0f, 1.0f, 0xff00ff00 },
+					{ fRight, fTop, 0.0f, 1.0f, 0xff00ff00 },
+					{ fRight, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+					{ fLeft, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+				};
+
+				DWORD dwPrevFVF;
+				s_lpD3DDev->GetFVF(&dwPrevFVF);
+
+				s_lpD3DDev->SetTexture(0, nullptr);
+				s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR);
+				s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, vLine, sizeof(__VertexTransformedColor));
+
+				s_lpD3DDev->SetFVF(dwPrevFVF);
+			}
+
+
 			//Knight & clan 렌더링..
 			if (m_pClanFont && m_pClanFont->IsSetText())
 			{

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -295,7 +295,7 @@ void CPlayerBase::IDSet(int iID, const std::string& szID, D3DCOLOR crID)
 #endif
 }
 
-void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank)
+void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank, e_KnightsDuty /*eDuty*/)
 {
 	std::string szPlug;
 	if (iGrade > 0 && iGrade <= 5)
@@ -744,6 +744,56 @@ void CPlayerBase::Tick()  // 회전, 지정된 에니메이션 Tick 및 색깔 �
 	}
 }
 
+constexpr int CLAN_LEADER_LINE_OFFSET    = 1; // gap between name baseline and clan leader bar
+constexpr int CLAN_LEADER_LINE_THICKNESS = 1; // thickness the clan leader bar
+
+void CPlayerBase::DrawClanLeaderIndicator(const _POINT& pt)
+{
+	SIZE nameSize                     = m_pIDFont->GetSize();
+	float fLeft                       = static_cast<float>(pt.x) - (static_cast<float>(nameSize.cx) / 2.0f);
+	float fRight                      = static_cast<float>(pt.x) + (static_cast<float>(nameSize.cx) / 2.0f);
+	float fTop                        = static_cast<float>(pt.y + nameSize.cy + CLAN_LEADER_LINE_OFFSET);
+	float fBottom                     = static_cast<float>(pt.y + nameSize.cy + CLAN_LEADER_LINE_OFFSET + CLAN_LEADER_LINE_THICKNESS);
+
+	__VertexTransformedColor vLine[4] = {
+		{ fLeft, fTop, 0.0f, 1.0f, 0xff00ff00 },
+		{ fRight, fTop, 0.0f, 1.0f, 0xff00ff00 },
+		{ fRight, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+		{ fLeft, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+	};
+
+	DWORD dwPrevFVF = 0;
+	if (FAILED(s_lpD3DDev->GetFVF(&dwPrevFVF)))
+		return;
+
+	IDirect3DBaseTexture9* pPrevTexture = nullptr;
+	s_lpD3DDev->GetTexture(0, &pPrevTexture);
+
+	if (FAILED(s_lpD3DDev->SetTexture(0, nullptr)))
+	{
+		if (pPrevTexture != nullptr)
+			pPrevTexture->Release();
+		return;
+	}
+
+	if (FAILED(s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR)))
+	{
+		s_lpD3DDev->SetTexture(0, pPrevTexture);
+		if (pPrevTexture != nullptr)
+			pPrevTexture->Release();
+		return;
+	}
+
+	s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, vLine, sizeof(__VertexTransformedColor));
+
+	s_lpD3DDev->SetTexture(0, pPrevTexture);
+	if (pPrevTexture != nullptr)
+		pPrevTexture->Release();
+
+	s_lpD3DDev->SetFVF(dwPrevFVF);
+}
+
+
 void CPlayerBase::Render(float fSunAngle)
 {
 	if (m_Chr.m_nLOD < 0 || m_Chr.m_nLOD >= MAX_CHR_LOD)
@@ -863,29 +913,7 @@ void CPlayerBase::Render(float fSunAngle)
 
 			// Draw green line under name if clan leader
 			if (KnightsDuty() == KNIGHTS_DUTY_CHIEF)
-			{
-				SIZE nameSize                     = m_pIDFont->GetSize();
-				float fLeft                       = static_cast<float>(pt.x - (nameSize.cx / 2));
-				float fRight                      = static_cast<float>(pt.x + (nameSize.cx / 2));
-				float fTop                        = static_cast<float>(pt.y + nameSize.cy + 1);
-				float fBottom                     = static_cast<float>(pt.y + nameSize.cy + 2);
-
-				__VertexTransformedColor vLine[4] = {
-					{ fLeft, fTop, 0.0f, 1.0f, 0xff00ff00 },
-					{ fRight, fTop, 0.0f, 1.0f, 0xff00ff00 },
-					{ fRight, fBottom, 0.0f, 1.0f, 0xff00ff00 },
-					{ fLeft, fBottom, 0.0f, 1.0f, 0xff00ff00 },
-				};
-
-				DWORD dwPrevFVF;
-				s_lpD3DDev->GetFVF(&dwPrevFVF);
-
-				s_lpD3DDev->SetTexture(0, nullptr);
-				s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR);
-				s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, vLine, sizeof(__VertexTransformedColor));
-
-				s_lpD3DDev->SetFVF(dwPrevFVF);
-			}
+				DrawClanLeaderIndicator(pt);
 
 
 			//Knight & clan 렌더링..
@@ -930,6 +958,7 @@ void CPlayerBase::Render(float fSunAngle)
 		}
 	}
 }
+
 
 __Vector3 CPlayerBase::HeadPosition() const
 {

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -37,8 +37,8 @@ CPlayerBase::CPlayerBase()
 	m_pvVertex[3].Set(-SHADOW_PLANE_SIZE, 0.0f, -SHADOW_PLANE_SIZE, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f);
 
 	const uint16_t index[] = { //
-		// Bottom
-		0, 1, 3, 2, 3, 1
+							   // Bottom
+							   0, 1, 3, 2, 3, 1
 	};
 	memcpy(m_pIndex, index, sizeof(m_pIndex));
 
@@ -366,8 +366,8 @@ void CPlayerBase::RenderChrInRect(CN3Chr* pChr, const RECT& Rect)
 	int iHeight             = Rect.bottom - Rect.top;
 	float fViewVolumeHeight = fChrHeight * vp.Height / iHeight; // 캐릭터의 키(클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
 	float fViewVolumeWidth  = fChrHeight * vp.Width
-							 / iHeight; // 가로는 pRect의 가로 세로 비율에 맞게 (클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
-										// 원래는 이거 : fChrHeight * iWidth / iHeight * vp.Width / iWidth;
+							  / iHeight; // 가로는 pRect의 가로 세로 비율에 맞게 (클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
+										 // 원래는 이거 : fChrHeight * iWidth / iHeight * vp.Width / iWidth;
 	mtxProj.OrthoLH(fViewVolumeWidth, fViewVolumeHeight, 0, 20);
 
 	float fCameraMoveX = ((fChrHeight * iWidth / iHeight) - fViewVolumeWidth) / 2.0f; // 클리핑에 따른 카메라 이동 수치
@@ -793,7 +793,6 @@ void CPlayerBase::DrawClanLeaderIndicator(const _POINT& pt)
 	s_lpD3DDev->SetFVF(dwPrevFVF);
 }
 
-
 void CPlayerBase::Render(float fSunAngle)
 {
 	if (m_Chr.m_nLOD < 0 || m_Chr.m_nLOD >= MAX_CHR_LOD)
@@ -900,8 +899,8 @@ void CPlayerBase::Render(float fSunAngle)
 			vHead.y         += this->Height() / 10.0f;
 			if (PSA_SITDOWN == m_eState)
 				vHead.y += this->RootPosition().y - this->Height() / 2.0f; // 앉아 있으면..
-			_POINT pt = ::_Convert3D_To_2DCoordinate(
-				vHead, s_CameraData.mtxView, s_CameraData.mtxProjection, s_CameraData.vp.Width, s_CameraData.vp.Height);
+			_POINT pt        = ::_Convert3D_To_2DCoordinate(vHead, s_CameraData.mtxView, s_CameraData.mtxProjection, s_CameraData.vp.Width,
+															s_CameraData.vp.Height);
 
 			SIZE size        = m_pIDFont->GetSize();
 			pt.y            -= size.cy + 5;
@@ -914,7 +913,6 @@ void CPlayerBase::Render(float fSunAngle)
 			// Draw green line under name if clan leader
 			if (KnightsDuty() == KNIGHTS_DUTY_CHIEF)
 				DrawClanLeaderIndicator(pt);
-
 
 			//Knight & clan 렌더링..
 			if (m_pClanFont && m_pClanFont->IsSetText())
@@ -958,7 +956,6 @@ void CPlayerBase::Render(float fSunAngle)
 		}
 	}
 }
-
 
 __Vector3 CPlayerBase::HeadPosition() const
 {
@@ -1933,9 +1930,9 @@ CN3CPart* CPlayerBase::PartSet(e_PartPosition ePos, const std::string& szFN, __T
 					e_PlugPosition ePlugPos2 = PLUG_POS_UNKNOWN;
 
 					MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], m_pItemPartExts[PART_POS_LOWER], &szFN2, nullptr, ePartPos2,
-						ePlugPos2, m_InfoBase.eRace);
+											ePlugPos2, m_InfoBase.eRace);
 					this->PartSet(PART_POS_LOWER, szFN2, m_pItemPartBasics[PART_POS_LOWER],
-						m_pItemPartExts[PART_POS_LOWER]);                                   // 하체에 전의 옷을 입힌다..
+								  m_pItemPartExts[PART_POS_LOWER]);                         // 하체에 전의 옷을 입힌다..
 				}
 				else                                                                        // 하체에 입고 있었던 아이템이 없다면..
 				{
@@ -2055,8 +2052,8 @@ void CPlayerBase::DurabilitySet(e_ItemSlot eSlot, int iDurability)
 		{
 			if (m_pItemPartBasics[ePartPos] && m_pItemPartExts[ePartPos])
 			{
-				int iDuMax = m_pItemPartBasics[ePartPos]->siMaxDurability
-							 + m_pItemPartExts[ePartPos]->siMaxDurability; // 기본내구력 + 확장 내구력
+				int iDuMax      = m_pItemPartBasics[ePartPos]->siMaxDurability
+								  + m_pItemPartExts[ePartPos]->siMaxDurability; // 기본내구력 + 확장 내구력
 				int iPercentage = iDurability * 100 / iDuMax;
 
 				std::string szFN;

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -37,8 +37,8 @@ CPlayerBase::CPlayerBase()
 	m_pvVertex[3].Set(-SHADOW_PLANE_SIZE, 0.0f, -SHADOW_PLANE_SIZE, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f);
 
 	const uint16_t index[] = { //
-							   // Bottom
-							   0, 1, 3, 2, 3, 1
+		// Bottom
+		0, 1, 3, 2, 3, 1
 	};
 	memcpy(m_pIndex, index, sizeof(m_pIndex));
 
@@ -366,8 +366,8 @@ void CPlayerBase::RenderChrInRect(CN3Chr* pChr, const RECT& Rect)
 	int iHeight             = Rect.bottom - Rect.top;
 	float fViewVolumeHeight = fChrHeight * vp.Height / iHeight; // 캐릭터의 키(클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
 	float fViewVolumeWidth  = fChrHeight * vp.Width
-							  / iHeight; // 가로는 pRect의 가로 세로 비율에 맞게 (클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
-										 // 원래는 이거 : fChrHeight * iWidth / iHeight * vp.Width / iWidth;
+							 / iHeight; // 가로는 pRect의 가로 세로 비율에 맞게 (클리핑 될 경우 클리핑 되는 비율에 맞게 좁혀준다.)
+										// 원래는 이거 : fChrHeight * iWidth / iHeight * vp.Width / iWidth;
 	mtxProj.OrthoLH(fViewVolumeWidth, fViewVolumeHeight, 0, 20);
 
 	float fCameraMoveX = ((fChrHeight * iWidth / iHeight) - fViewVolumeWidth) / 2.0f; // 클리핑에 따른 카메라 이동 수치
@@ -899,8 +899,8 @@ void CPlayerBase::Render(float fSunAngle)
 			vHead.y         += this->Height() / 10.0f;
 			if (PSA_SITDOWN == m_eState)
 				vHead.y += this->RootPosition().y - this->Height() / 2.0f; // 앉아 있으면..
-			_POINT pt        = ::_Convert3D_To_2DCoordinate(vHead, s_CameraData.mtxView, s_CameraData.mtxProjection, s_CameraData.vp.Width,
-															s_CameraData.vp.Height);
+			_POINT pt = ::_Convert3D_To_2DCoordinate(
+				vHead, s_CameraData.mtxView, s_CameraData.mtxProjection, s_CameraData.vp.Width, s_CameraData.vp.Height);
 
 			SIZE size        = m_pIDFont->GetSize();
 			pt.y            -= size.cy + 5;
@@ -1930,9 +1930,9 @@ CN3CPart* CPlayerBase::PartSet(e_PartPosition ePos, const std::string& szFN, __T
 					e_PlugPosition ePlugPos2 = PLUG_POS_UNKNOWN;
 
 					MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], m_pItemPartExts[PART_POS_LOWER], &szFN2, nullptr, ePartPos2,
-											ePlugPos2, m_InfoBase.eRace);
+						ePlugPos2, m_InfoBase.eRace);
 					this->PartSet(PART_POS_LOWER, szFN2, m_pItemPartBasics[PART_POS_LOWER],
-								  m_pItemPartExts[PART_POS_LOWER]);                         // 하체에 전의 옷을 입힌다..
+						m_pItemPartExts[PART_POS_LOWER]);                                   // 하체에 전의 옷을 입힌다..
 				}
 				else                                                                        // 하체에 입고 있었던 아이템이 없다면..
 				{
@@ -2052,8 +2052,8 @@ void CPlayerBase::DurabilitySet(e_ItemSlot eSlot, int iDurability)
 		{
 			if (m_pItemPartBasics[ePartPos] && m_pItemPartExts[ePartPos])
 			{
-				int iDuMax      = m_pItemPartBasics[ePartPos]->siMaxDurability
-								  + m_pItemPartExts[ePartPos]->siMaxDurability; // 기본내구력 + 확장 내구력
+				int iDuMax = m_pItemPartBasics[ePartPos]->siMaxDurability
+							 + m_pItemPartExts[ePartPos]->siMaxDurability; // 기본내구력 + 확장 내구력
 				int iPercentage = iDurability * 100 / iDuMax;
 
 				std::string szFN;

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -104,10 +104,6 @@ protected:
 	e_StateAction m_eStateNext                            = PSA_BASIC;                // 직전에 세팅된 행동 상태..
 	e_StateMove m_eStateMove                              = PSM_STOP;                 // 움직이는 상태..
 	e_StateDying m_eStateDying                            = PSD_UNKNOWN;              // 죽을때 어떻게 죽는가..??
-	virtual e_KnightsDuty KnightsDuty() const
-	{
-		return KNIGHTS_DUTY_UNKNOWN;
-	}
 	float m_fTimeDying                                    = 0.0f;                     // 죽는 모션을 취하는 시간..
 
 	__ColorValue m_cvDuration                             = { 1, 1, 1, 1 };           // 지속 컬러 값
@@ -375,7 +371,14 @@ public:
 	void InfoStringSet(const std::string& szInfo, D3DCOLOR crFont);
 	void BalloonStringSet(const std::string& szBalloon, D3DCOLOR crFont);
 	void IDSet(int iID, const std::string& szID, D3DCOLOR crID);
-	virtual void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank);
+
+	virtual e_KnightsDuty KnightsDuty() const
+	{
+		return KNIGHTS_DUTY_UNKNOWN;
+	}
+
+	void DrawClanLeaderIndicator(const _POINT& pt);
+	virtual void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN);
 
 	// ID 는 Character 포인터의 이름으로 대신한다.
 	const std::string& IDString() const

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -104,6 +104,10 @@ protected:
 	e_StateAction m_eStateNext                            = PSA_BASIC;                // 직전에 세팅된 행동 상태..
 	e_StateMove m_eStateMove                              = PSM_STOP;                 // 움직이는 상태..
 	e_StateDying m_eStateDying                            = PSD_UNKNOWN;              // 죽을때 어떻게 죽는가..??
+	virtual e_KnightsDuty KnightsDuty() const
+	{
+		return KNIGHTS_DUTY_UNKNOWN;
+	}
 	float m_fTimeDying                                    = 0.0f;                     // 죽는 모션을 취하는 시간..
 
 	__ColorValue m_cvDuration                             = { 1, 1, 1, 1 };           // 지속 컬러 값

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -990,13 +990,14 @@ void CPlayerMySelf::InitHair()
 	}
 }
 
-void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank)
+void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty)
 {
-	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank);
+	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank, eDuty);
 
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
+	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerMySelf.h
+++ b/src/Client/WarFare/PlayerMySelf.h
@@ -43,6 +43,11 @@ public:
 	__Vector3 m_vTargetPos;          // 이동할 지점 위치
 	void SetMoveTargetID(int iID);
 	void SetMoveTargetPos(const __Vector3& vPos);
+	e_KnightsDuty KnightsDuty() const override
+	{
+		return m_InfoExt.eKnightsDuty;
+	}
+
 
 public:
 	void TargetOrPosMove();

--- a/src/Client/WarFare/PlayerMySelf.h
+++ b/src/Client/WarFare/PlayerMySelf.h
@@ -43,13 +43,13 @@ public:
 	__Vector3 m_vTargetPos;          // 이동할 지점 위치
 	void SetMoveTargetID(int iID);
 	void SetMoveTargetPos(const __Vector3& vPos);
+
+public:
 	e_KnightsDuty KnightsDuty() const override
 	{
 		return m_InfoExt.eKnightsDuty;
 	}
 
-
-public:
 	void TargetOrPosMove();
 	void Stun(float fTime); // 일정한 시간동안 기절 시키기.
 	void StunRelease();     // 기절 풀기..
@@ -62,7 +62,7 @@ public:
 
 	// 갖고 있는 정보로 머리카락을 초기화 한다..
 	void InitHair() override;
-	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank) override;
+	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN) override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
 
 	float AttackableDistance(CPlayerBase* pTarget);

--- a/src/Client/WarFare/PlayerOther.cpp
+++ b/src/Client/WarFare/PlayerOther.cpp
@@ -201,13 +201,14 @@ void CPlayerOther::InitHair()
 	}
 }
 
-void CPlayerOther::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank)
+void CPlayerOther::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty)
 {
-	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank);
+	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank, eDuty);
 
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
+	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerOther.h
+++ b/src/Client/WarFare/PlayerOther.h
@@ -25,7 +25,7 @@ public:
 public:
 	void InitFace() override;
 	void InitHair() override;
-	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank) override;
+	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN) override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
 
 	bool Init(enum e_Race eRace, int iFace, int iHair, uint32_t* pdwItemIDs, int* piItenDurabilities, uint8_t* pbyItemFlags);

--- a/src/Client/WarFare/PlayerOther.h
+++ b/src/Client/WarFare/PlayerOther.h
@@ -17,6 +17,10 @@ class CPlayerOther : public CPlayerNPC
 public:
 	__InfoPlayerOther m_InfoExt; // 캐릭터 정보 확장..
 	bool m_bSit;
+	e_KnightsDuty KnightsDuty() const override
+	{
+		return m_InfoExt.eKnightsDuty;
+	}
 
 public:
 	void InitFace() override;


### PR DESCRIPTION
Draw the green line under the player name if they are a clan leader.

## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
No green line is drawn under the players name if they are a clan leader to address #374 

## What is the new behaviour?
The green line is drawn under the players name if they are a clan leader.

## Why and how did I change this?
The packet was there to be read, however it was commented out in GameProcMain. 
Move e_KnightsDuty up to InfoPlayerOther so it could be seen by all players to draw the green line for all clan leaders.
I think virtual is the cleanest way to do this but open to suggestions.

## Was AI used at some point for any part of this change? If so, what?
No

## Demo
<img width="318" height="324" alt="image" src="https://github.com/user-attachments/assets/5d423a0d-3f2c-4b7e-a4c2-f170566a98d8" />

## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).