### PR TITLE
Client - Clan leader line

### DIFF
--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -419,18 +419,17 @@ struct __TABLE_PLAYER;
 
 struct __InfoPlayerOther
 {
-	int iFace;                  // Face type
-	int iHair;                  // Hair type
+	int iFace;             // Face type
+	int iHair;             // Hair type
 
-	int iCity;                  // Affiliated city
-	std::string szKnights;      // Clan name
-	int iKnightsGrade;          // Clan grade
-	int iKnightsRank;           // Clan ranking
-	e_KnightsDuty eKnightsDuty; // Clan role/duty
+	int iCity;             // Affiliated city
+	std::string szKnights; // Clan name
+	int iKnightsGrade;     // Clan grade
+	int iKnightsRank;      // Clan ranking
 
-	int iRank;                  // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
-	int iTitle;                 // Bitmask representing various titles/roles including:
-								// Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
+	int iRank;             // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
+	int iTitle;            // Bitmask representing various titles/roles including:
+						   // Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
 
 	__InfoPlayerOther()
 	{
@@ -444,7 +443,6 @@ struct __InfoPlayerOther
 		iCity         = 0;
 		iKnightsGrade = 0;
 		iKnightsRank  = 0;
-		eKnightsDuty  = KNIGHTS_DUTY_UNKNOWN;
 		iTitle        = 0;
 
 		szKnights.clear();
@@ -467,43 +465,42 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther
 	int iGold;
 	int64_t iExpNext;
 	int64_t iExp;
-	int iRealmPoint;            // National Points
-	int iRealmPointMonthly;     // Monthly National Points
-	e_KnightsDuty eKnightsDuty; // Clan member position/role/duty
-	int iWeightMax;             // Max weight
-	int iWeight;                // Current weight
-	int iStrength;              // Strength
-	int iStrength_Delta;        // Bonus strength
-	int iStamina;               // Stamina
-	int iStamina_Delta;         // Bonus stamina
-	int iDexterity;             // Dexterity
-	int iDexterity_Delta;       // Bonus dexterity
-	int iIntelligence;          // Intelligence
-	int iIntelligence_Delta;    // Bonus intelligence
-	int iMagicAttak;            // Charisma/Magic Power
-	int iMagicAttak_Delta;      // Bonus Charisma/Magic Power
+	int iRealmPoint;         // National Points
+	int iRealmPointMonthly;  // Monthly National Points
+	int iWeightMax;          // Max weight
+	int iWeight;             // Current weight
+	int iStrength;           // Strength
+	int iStrength_Delta;     // Bonus strength
+	int iStamina;            // Stamina
+	int iStamina_Delta;      // Bonus stamina
+	int iDexterity;          // Dexterity
+	int iDexterity_Delta;    // Bonus dexterity
+	int iIntelligence;       // Intelligence
+	int iIntelligence_Delta; // Bonus intelligence
+	int iMagicAttak;         // Charisma/Magic Power
+	int iMagicAttak_Delta;   // Bonus Charisma/Magic Power
 
-	int iAttack;                // Attack Power
-	int iAttack_Delta;          // Bonus Attack Power
-	int iGuard;                 // Defense
-	int iGuard_Delta;           // Bonus Defense
+	int iAttack;             // Attack Power
+	int iAttack_Delta;       // Bonus Attack Power
+	int iGuard;              // Defense
+	int iGuard_Delta;        // Bonus Defense
 
-	int iRegistFire;            // Fire resistance
-	int iRegistFire_Delta;      // Bonus fire resistance
-	int iRegistCold;            // Cold resistance
-	int iRegistCold_Delta;      // Bonus cold resistance
-	int iRegistLight;           // Lightning resistance
-	int iRegistLight_Delta;     // Bonus lightning resistance
-	int iRegistMagic;           // Magic resistance
-	int iRegistMagic_Delta;     // Bonus magic resistance
-	int iRegistCurse;           // Curse resistance
-	int iRegistCurse_Delta;     // Bonus curse resistance
-	int iRegistPoison;          // Poison resistance
-	int iRegistPoison_Delta;    // Bonus poison resistance
+	int iRegistFire;         // Fire resistance
+	int iRegistFire_Delta;   // Bonus fire resistance
+	int iRegistCold;         // Cold resistance
+	int iRegistCold_Delta;   // Bonus cold resistance
+	int iRegistLight;        // Lightning resistance
+	int iRegistLight_Delta;  // Bonus lightning resistance
+	int iRegistMagic;        // Magic resistance
+	int iRegistMagic_Delta;  // Bonus magic resistance
+	int iRegistCurse;        // Curse resistance
+	int iRegistCurse_Delta;  // Bonus curse resistance
+	int iRegistPoison;       // Poison resistance
+	int iRegistPoison_Delta; // Bonus poison resistance
 
-	int iZoneInit;              // Initial Zone ID received from the server
-	int iZoneCur;               // Current zone ID
-	int iVictoryNation;         // Last war outcome - 0: Draw, 1: El Morad victory, 2: Karus victory
+	int iZoneInit;           // Initial Zone ID received from the server
+	int iZoneCur;            // Current zone ID
+	int iVictoryNation;      // Last war outcome - 0: Draw, 1: El Morad victory, 2: Karus victory
 
 	e_ZoneAbilityType eZoneAbilityType;
 	bool bCanTradeWithOtherNation;

--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -419,17 +419,18 @@ struct __TABLE_PLAYER;
 
 struct __InfoPlayerOther
 {
-	int iFace;             // Face type
-	int iHair;             // Hair type
+	int iFace;                  // Face type
+	int iHair;                  // Hair type
 
-	int iCity;             // Affiliated city
-	std::string szKnights; // Clan name
-	int iKnightsGrade;     // Clan grade
-	int iKnightsRank;      // Clan ranking
+	int iCity;                  // Affiliated city
+	std::string szKnights;      // Clan name
+	int iKnightsGrade;          // Clan grade
+	int iKnightsRank;           // Clan ranking
+	e_KnightsDuty eKnightsDuty; // Clan role/duty
 
-	int iRank;             // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
-	int iTitle;            // Bitmask representing various titles/roles including:
-						   // Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
+	int iRank;                  // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
+	int iTitle;                 // Bitmask representing various titles/roles including:
+								// Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
 
 	__InfoPlayerOther()
 	{
@@ -443,6 +444,7 @@ struct __InfoPlayerOther
 		iCity         = 0;
 		iKnightsGrade = 0;
 		iKnightsRank  = 0;
+		eKnightsDuty  = KNIGHTS_DUTY_UNKNOWN;
 		iTitle        = 0;
 
 		szKnights.clear();
@@ -529,7 +531,6 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther
 		iExp                     = 0;
 		iRealmPoint              = 0;
 		iRealmPointMonthly       = 0;
-		eKnightsDuty             = KNIGHTS_DUTY_UNKNOWN;
 		iWeightMax               = 0;
 		iWeight                  = 0;
 		iStrength                = 0;

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1883,10 +1883,10 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	s_pPlayer->m_InfoExt.iCity              = pkt.read<uint8_t>();
 
 	std::string szKnightsName               = "";
-	int iKnightsID                          = pkt.read<int16_t>();                 // 소속 기사단 ID
-	e_KnightsDuty eKnightsDuty              = (e_KnightsDuty) pkt.read<uint8_t>(); // 기사단에서의 권한..
+	int iKnightsID                          = pkt.read<int16_t>();                             // 소속 기사단 ID
+	e_KnightsDuty eKnightsDuty              = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 기사단에서의 권한..
 
-																				   // NOTE(srmeier): adding alliance ID and knight's byFlag
+	// NOTE(srmeier): adding alliance ID and knight's byFlag
 	/*int iAllianceID                       =*/pkt.read<int16_t>();
 	/*uint8_t byFlag                        =*/pkt.read<uint8_t>();
 
@@ -1900,7 +1900,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 	// 기사단 관련 세팅..
 	s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
-	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank, eKnightsDuty);
 	m_pUIVar->UpdateKnightsInfo();
 
 	s_pPlayer->m_InfoBase.iHPMax             = pkt.read<int16_t>();
@@ -2534,11 +2534,11 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	int iNameLen = pkt.read<uint8_t>();
 	pkt.readString(szName, iNameLen);
 
-	e_Nation eNation = (e_Nation) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
+	e_Nation eNation           = (e_Nation) pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
 
 	// 기사단 관련
-	int iKnightsID   = pkt.read<int16_t>();                               // 기사단 ID
-	/*e_KnightsDuty eKnightsDuty = (e_KnightsDuty)*/ pkt.read<uint8_t>(); // 소속 국가. 0 이면 없다. 1
+	int iKnightsID             = pkt.read<int16_t>();                             // 기사단 ID
+	e_KnightsDuty eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>()); // 소속 국가. 0 이면 없다. 1
 
 	/*int16_t sAllianceID      =*/pkt.read<int16_t>();
 
@@ -2631,7 +2631,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->m_InfoBase.iAuthority = byAuthority;
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
-	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank, eKnightsDuty);
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);
@@ -6366,8 +6366,7 @@ void CGameProcMain::MsgRecv_Knights(Packet& pkt)
 					break;
 			}
 
