### PR TITLE
Doxygen: Explicitly scan src directory only

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -129,7 +129,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  =
+INPUT                  = src
 INPUT_ENCODING         = UTF-8
 INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.c \


### PR DESCRIPTION
Scan only the src/ directory.

This means we can run it from root without worrying about it catching things like bin or the arbitrarily created CMake dir, which locally causes it to segfault (perhaps too much memory or certain binary files confuse it).
This doesn't really happen in the workflow because it's generating from a clean dir, but for local use (and verifying doc output), this should "just work".