### PR TITLE
UI Update - Hover Button Reset

### DIFF
--- a/src/N3Base/N3UIButton.cpp
+++ b/src/N3Base/N3UIButton.cpp
@@ -192,7 +192,7 @@ uint32_t CN3UIButton::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POIN
 			if (m_pParent != nullptr
 				&& UI_STATE_BUTTON_DOWN == m_eState) // 이전 상태가 버튼을 Down 상태이면
 			{
-				SetState(UI_STATE_BUTTON_NORMAL);        // 버튼을 On 상태로 만든다..
+				SetState(UI_STATE_BUTTON_NORMAL);    // 버튼을 On 상태로 만든다..
 				m_pParent->ReceiveMessage(this, UIMSG_BUTTON_CLICK); // 부모에게 버튼 클릭 통지..
 			}
 			dwRet |= UI_MOUSEPROC_DONESOMETHING;

--- a/src/N3Base/N3UIButton.cpp
+++ b/src/N3Base/N3UIButton.cpp
@@ -192,7 +192,7 @@ uint32_t CN3UIButton::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POIN
 			if (m_pParent != nullptr
 				&& UI_STATE_BUTTON_DOWN == m_eState) // 이전 상태가 버튼을 Down 상태이면
 			{
-				SetState(UI_STATE_BUTTON_ON);        // 버튼을 On 상태로 만든다..
+				SetState(UI_STATE_BUTTON_NORMAL);        // 버튼을 On 상태로 만든다..
 				m_pParent->ReceiveMessage(this, UIMSG_BUTTON_CLICK); // 부모에게 버튼 클릭 통지..
 			}
 			dwRet |= UI_MOUSEPROC_DONESOMETHING;


### PR DESCRIPTION
The UI hover button (X) state was not being reset when the window was being closed. 

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
When you click X to close a window, the hover state is not being removed. When you open the window again, the hover state remains.

## What is the new behaviour?
When you click X to close a window it resets the state to normal. When the window is reopened it does not have the hover state.

## Why and how did I change this?
To fix #406 
Change the called stated from on to normal. This was the bug causing the problem.

## Was AI used at some point for any part of this change? If so, what?
No

## Demo

## Checklist

- [X] I have performed a self-review of my own code.
- [X] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [X] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