-			s_pPlayer->m_InfoExt.eKnightsDuty = KNIGHTS_DUTY_UNKNOWN;
-			s_pPlayer->KnightsInfoSet(0, "", 0, 0);
+			s_pPlayer->KnightsInfoSet(0, "", 0, 0, KNIGHTS_DUTY_UNKNOWN);
 			m_pUIVar->UpdateKnightsInfo();
 		}
 		break;
@@ -6886,8 +6885,7 @@ void CGameProcMain::MsgRecv_Knights_Create(Packet& pkt)
 					m_pSubProcPerTrade->m_pUIPerTradeDlg->GoldUpdate();
 
 				//기사단(클랜)UI업데이트...해라...
-				s_pPlayer->m_InfoExt.eKnightsDuty = KNIGHTS_DUTY_CHIEF;
-				s_pPlayer->KnightsInfoSet(iID, szID, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szID, iGrade, iRank, KNIGHTS_DUTY_CHIEF);
 				m_pUIVar->UpdateKnightsInfo();
 
 				if (m_pUIVar->m_pPageKnights->IsVisible())
@@ -6945,7 +6943,7 @@ void CGameProcMain::MsgRecv_Knights_Withdraw(Packet& pkt)
 			if (s_pPlayer->IDNumber() == sid)
 			{
 				s_pPlayer->m_InfoBase.iKnightsID  = pkt.read<int16_t>();
-				s_pPlayer->m_InfoExt.eKnightsDuty = (e_KnightsDuty) pkt.read<uint8_t>();
+				s_pPlayer->m_InfoExt.eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
 				m_pUIVar->UpdateKnightsInfo();
 
 				s_pPlayer->KnightsInfoSet(s_pPlayer->m_InfoBase.iKnightsID, "", 0, 0);
@@ -7021,8 +7019,7 @@ void CGameProcMain::MsgRecv_Knights_Join(Packet& pkt)
 
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
-				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank, eDuty);
 				m_pUIVar->UpdateKnightsInfo();
 
 				szMsg = fmt::format_text_resource(IDS_CLAN_JOIN_SUCCESS);
