### PR TITLE
VersionManager: Fix Windows ODBC auth

### DIFF
--- a/src/Server/VersionManager/VersionManagerApp.cpp
+++ b/src/Server/VersionManager/VersionManagerApp.cpp
@@ -132,9 +132,7 @@ bool VersionManagerApp::LoadConfig(CIni& iniFile)
 		return false;
 	}
 
-	if (datasourceName.empty()
-		// TODO: Should we not validate UID/Pass length?  Would that allow Windows Auth?
-		|| datasourceUser.empty() || datasourcePass.empty())
+	if (datasourceName.empty())
 	{
 		spdlog::error("VersionManagerApp::LoadConfig: Datasource config must be set.");
 		return false;


### PR DESCRIPTION
VersionManager is the only server that explicitly checks the ODBC config here. Aside from that, empty values (as opposed to missing keys) are loaded directly as empty correctly, so ODBC can correctly default to Windows auth on an empty value.