@@ -7120,8 +7117,7 @@ void CGameProcMain::MsgRecv_Knights_Leave(Packet& pkt)
 
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
-				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank);
+				s_pPlayer->KnightsInfoSet(iID, szKnightsName, iGrade, iRank, eDuty);
 				m_pUIVar->UpdateKnightsInfo();
 
 				szMsg = fmt::format_text_resource(IDS_CLAN_JOIN_SUCCESS);
@@ -7343,7 +7339,7 @@ void CGameProcMain::MsgRecv_Knights_Duty_Change(Packet& pkt)
 		{
 			int sid             = pkt.read<int16_t>();
 			int iID             = pkt.read<int16_t>();
-			e_KnightsDuty eDuty = (e_KnightsDuty) pkt.read<uint8_t>();
+			e_KnightsDuty eDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
 
 			if (s_pPlayer->IDNumber() == sid)
 			{

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1899,7 +1899,6 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	/*int16_t sCapeID                 =*/pkt.read<int16_t>();
 
 	// 기사단 관련 세팅..
-	s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
 	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank, eKnightsDuty);
 	m_pUIVar->UpdateKnightsInfo();
 
@@ -5946,7 +5945,7 @@ void CGameProcMain::ParseChattingCommand(const std::string& szCmd)
 
 		case CMD_JOINCLAN:
 		{
-			if (s_pPlayer->m_InfoExt.eKnightsDuty == KNIGHTS_DUTY_CHIEF || s_pPlayer->m_InfoExt.eKnightsDuty == KNIGHTS_DUTY_VICECHIEF)
+			if (s_pPlayer->m_InfoBase.eKnightsDuty == KNIGHTS_DUTY_CHIEF || s_pPlayer->m_InfoBase.eKnightsDuty == KNIGHTS_DUTY_VICECHIEF)
 				MsgSend_KnightsJoin(s_pPlayer->m_iIDTarget);
 		}
 		break;
@@ -5957,7 +5956,7 @@ void CGameProcMain::ParseChattingCommand(const std::string& szCmd)
 
 		case CMD_FIRECLAN:
 		{
-			if (s_pPlayer->m_InfoExt.eKnightsDuty == KNIGHTS_DUTY_CHIEF)
+			if (s_pPlayer->m_InfoBase.eKnightsDuty == KNIGHTS_DUTY_CHIEF)
 			{
 				std::string szName = szCmds[1];
 				MsgSend_KnightsLeave(szName);
@@ -5967,7 +5966,7 @@ void CGameProcMain::ParseChattingCommand(const std::string& szCmd)
 
 		case CMD_APPOINTVICECHIEF:
 		{
-			if (s_pPlayer->m_InfoExt.eKnightsDuty == KNIGHTS_DUTY_CHIEF)
+			if (s_pPlayer->m_InfoBase.eKnightsDuty == KNIGHTS_DUTY_CHIEF)
 			{
 				std::string szName = szCmds[1];
 				MsgSend_KnightsAppointViceChief(szName);
@@ -6891,7 +6890,7 @@ void CGameProcMain::MsgRecv_Knights_Create(Packet& pkt)
 				if (m_pUIVar->m_pPageKnights->IsVisible())
 				{
 					m_pUIVar->m_pPageKnights->MsgSend_MemberInfoAll();
-					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoExt.eKnightsDuty);
+					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoBase.eKnightsDuty);
 				}
 
 				//m_pUIKnightsOp->KnightsInfoInsert(iID, szID); // 기사단 정보 추가..
@@ -6942,8 +6941,8 @@ void CGameProcMain::MsgRecv_Knights_Withdraw(Packet& pkt)
 			int sid = pkt.read<int16_t>();
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoBase.iKnightsID  = pkt.read<int16_t>();
-				s_pPlayer->m_InfoExt.eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
+				s_pPlayer->m_InfoBase.iKnightsID   = pkt.read<int16_t>();
+				s_pPlayer->m_InfoBase.eKnightsDuty = static_cast<e_KnightsDuty>(pkt.read<uint8_t>());
 				m_pUIVar->UpdateKnightsInfo();
 
 				s_pPlayer->KnightsInfoSet(s_pPlayer->m_InfoBase.iKnightsID, "", 0, 0);
@@ -6953,7 +6952,7 @@ void CGameProcMain::MsgRecv_Knights_Withdraw(Packet& pkt)
 				if (m_pUIVar->m_pPageKnights->IsVisible())
 				{
 					m_pUIVar->m_pPageKnights->MsgSend_MemberInfoAll();
-					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoExt.eKnightsDuty);
+					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoBase.eKnightsDuty);
 				}
 			}
 			else
@@ -7028,7 +7027,7 @@ void CGameProcMain::MsgRecv_Knights_Join(Packet& pkt)
 				if (m_pUIVar->m_pPageKnights->IsVisible())
 				{
 					m_pUIVar->m_pPageKnights->MsgSend_MemberInfoAll();
-					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoExt.eKnightsDuty);
+					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoBase.eKnightsDuty);
 				}
 			}
 			else
@@ -7126,7 +7125,7 @@ void CGameProcMain::MsgRecv_Knights_Leave(Packet& pkt)
 				if (m_pUIVar->m_pPageKnights->IsVisible())
 				{
 					m_pUIVar->m_pPageKnights->MsgSend_MemberInfoAll();
-					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoExt.eKnightsDuty);
+					m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoBase.eKnightsDuty);
 				}
 			}
 			else
@@ -7202,11 +7201,11 @@ void CGameProcMain::MsgRecv_Knights_AppointViceChief(Packet& pkt)
 	{
 		case N3_SP_KNIGHTS_COMMON_SUCCESS: //클랜가입 성공
 		{
-			int iID                           = pkt.read<int16_t>();
-			e_KnightsDuty eDuty               = (e_KnightsDuty) pkt.read<uint8_t>();
+			int iID                            = pkt.read<int16_t>();
+			e_KnightsDuty eDuty                = (e_KnightsDuty) pkt.read<uint8_t>();
 
-			s_pPlayer->m_InfoBase.iKnightsID  = iID;
-			s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
+			s_pPlayer->m_InfoBase.iKnightsID   = iID;
+			s_pPlayer->m_InfoBase.eKnightsDuty = eDuty;
 			m_pUIVar->UpdateKnightsInfo();
 
 			szMsg = fmt::format_text_resource(IDS_CLAN_JOIN_SUCCESS);
@@ -7215,7 +7214,7 @@ void CGameProcMain::MsgRecv_Knights_AppointViceChief(Packet& pkt)
 			if (m_pUIVar->m_pPageKnights->IsVisible())
 			{
 				m_pUIVar->m_pPageKnights->MsgSend_MemberInfoAll();
-				m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoExt.eKnightsDuty);
+				m_pUIVar->m_pPageKnights->ChangeUIByDuty(s_pPlayer->m_InfoBase.eKnightsDuty);
 			}
 		}
 		break;
@@ -7343,8 +7342,8 @@ void CGameProcMain::MsgRecv_Knights_Duty_Change(Packet& pkt)
 
 			if (s_pPlayer->IDNumber() == sid)
 			{
-				s_pPlayer->m_InfoBase.iKnightsID  = iID;
-				s_pPlayer->m_InfoExt.eKnightsDuty = eDuty;
+				s_pPlayer->m_InfoBase.iKnightsID   = iID;
+				s_pPlayer->m_InfoBase.eKnightsDuty = eDuty;
 				m_pUIVar->UpdateKnightsInfo();
 				if (s_pPlayer->m_InfoBase.iKnightsID == 0)
 					s_pPlayer->KnightsInfoSet(0, "", 0, 0);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -786,12 +786,11 @@ void CPlayerBase::RenderOverhead(_POINT pt)
 	// 풍선 메시지..
 	if (m_pBalloonFont && m_pBalloonFont->IsSetText()) //->GetFontHeight())
 	{
-		crFont = m_pBalloonFont->GetFontColor();
-		if (m_fTimeBalloon < 2.0f)                     // 천천히 흐릿하게 없앤다..
+		D3DCOLOR crBalloon = m_pBalloonFont->GetFontColor();
+		if (m_fTimeBalloon < 2.0f)
 		{
-			uint32_t crFont = m_pBalloonFont->GetFontColor();
-			crFont          = (crFont & 0x00ffffff) | ((uint32_t) (255 * (m_fTimeBalloon / 2.0f)) << 24);
-			m_pBalloonFont->SetFontColor(crFont);
+			crBalloon = (crBalloon & 0x00ffffff) | ((uint32_t) (255 * (m_fTimeBalloon / 2.0f)) << 24);
+			m_pBalloonFont->SetFontColor(crBalloon);
 		}
 
 		size  = m_pBalloonFont->GetSize();

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -295,7 +295,7 @@ void CPlayerBase::IDSet(int iID, const std::string& szID, D3DCOLOR crID)
 #endif
 }
 
-void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank)
+void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank, e_KnightsDuty /*eDuty*/)
 {
 	std::string szPlug;
 	if (iGrade > 0 && iGrade <= 5)
@@ -744,6 +744,55 @@ void CPlayerBase::Tick()  // 회전, 지정된 에니메이션 Tick 및 색깔 �
 	}
 }
 
+constexpr int CLAN_LEADER_LINE_OFFSET    = 1; // gap between name baseline and clan leader bar
+constexpr int CLAN_LEADER_LINE_THICKNESS = 1; // thickness the clan leader bar
+
+void CPlayerBase::DrawClanLeaderIndicator(const _POINT& pt)
+{
+	SIZE nameSize                     = m_pIDFont->GetSize();
+	float fLeft                       = static_cast<float>(pt.x) - (static_cast<float>(nameSize.cx) / 2.0f);
+	float fRight                      = static_cast<float>(pt.x) + (static_cast<float>(nameSize.cx) / 2.0f);
+	float fTop                        = static_cast<float>(pt.y + nameSize.cy + CLAN_LEADER_LINE_OFFSET);
+	float fBottom                     = static_cast<float>(pt.y + nameSize.cy + CLAN_LEADER_LINE_OFFSET + CLAN_LEADER_LINE_THICKNESS);
+
+	__VertexTransformedColor vLine[4] = {
+		{ fLeft, fTop, 0.0f, 1.0f, 0xff00ff00 },
+		{ fRight, fTop, 0.0f, 1.0f, 0xff00ff00 },
+		{ fRight, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+		{ fLeft, fBottom, 0.0f, 1.0f, 0xff00ff00 },
+	};
+
+	DWORD dwPrevFVF = 0;
+	if (FAILED(s_lpD3DDev->GetFVF(&dwPrevFVF)))
+		return;
+
+	IDirect3DBaseTexture9* pPrevTexture = nullptr;
+	s_lpD3DDev->GetTexture(0, &pPrevTexture);
+
+	if (FAILED(s_lpD3DDev->SetTexture(0, nullptr)))
+	{
+		if (pPrevTexture != nullptr)
+			pPrevTexture->Release();
+		return;
+	}
+
+	if (FAILED(s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR)))
+	{
+		s_lpD3DDev->SetTexture(0, pPrevTexture);
+		if (pPrevTexture != nullptr)
+			pPrevTexture->Release();
+		return;
+	}
+
+	s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, vLine, sizeof(__VertexTransformedColor));
+
+	s_lpD3DDev->SetTexture(0, pPrevTexture);
+	if (pPrevTexture != nullptr)
+		pPrevTexture->Release();
+
+	s_lpD3DDev->SetFVF(dwPrevFVF);
+}
+
 void CPlayerBase::Render(float fSunAngle)
 {
 	if (m_Chr.m_nLOD < 0 || m_Chr.m_nLOD >= MAX_CHR_LOD)
@@ -860,6 +909,10 @@ void CPlayerBase::Render(float fSunAngle)
 			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
 			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
 			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
+
+			// Draw green line under name if clan leader
+			if (KnightsDuty() == KNIGHTS_DUTY_CHIEF)
+				DrawClanLeaderIndicator(pt);
 
 			//Knight & clan 렌더링..
 			if (m_pClanFont && m_pClanFont->IsSetText())

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -295,9 +295,10 @@ void CPlayerBase::IDSet(int iID, const std::string& szID, D3DCOLOR crID)
 #endif
 }
 
-void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank, e_KnightsDuty /*eDuty*/)
+void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGrade, int iRank, e_KnightsDuty eDuty)
 {
 	std::string szPlug;
+	m_InfoBase.eKnightsDuty = eDuty;
 	if (iGrade > 0 && iGrade <= 5)
 	{
 		// 종족과 등급으로 플러그 이름을 만든다..
@@ -747,6 +748,60 @@ void CPlayerBase::Tick()  // 회전, 지정된 에니메이션 Tick 및 색깔 �
 constexpr int CLAN_LEADER_LINE_OFFSET    = 1; // gap between name baseline and clan leader bar
 constexpr int CLAN_LEADER_LINE_THICKNESS = 1; // thickness the clan leader bar
 
+void CPlayerBase::RenderOverhead(_POINT pt)
+{
+	SIZE size        = m_pIDFont->GetSize();
+	pt.y            -= size.cy + 5;
+	D3DCOLOR crFont  = m_pIDFont->GetFontColor();
+
+	m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
+	m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
+	m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
+
+	if (m_InfoBase.eKnightsDuty == KNIGHTS_DUTY_CHIEF)
+		DrawClanLeaderIndicator(pt);
+
+	//Knight & clan 렌더링..
+	if (m_pClanFont && m_pClanFont->IsSetText())
+	{
+		size    = m_pClanFont->GetSize();
+		pt.y   -= size.cy + 5;
+		crFont  = m_pClanFont->GetFontColor();
+		m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
+		m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
+		m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
+	}
+
+	// 파티 모집...
+	if (m_pInfoFont && m_pInfoFont->IsSetText()) //->GetFontHeight() > 0)
+	{
+		size    = m_pInfoFont->GetSize();
+		pt.y   -= size.cy + 5;
+		crFont  = m_pInfoFont->GetFontColor();
+		m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
+		m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
+		m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
+	}
+
+	// 풍선 메시지..
+	if (m_pBalloonFont && m_pBalloonFont->IsSetText()) //->GetFontHeight())
+	{
+		crFont = m_pBalloonFont->GetFontColor();
+		if (m_fTimeBalloon < 2.0f)                     // 천천히 흐릿하게 없앤다..
+		{
+			uint32_t crFont = m_pBalloonFont->GetFontColor();
+			crFont          = (crFont & 0x00ffffff) | ((uint32_t) (255 * (m_fTimeBalloon / 2.0f)) << 24);
+			m_pBalloonFont->SetFontColor(crFont);
+		}
+
+		size  = m_pBalloonFont->GetSize();
+		pt.y -= size.cy + 5;
+		m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
+		m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
+		m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, D3DFONT_BOLD);
+	}
+}
+
 void CPlayerBase::DrawClanLeaderIndicator(const _POINT& pt)
 {
 	SIZE nameSize                     = m_pIDFont->GetSize();
@@ -902,57 +957,7 @@ void CPlayerBase::Render(float fSunAngle)
 			_POINT pt = ::_Convert3D_To_2DCoordinate(
 				vHead, s_CameraData.mtxView, s_CameraData.mtxProjection, s_CameraData.vp.Width, s_CameraData.vp.Height);
 
-			SIZE size        = m_pIDFont->GetSize();
-			pt.y            -= size.cy + 5;
-			D3DCOLOR crFont  = m_pIDFont->GetFontColor();
-
-			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
-			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
-			m_pIDFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
-
-			// Draw green line under name if clan leader
-			if (KnightsDuty() == KNIGHTS_DUTY_CHIEF)
-				DrawClanLeaderIndicator(pt);
-
-			//Knight & clan 렌더링..
-			if (m_pClanFont && m_pClanFont->IsSetText())
-			{
-				size    = m_pClanFont->GetSize();
-				pt.y   -= size.cy + 5;
-				crFont  = m_pClanFont->GetFontColor();
-				m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
-				m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
-				m_pClanFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
-			}
-
-			// 파티 모집...
-			if (m_pInfoFont && m_pInfoFont->IsSetText()) //->GetFontHeight() > 0)
-			{
-				size    = m_pInfoFont->GetSize();
-				pt.y   -= size.cy + 5;
-				crFont  = m_pInfoFont->GetFontColor();
-				m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
-				m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
-				m_pInfoFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, 0);
-			}
-
-			// 풍선 메시지..
-			if (m_pBalloonFont && m_pBalloonFont->IsSetText()) //->GetFontHeight())
-			{
-				crFont = m_pBalloonFont->GetFontColor();
-				if (m_fTimeBalloon < 2.0f)                     // 천천히 흐릿하게 없앤다..
-				{
-					uint32_t crFont = m_pBalloonFont->GetFontColor();
-					crFont          = (crFont & 0x00ffffff) | ((uint32_t) (255 * (m_fTimeBalloon / 2.0f)) << 24);
-					m_pBalloonFont->SetFontColor(crFont);
-				}
-
-				size  = m_pBalloonFont->GetSize();
-				pt.y -= size.cy + 5;
-				m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) - 1.0f, pt.y - 1.0f, 0xff000000, 0);
-				m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) + 1.0f, pt.y + 1.0f, 0xff000000, 0);
-				m_pBalloonFont->DrawText(pt.x - (size.cx / 2.0f) + 0.0f, pt.y + 0.0f, crFont, D3DFONT_BOLD);
-			}
+			RenderOverhead(pt); // Render information over character
 		}
 	}
 }

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -371,7 +371,13 @@ public:
 	void InfoStringSet(const std::string& szInfo, D3DCOLOR crFont);
 	void BalloonStringSet(const std::string& szBalloon, D3DCOLOR crFont);
 	void IDSet(int iID, const std::string& szID, D3DCOLOR crID);
-	virtual void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank);
+	virtual e_KnightsDuty KnightsDuty() const
+	{
+		return KNIGHTS_DUTY_UNKNOWN;
+	}
+
+	void DrawClanLeaderIndicator(const _POINT& pt);
+	virtual void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN);
 
 	// ID 는 Character 포인터의 이름으로 대신한다.
 	const std::string& IDString() const

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -41,12 +41,12 @@ struct __InfoPlayerBase
 	int iHP;
 	int iMP;
 	int iMPMax;
-	int iAuthority; // 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
-	int iKnightsID; // Clan ID
+	int iAuthority;             // 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
+	int iKnightsID;             // Clan ID
 	int iAllianceID;
 	int iKnightsWarEnemyID;
-
-	bool bRenderID; // 화면에 ID 를 찍는지..
+	bool bRenderID;             // 화면에 ID 를 찍는지..
+	e_KnightsDuty eKnightsDuty; //Clan leader/ duty role
 
 	__InfoPlayerBase()
 	{
@@ -70,6 +70,7 @@ struct __InfoPlayerBase
 		iKnightsID         = 0;
 		iAllianceID        = 0;
 		iKnightsWarEnemyID = 0;
+		eKnightsDuty       = KNIGHTS_DUTY_UNKNOWN;
 		bRenderID          = true;
 	}
 };
@@ -371,12 +372,8 @@ public:
 	void InfoStringSet(const std::string& szInfo, D3DCOLOR crFont);
 	void BalloonStringSet(const std::string& szBalloon, D3DCOLOR crFont);
 	void IDSet(int iID, const std::string& szID, D3DCOLOR crID);
-	virtual e_KnightsDuty KnightsDuty() const
-	{
-		return KNIGHTS_DUTY_UNKNOWN;
-	}
-
 	void DrawClanLeaderIndicator(const _POINT& pt);
+	virtual void RenderOverhead(_POINT pt);
 	virtual void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN);
 
 	// ID 는 Character 포인터의 이름으로 대신한다.

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -990,13 +990,14 @@ void CPlayerMySelf::InitHair()
 	}
 }
 
-void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank)
+void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty)
 {
-	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank);
+	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank, eDuty);
 
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
+	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -997,7 +997,6 @@ void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrad
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
-	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerMySelf.h
+++ b/src/Client/WarFare/PlayerMySelf.h
@@ -43,6 +43,10 @@ public:
 	__Vector3 m_vTargetPos;          // 이동할 지점 위치
 	void SetMoveTargetID(int iID);
 	void SetMoveTargetPos(const __Vector3& vPos);
+	e_KnightsDuty KnightsDuty() const override
+	{
+		return m_InfoExt.eKnightsDuty;
+	}
 
 public:
 	void TargetOrPosMove();
@@ -57,7 +61,7 @@ public:
 
 	// 갖고 있는 정보로 머리카락을 초기화 한다..
 	void InitHair() override;
-	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank) override;
+	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN) override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
 
 	float AttackableDistance(CPlayerBase* pTarget);

--- a/src/Client/WarFare/PlayerMySelf.h
+++ b/src/Client/WarFare/PlayerMySelf.h
@@ -43,10 +43,6 @@ public:
 	__Vector3 m_vTargetPos;          // 이동할 지점 위치
 	void SetMoveTargetID(int iID);
 	void SetMoveTargetPos(const __Vector3& vPos);
-	e_KnightsDuty KnightsDuty() const override
-	{
-		return m_InfoExt.eKnightsDuty;
-	}
 
 public:
 	void TargetOrPosMove();

--- a/src/Client/WarFare/PlayerNPC.cpp
+++ b/src/Client/WarFare/PlayerNPC.cpp
@@ -127,6 +127,11 @@ void CPlayerNPC::MoveTo(float fPosX, float fPosY, float fPosZ, float fSpeed, int
 		m_fMoveSpeedPerSec *= -1.0f;   // 뒤로 간다..
 }
 
+void CPlayerNPC::RenderOverhead(_POINT pt)
+{
+	CPlayerBase::RenderOverhead(pt);
+}
+
 void CPlayerNPC::SetSoundAndInitFont(uint32_t dwFontFlag)
 {
 	CPlayerBase::SetSoundAndInitFont(dwFontFlag);

--- a/src/Client/WarFare/PlayerNPC.h
+++ b/src/Client/WarFare/PlayerNPC.h
@@ -18,6 +18,7 @@ public:
 	void MoveTo(float fPosX, float fPosY, float fPosZ, float fMoveSpeed, int iMoveMode); // 이 위치로 이동..
 	void Tick() override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
+	void RenderOverhead(_POINT pt) override;			// Information over character
 
 	CPlayerNPC();
 	~CPlayerNPC() override;

--- a/src/Client/WarFare/PlayerNPC.h
+++ b/src/Client/WarFare/PlayerNPC.h
@@ -18,7 +18,7 @@ public:
 	void MoveTo(float fPosX, float fPosY, float fPosZ, float fMoveSpeed, int iMoveMode); // 이 위치로 이동..
 	void Tick() override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
-	void RenderOverhead(_POINT pt) override;			// Information over character
+	void RenderOverhead(_POINT pt) override;                                             // Information over character
 
 	CPlayerNPC();
 	~CPlayerNPC() override;

--- a/src/Client/WarFare/PlayerOther.cpp
+++ b/src/Client/WarFare/PlayerOther.cpp
@@ -208,7 +208,6 @@ void CPlayerOther::KnightsInfoSet(int iID, const std::string& szName, int iGrade
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
-	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerOther.cpp
+++ b/src/Client/WarFare/PlayerOther.cpp
@@ -201,13 +201,14 @@ void CPlayerOther::InitHair()
 	}
 }
 
-void CPlayerOther::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank)
+void CPlayerOther::KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty)
 {
-	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank);
+	CPlayerBase::KnightsInfoSet(iID, szName, iGrade, iRank, eDuty);
 
 	m_InfoExt.szKnights     = szName;
 	m_InfoExt.iKnightsGrade = iGrade;
 	m_InfoExt.iKnightsRank  = iRank;
+	m_InfoExt.eKnightsDuty  = eDuty;
 
 	if (m_InfoExt.szKnights.empty())
 	{

--- a/src/Client/WarFare/PlayerOther.h
+++ b/src/Client/WarFare/PlayerOther.h
@@ -17,10 +17,6 @@ class CPlayerOther : public CPlayerNPC
 public:
 	__InfoPlayerOther m_InfoExt; // 캐릭터 정보 확장..
 	bool m_bSit;
-	e_KnightsDuty KnightsDuty() const override
-	{
-		return m_InfoExt.eKnightsDuty;
-	}
 
 public:
 	void InitFace() override;

--- a/src/Client/WarFare/PlayerOther.h
+++ b/src/Client/WarFare/PlayerOther.h
@@ -17,11 +17,15 @@ class CPlayerOther : public CPlayerNPC
 public:
 	__InfoPlayerOther m_InfoExt; // 캐릭터 정보 확장..
 	bool m_bSit;
+	e_KnightsDuty KnightsDuty() const override
+	{
+		return m_InfoExt.eKnightsDuty;
+	}
 
 public:
 	void InitFace() override;
 	void InitHair() override;
-	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank) override;
+	void KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank, e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN) override;
 	void SetSoundAndInitFont(uint32_t dwFontFlag = 0U) override;
 
 	bool Init(enum e_Race eRace, int iFace, int iHair, uint32_t* pdwItemIDs, int* piItenDurabilities, uint8_t* pbyItemFlags);

--- a/src/Client/WarFare/UIVarious.cpp
+++ b/src/Client/WarFare/UIVarious.cpp
@@ -579,7 +579,7 @@ void CUIKnights::Clear()
 	m_pText_Duty->SetString("");
 	m_pText_MemberCount->SetString("0");
 
-	this->ChangeUIByDuty(CGameBase::s_pPlayer->m_InfoExt.eKnightsDuty);
+	this->ChangeUIByDuty(CGameBase::s_pPlayer->m_InfoBase.eKnightsDuty);
 }
 
 void CUIKnights::SetVisible(bool bVisible)
@@ -1027,11 +1027,11 @@ void CUIKnights::ChangeUIByDuty(e_KnightsDuty eDuty) // 권한에 따라 UI 변�
 
 void CUIKnights::UpdateExceptList()
 {
-	UpdateKnightsDuty(CGameBase::s_pPlayer->m_InfoExt.eKnightsDuty);
+	UpdateKnightsDuty(CGameBase::s_pPlayer->m_InfoBase.eKnightsDuty);
 	UpdateKnightsName(CGameBase::s_pPlayer->m_InfoExt.szKnights);
 	UpdateKnightsGrade(CGameBase::s_pPlayer->m_InfoExt.iKnightsGrade);
 	UpdateKnightsRank(CGameBase::s_pPlayer->m_InfoExt.iKnightsRank);
-	ChangeUIByDuty(CGameBase::s_pPlayer->m_InfoExt.eKnightsDuty);
+	ChangeUIByDuty(CGameBase::s_pPlayer->m_InfoBase.eKnightsDuty);
 }
 
 CUIFriends::CUIFriends()
@@ -1781,7 +1781,7 @@ void CUIVarious::UpdateKnightsInfo()
 		return;
 
 	/*
-		m_pPageKnights->UpdateKnightsDuty(CGameBase::s_pPlayer->m_InfoExt.eKnightsDuty);
+		m_pPageKnights->UpdateKnightsDuty(CGameBase::s_pPlayer->m_InfoBase.eKnightsDuty);
 		m_pPageKnights->UpdateKnightsName(CGameBase::s_pPlayer->m_InfoExt.szKnights);
 		m_pPageKnights->UpdateKnightsGrade(CGameBase::s_pPlayer->m_InfoExt.iKnightsGrade);
 		m_pPageKnights->UpdateKnightsRank(CGameBase::s_pPlayer->m_InfoExt.iKnightsRank);


### PR DESCRIPTION
## Pull request type


Please check the type of change your PR introduces:

- [X] Bugfix

## What is the current behaviour?
The green clan leader line does not appear under the character name. Refer to #374.

## What is the new behaviour?
The green clan leader line appears if the character is a clan leader.

## Why and how did I change this?
The packet was in the code, however it was commented out in GameProcMain.
Moved the character overhead information into CPlayerBase::RenderOverhead

## Was AI used at some point for any part of this change? If so, what?
No

## Demo
<img width="318" height="324" alt="567234497-5d423a0d-3f2c-4b7e-a4c2-f170566a98d8" src="https://github.com/user-attachments/assets/f08d29ca-6329-42ca-85fc-092978936685" />


## Checklist

- [X] I have performed a self-review of my own code.
- [X] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [X] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
