### PR TITLE
feat: King System (Phase 1-3), cape rendering, equip-crash fixes 

### DIFF
--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -443,6 +443,7 @@ struct __InfoPlayerOther
 		iCity         = 0;
 		iKnightsGrade = 0;
 		iKnightsRank  = 0;
+		iRank         = 0;
 		iTitle        = 0;
 
 		szKnights.clear();

--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -427,7 +427,6 @@ struct __InfoPlayerOther
 	int iKnightsGrade;     // Clan grade
 	int iKnightsRank;      // Clan ranking
 
-	int iRank;             // Noble rank - used to identify high-ranking titles like King [1], Senator [2].
 	int iTitle;            // Bitmask representing various titles/roles including:
 						   // Clan Leader, Clan Assistant, Castle Lord, Feudal Lord, King, Emperor, Party leader, Solo player
 
@@ -443,7 +442,6 @@ struct __InfoPlayerOther
 		iCity         = 0;
 		iKnightsGrade = 0;
 		iKnightsRank  = 0;
-		iRank         = 0;
 		iTitle        = 0;
 
 		szKnights.clear();

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -2176,10 +2176,10 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	// 기본값 읽기..
 	////////////////////////////////////////////////////////////
 
-	InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
+	InitPlayerPosition(__Vector3(fX, fY, fZ));                   // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 	s_pPlayer->RegenerateCollisionMesh();
-	s_pPlayer->AttachCloak(sCapeID);           // Cloak
-	s_pOPMgr->Release();                       // 다른 유저 관리 클래스 초기화..
+	s_pPlayer->AttachCloak(sCapeID, s_pPlayer->m_InfoExt.iRank); // Cloak
+	s_pOPMgr->Release();                                         // 다른 유저 관리 클래스 초기화..
 
 	if (m_pUICmdList != nullptr)
 		m_pUICmdList->CreateCategoryList();
@@ -2542,7 +2542,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	int iKnightsRank     = pkt.read<uint8_t>(); // 순위
 
 	int16_t sMarkVersion = pkt.read<int16_t>(); // Clan mark
-	int16_t sCapeID      = pkt.read<int16_t>(); // Clan cloak
+	int16_t sCapeID      = pkt.read<int16_t>(); // Cloak
 
 	int iLevel           = pkt.read<uint8_t>(); // 레벨...
 	e_Race eRace         = (e_Race) pkt.read<uint8_t>();
@@ -2574,7 +2574,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	/*uint8_t bInvisibilityType =*/pkt.read<uint8_t>();
 	/*int16_t sDirection        =*/pkt.read<int16_t>();
 	/*bool bIsChicken           =*/pkt.read<bool>();
-	/*uint8_t bRank             =*/pkt.read<uint8_t>();
+	uint8_t byRank = pkt.read<uint8_t>(); // Noble rank??
 	/*uint8_t bKnightsRank      =*/pkt.read<uint8_t>();
 	/*uint8_t bPersonalRank     =*/pkt.read<uint8_t>();
 
@@ -2624,8 +2624,9 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->m_InfoBase.iAuthority = byAuthority;
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
+	pUPC->m_InfoBase.iMarkVersion = sMarkVersion;
 	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
-	pUPC->AttachCloak(sCapeID);
+	pUPC->AttachCloak(sCapeID, byRank);
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1890,17 +1890,18 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	/*int iAllianceID                       =*/pkt.read<int16_t>();
 	/*uint8_t byFlag                        =*/pkt.read<uint8_t>();
 
-	int iKnightNameLen = pkt.read<uint8_t>(); // 소속 기사단 이름 길이.
+	int iKnightNameLen = pkt.read<uint8_t>();                // 소속 기사단 이름 길이.
 	pkt.readString(szKnightsName, iKnightNameLen);
-	int iKnightsGrade = pkt.read<uint8_t>();  // 소속 기사단 등급
-	int iKnightsRank  = pkt.read<uint8_t>();  // 소속 기사단 순위
+	int iKnightsGrade = pkt.read<uint8_t>();                 // 소속 기사단 등급
+	int iKnightsRank  = pkt.read<uint8_t>();                 // 소속 기사단 순위
 
 	/*int16_t sMarkVersion            =*/pkt.read<int16_t>();
-	/*int16_t sCapeID                 =*/pkt.read<int16_t>();
+	int16_t sCapeID                   = pkt.read<int16_t>(); // Clan cape
 
 	// 기사단 관련 세팅..
 	s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
 	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	s_pPlayer->AttachCloak(sCapeID);
 	m_pUIVar->UpdateKnightsInfo();
 
 	s_pPlayer->m_InfoBase.iHPMax             = pkt.read<int16_t>();
@@ -2178,14 +2179,6 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 	s_pPlayer->RegenerateCollisionMesh();
 
-	// berserk temp
-	//s_pPlayer->PlugSet(PLUG_POS_BACK, "item/babacloak.n3cplug_cloak", nullptr);	// 파트를 셋팅..
-	// end berserk temp
-
-	// berserk
-	//s_pPlayer->AttachCloak();
-
-	//..
 	s_pOPMgr->Release(); // 다른 유저 관리 클래스 초기화..
 
 	if (m_pUICmdList != nullptr)
@@ -2549,9 +2542,9 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	int iKnightsRank  = pkt.read<uint8_t>();  // 순위
 
 	/*int16_t sMarkVersion =*/pkt.read<int16_t>();
-	/*int16_t sCapeID    =*/pkt.read<int16_t>();
+	int16_t sCapeID = pkt.read<int16_t>();    // Clan cape
 
-	int iLevel      = pkt.read<uint8_t>(); // 레벨...
+	int iLevel      = pkt.read<uint8_t>();    // 레벨...
 	e_Race eRace    = (e_Race) pkt.read<uint8_t>();
 	e_Class eClass  = (e_Class) pkt.read<int16_t>();
 	float fXPos     = (pkt.read<uint16_t>()) / 10.0f;
@@ -2632,6 +2625,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
 	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
+	pUPC->AttachCloak(sCapeID);
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1088,6 +1088,9 @@ bool CGameProcMain::ProcessPacket(Packet& pkt)
 			}
 		}
 		break;
+		case WIZ_SERVER_INDEX:
+			this->MsgRecv_ServerIndex(pkt);
+			return true;
 
 		case WIZ_ITEM_UPGRADE:
 			MsgRecv_ItemUpgrade(pkt);
@@ -1867,7 +1870,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	__ASSERT(pLooks, "failed find character resource data");
 	s_pPlayer->InitChr(pLooks); // 관절 세팅..
 
-	s_pPlayer->m_InfoExt.iRank              = pkt.read<uint8_t>();
+	s_pPlayer->m_InfoBase.iRank             = pkt.read<uint8_t>();
 	s_pPlayer->m_InfoExt.iTitle             = pkt.read<uint8_t>();
 	s_pPlayer->m_InfoBase.iLevel            = pkt.read<uint8_t>();
 	s_pPlayer->m_InfoExt.iLevelPrev         = s_pPlayer->m_InfoBase.iLevel;
@@ -2176,10 +2179,10 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	// 기본값 읽기..
 	////////////////////////////////////////////////////////////
 
-	InitPlayerPosition(__Vector3(fX, fY, fZ));                   // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
+	InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 	s_pPlayer->RegenerateCollisionMesh();
-	s_pPlayer->AttachCloak(sCapeID, s_pPlayer->m_InfoExt.iRank); // Cloak
-	s_pOPMgr->Release();                                         // 다른 유저 관리 클래스 초기화..
+	s_pPlayer->AttachCloak(sCapeID);           // Cloak
+	s_pOPMgr->Release();                       // 다른 유저 관리 클래스 초기화..
 
 	if (m_pUICmdList != nullptr)
 		m_pUICmdList->CreateCategoryList();
@@ -2574,7 +2577,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	/*uint8_t bInvisibilityType =*/pkt.read<uint8_t>();
 	/*int16_t sDirection        =*/pkt.read<int16_t>();
 	/*bool bIsChicken           =*/pkt.read<bool>();
-	uint8_t byRank = pkt.read<uint8_t>(); // Noble rank??
+	uint8_t byRank = pkt.read<uint8_t>(); // Noble rank - used to identify high-ranking titles like King [1], Senator [2]
 	/*uint8_t bKnightsRank      =*/pkt.read<uint8_t>();
 	/*uint8_t bPersonalRank     =*/pkt.read<uint8_t>();
 
@@ -2622,11 +2625,12 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 	pUPC->m_InfoBase.eClass     = eClass;
 	pUPC->m_InfoBase.iLevel     = iLevel;
 	pUPC->m_InfoBase.iAuthority = byAuthority;
+	pUPC->m_InfoBase.iRank      = byRank;
 	pUPC->Init(eRace, iFace, iHair, dwItemIDs, iItemDurabilities, byItemFlags);
 	pUPC->RotateTo(DegreesToRadians(rand() % 360), true);
 	pUPC->m_InfoBase.iMarkVersion = sMarkVersion;
 	pUPC->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
-	pUPC->AttachCloak(sCapeID, byRank);
+	pUPC->AttachCloak(sCapeID);
 
 	//__KnightsInfoBase* pKIB = m_pUIKnightsOp->KnightsInfoFind(iKightsID);
 	//if(pKIB) pUPC->KnightsNameSet(pKIB->szName, 0xffff0000);
@@ -8045,4 +8049,12 @@ void CGameProcMain::MsgRecv_ZoneAbility(Packet& pkt)
 		s_pPlayer->m_InfoExt.bCanTalkToOtherNation    = pkt.read<bool>();
 		s_pPlayer->m_InfoExt.sZoneTariff              = pkt.read<int16_t>();
 	}
+}
+
+void CGameProcMain::MsgRecv_ServerIndex(Packet& pkt)
+{
+	int16_t sResult = pkt.read<int16_t>();
+	if (sResult == 0) // 1 = success, 0 = server index unavailable
+		return;
+	m_nServerIndex = pkt.read<int16_t>();
 }

--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -1890,18 +1890,18 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	/*int iAllianceID                       =*/pkt.read<int16_t>();
 	/*uint8_t byFlag                        =*/pkt.read<uint8_t>();
 
-	int iKnightNameLen = pkt.read<uint8_t>();                // 소속 기사단 이름 길이.
+	int iKnightNameLen = pkt.read<uint8_t>();                 // 소속 기사단 이름 길이.
 	pkt.readString(szKnightsName, iKnightNameLen);
-	int iKnightsGrade = pkt.read<uint8_t>();                 // 소속 기사단 등급
-	int iKnightsRank  = pkt.read<uint8_t>();                 // 소속 기사단 순위
+	int iKnightsGrade                  = pkt.read<uint8_t>(); // 소속 기사단 등급
+	int iKnightsRank                   = pkt.read<uint8_t>(); // 소속 기사단 순위
 
-	/*int16_t sMarkVersion            =*/pkt.read<int16_t>();
-	int16_t sCapeID                   = pkt.read<int16_t>(); // Clan cape
+	int16_t sMarkVersion               = pkt.read<int16_t>(); // Clan mark
+	int16_t sCapeID                    = pkt.read<int16_t>(); // Clan cloak
 
 	// 기사단 관련 세팅..
-	s_pPlayer->m_InfoExt.eKnightsDuty = eKnightsDuty; // 기사단에서의 권한..
+	s_pPlayer->m_InfoExt.eKnightsDuty  = eKnightsDuty; // 기사단에서의 권한..
+	s_pPlayer->m_InfoBase.iMarkVersion = sMarkVersion; // Clan mark
 	s_pPlayer->KnightsInfoSet(iKnightsID, szKnightsName, iKnightsGrade, iKnightsRank);
-	s_pPlayer->AttachCloak(sCapeID);
 	m_pUIVar->UpdateKnightsInfo();
 
 	s_pPlayer->m_InfoBase.iHPMax             = pkt.read<int16_t>();
@@ -2178,8 +2178,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 	InitPlayerPosition(__Vector3(fX, fY, fZ)); // 플레이어 위치 초기화.. 일으켜 세우고, 기본동작을 취하게 한다.
 	s_pPlayer->RegenerateCollisionMesh();
-
-	s_pOPMgr->Release(); // 다른 유저 관리 클래스 초기화..
+	s_pPlayer->AttachCloak(sCapeID);           // Cloak
+	s_pOPMgr->Release();                       // 다른 유저 관리 클래스 초기화..
 
 	if (m_pUICmdList != nullptr)
 		m_pUICmdList->CreateCategoryList();
@@ -2535,24 +2535,24 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 
 	/*int16_t sAllianceID      =*/pkt.read<int16_t>();
 
-	int iKnightNameLen = pkt.read<uint8_t>(); // 소속 기사단 이름 길이.
+	int iKnightNameLen = pkt.read<uint8_t>();   // 소속 기사단 이름 길이.
 	std::string szKnightsName;
 	pkt.readString(szKnightsName, iKnightNameLen);
-	int iKnightsGrade = pkt.read<uint8_t>();  // 등급
-	int iKnightsRank  = pkt.read<uint8_t>();  // 순위
+	int iKnightsGrade    = pkt.read<uint8_t>(); // 등급
+	int iKnightsRank     = pkt.read<uint8_t>(); // 순위
 
-	/*int16_t sMarkVersion =*/pkt.read<int16_t>();
-	int16_t sCapeID = pkt.read<int16_t>();    // Clan cape
+	int16_t sMarkVersion = pkt.read<int16_t>(); // Clan mark
+	int16_t sCapeID      = pkt.read<int16_t>(); // Clan cloak
 
-	int iLevel      = pkt.read<uint8_t>();    // 레벨...
-	e_Race eRace    = (e_Race) pkt.read<uint8_t>();
-	e_Class eClass  = (e_Class) pkt.read<int16_t>();
-	float fXPos     = (pkt.read<uint16_t>()) / 10.0f;
-	float fZPos     = (pkt.read<uint16_t>()) / 10.0f;
-	float fYPos     = (pkt.read<int16_t>()) / 10.0f;
+	int iLevel           = pkt.read<uint8_t>(); // 레벨...
+	e_Race eRace         = (e_Race) pkt.read<uint8_t>();
+	e_Class eClass       = (e_Class) pkt.read<int16_t>();
+	float fXPos          = (pkt.read<uint16_t>()) / 10.0f;
+	float fZPos          = (pkt.read<uint16_t>()) / 10.0f;
+	float fYPos          = (pkt.read<int16_t>()) / 10.0f;
 
-	float fYTerrain = ACT_WORLD->GetHeightWithTerrain(fXPos, fZPos);                          // 지형의 높이값 얻기..
-	float fYObject  = ACT_WORLD->GetHeightNearstPosWithShape(__Vector3(fXPos, fYPos, fZPos)); // 오브젝트에서 가장 가까운 높이값 얻기..
+	float fYTerrain      = ACT_WORLD->GetHeightWithTerrain(fXPos, fZPos);                          // 지형의 높이값 얻기..
+	float fYObject       = ACT_WORLD->GetHeightNearstPosWithShape(__Vector3(fXPos, fYPos, fZPos)); // 오브젝트에서 가장 가까운 높이값 얻기..
 	if (fYObject > fYTerrain)
 		fYPos = fYObject;
 	else

--- a/src/Client/WarFare/GameProcMain.h
+++ b/src/Client/WarFare/GameProcMain.h
@@ -108,6 +108,8 @@ protected:
 
 	bool MsgRecv_CharacterSelect(Packet& pkt) override; // virtual
 	int MsgRecv_VersionCheck(Packet& pkt) override;     // virtual
+	void MsgRecv_ServerIndex(Packet& pkt);              // Server index
+	int m_nServerIndex = 0;
 
 	bool MsgRecv_MyInfo_All(Packet& pkt);
 	void MsgRecv_MyInfo_HP(Packet& pkt);

--- a/src/Client/WarFare/GameProcedure.cpp
+++ b/src/Client/WarFare/GameProcedure.cpp
@@ -711,6 +711,11 @@ std::string CGameProcedure::GetStrRegKeySetting()
 	return fmt::format("Software\\KnightOnline\\{}_{}_{}", s_szAccount, s_szServer, s_iChrSelectIndex);
 }
 
+std::string CGameProcedure::GetSymbolFilename(const int serverIndex, const int knightsId, const int markVersion)
+{
+	return fmt::format("symbol_us\\s_{}_{}_{}.dxt", serverIndex, knightsId, markVersion);
+}
+
 bool CGameProcedure::ProcessPacket(Packet& pkt)
 {
 	int iCmd = pkt.read<uint8_t>(); // 커멘드 파싱..

--- a/src/Client/WarFare/GameProcedure.cpp
+++ b/src/Client/WarFare/GameProcedure.cpp
@@ -716,6 +716,11 @@ std::string CGameProcedure::GetSymbolFilename(const int serverIndex, const int k
 	return fmt::format("symbol_us\\s_{}_{}_{}.dxt", serverIndex, knightsId, markVersion);
 }
 
+int CGameProcedure::GetServerIndex()
+{
+	return s_pProcMain ? s_pProcMain->m_nServerIndex : 0;
+}
+
 bool CGameProcedure::ProcessPacket(Packet& pkt)
 {
 	int iCmd = pkt.read<uint8_t>(); // 커멘드 파싱..

--- a/src/Client/WarFare/GameProcedure.h
+++ b/src/Client/WarFare/GameProcedure.h
@@ -149,6 +149,8 @@ public:
 	static void SetGameCursor(e_Cursor eCursor, bool bLocked = false);
 	static void RestoreGameCursor();
 
+	static std::string GetSymbolFilename(const int serverIndex, const int knightsId, const int markVersion);
+
 protected:
 	virtual bool ProcessPacket(Packet& pkt);
 	void MsgRecv_ServerChange(Packet& pkt);

--- a/src/Client/WarFare/GameProcedure.h
+++ b/src/Client/WarFare/GameProcedure.h
@@ -150,6 +150,7 @@ public:
 	static void RestoreGameCursor();
 
 	static std::string GetSymbolFilename(const int serverIndex, const int knightsId, const int markVersion);
+	static int GetServerIndex();
 
 protected:
 	virtual bool ProcessPacket(Packet& pkt);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1723,7 +1723,14 @@ CN3CPlugBase* CPlayerBase::PlugSet(
 		__ASSERT(0, "Invalid Plug Position");
 		return nullptr;
 	}
-
+	if (m_InfoBase.bIsTransformed && !isForce) // Skip plug if player is transformed
+	{
+		if (pItemBasic)
+			m_pItemPlugBasics[ePos] = pItemBasic;
+		if (pItemExt)
+			m_pItemPlugExts[ePos] = pItemExt;
+		return nullptr;
+	}
 	int iJoint = 0;
 	if (PLUG_POS_RIGHTHAND == ePos)
 	{
@@ -1870,12 +1877,11 @@ CN3CPlugBase* CPlayerBase::PlugSet(
 	return pPlug;
 }
 
-void CPlayerBase::AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce)
+void CPlayerBase::AttachCloak(int16_t sCapeID, bool isForce)
 {
-	PlugSet(PLUG_POS_BACK, "", nullptr, nullptr, isForce);
+	PlugSet(PLUG_POS_BACK, "", nullptr, nullptr, /*isForce=*/true);                                             // Remove cloak
 
-	//Temporary to prevent cloaks on all chars while still a work in progress -1 = no cloak
-	if (sCapeID < 0)
+	if (sCapeID < 0)                                                                                            // No cloak
 		return;
 
 	const std::string sMeshPath = fmt::format("Item\\Cloak_{:03}.n3cplug", static_cast<int>(m_InfoBase.eRace)); // Cloak mesh for each race
@@ -1887,7 +1893,7 @@ void CPlayerBase::AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce)
 	std::string sPatternTexPath;
 	std::string sClanMarkTexPath;
 
-	if (iNobleRank == 1)
+	if (m_InfoBase.iRank == 1)
 	{
 		SColourTexPath = "Item\\Cloak_C_99.dxt"; // King cloak
 	}
@@ -1896,15 +1902,13 @@ void CPlayerBase::AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce)
 		int nColour      = sCapeID % 100;
 		int nPattern     = sCapeID / 100;
 
-		SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                                          // Cloak colour
-		sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                                         // Cloak pattern
-		sClanMarkTexPath = "";                                                                                       // No Clan Mark
+		SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);  // Cloak colour
+		sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern); // Cloak pattern
+		sClanMarkTexPath = "";                                               // No Clan Mark
 
 		if (m_InfoBase.iKnightsGrade <= 2)
-			sClanMarkTexPath = CGameProcedure::GetSymbolFilename(1, m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
-		// TODO: serverIndex is temp hard coded to 1 for testing,
-		// need to talk to someone smarter than me to confirm if
-		// this is implemented on the server side yet as I cant find the packet
+			sClanMarkTexPath = CGameProcedure::GetSymbolFilename(
+				CGameProcedure::GetServerIndex(), m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
 	}
 
 	pCloak->Init(pCloak->Mesh(), SColourTexPath, sClanMarkTexPath, sPatternTexPath);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -304,9 +304,10 @@ void CPlayerBase::KnightsInfoSet(int iID, const std::string& /*szName*/, int iGr
 		szPlug = fmt::format("Item\\ClanAddOn_{:03}_{}.n3cplug", static_cast<int>(m_InfoBase.eRace), iGrade);
 	}
 
-	m_InfoBase.iKnightsID = iID;
+	m_InfoBase.iKnightsID    = iID;
+	m_InfoBase.iKnightsGrade = iGrade;
 
-	CN3CPlugBase* pPlug   = PlugSet(PLUG_POS_KNIGHTS_GRADE, szPlug, nullptr, nullptr);
+	CN3CPlugBase* pPlug      = PlugSet(PLUG_POS_KNIGHTS_GRADE, szPlug, nullptr, nullptr);
 	if (pPlug == nullptr)
 		return;
 
@@ -1714,7 +1715,8 @@ bool CPlayerBase::CheckCollisionToTargetByPlug(CPlayerBase* pTarget, int nPlug, 
 	return pTarget->CheckCollisionByBox(v1, v2, pVCol, nullptr);
 }
 
-CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt)
+CN3CPlugBase* CPlayerBase::PlugSet(
+	e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce)
 {
 	if (ePos < PLUG_POS_RIGHTHAND || ePos >= PLUG_POS_COUNT)
 	{
@@ -1868,42 +1870,35 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	return pPlug;
 }
 
-void CPlayerBase::AttachCloak(int16_t sCapeID)
+void CPlayerBase::AttachCloak(int16_t sCapeID, bool isForce)
 {
-	m_Chr.CloakPlugSet("");
+	PlugSet(PLUG_POS_BACK, "", nullptr, nullptr, isForce);
 
-	// -1 = no clan, 0 = no cape
-	if (sCapeID <= 0)
+	//Temporary to prevent cloaks on all chars while still a work in progress -1 = no cloak
+	if (sCapeID < 0)
 		return;
 
-	// Cloak mesh for each race
-	const std::string szMesh = fmt::format("Item\\cloak_{:03}.n3cplug", static_cast<int>(m_InfoBase.eRace));
-	CN3CPlug_Cloak* pCloak   = m_Chr.CloakPlugSet(szMesh);
+	const std::string sMeshPath = fmt::format("Item\\Cloak_{:03}.n3cplug", static_cast<int>(m_InfoBase.eRace)); // Cloak mesh for each race
+	CN3CPlug_Cloak* pCloak      = static_cast<CN3CPlug_Cloak*>(PlugSet(PLUG_POS_BACK, sMeshPath, nullptr, nullptr, isForce));
 	if (pCloak == nullptr)
 		return;
 
-	// Attach cloak to shoulders
-	pCloak->m_nJointIndex = ITEM_POS_SHOULDER;
+	// TODO: Implement king cloak, need to look at binary client some more
 
-	// Cloak colour and pattern
-	int nPattern          = sCapeID / 100;
-	int nColour           = sCapeID % 100;
+	int nColour                  = sCapeID % 100;
+	int nPattern                 = sCapeID / 100;
 
-	std::string szColour;
-	if (nColour > 0)
-		szColour = fmt::format("Item\\cloak_c_{:02}.dxt", nColour);
-	else
-		szColour = "Item\\cloak_basic.dxt";
+	std::string SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                              // Cloak colour
+	std::string sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                             // Cloak pattern
+	std::string sClanMarkTexPath = "";                                                                           // No Clan Mark
 
-	if (pCloak->TexSet(szColour) == nullptr)
-		pCloak->TexSet("Item\\cloak_basic.dxt");
+	if (m_InfoBase.iKnightsGrade <= 2)
+		sClanMarkTexPath = CGameProcedure::GetSymbolFilename(1, m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
+	// TODO: serverIndex is temp hard coded to 1 for testing,
+	// need to talk to someone smarter than me to confirm if
+	// this is implemented on the server side yet as I cant find the packet
 
-	if (nPattern >= 1 && nPattern <= 5)
-		pCloak->TexOverlapSet(fmt::format("Item\\cloak_M_{:02}.dxt", nPattern));
-	else
-		pCloak->TexOverlapSet(static_cast<CN3Texture*>(nullptr));
-
-	pCloak->GetCloak()->Init(pCloak);
+	pCloak->Init(pCloak->Mesh(), SColourTexPath, sClanMarkTexPath, sPatternTexPath);
 }
 
 CN3CPart* CPlayerBase::PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt)

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1870,7 +1870,7 @@ CN3CPlugBase* CPlayerBase::PlugSet(
 	return pPlug;
 }
 
-void CPlayerBase::AttachCloak(int16_t sCapeID, bool isForce)
+void CPlayerBase::AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce)
 {
 	PlugSet(PLUG_POS_BACK, "", nullptr, nullptr, isForce);
 
@@ -1883,20 +1883,30 @@ void CPlayerBase::AttachCloak(int16_t sCapeID, bool isForce)
 	if (pCloak == nullptr)
 		return;
 
-	// TODO: Implement king cloak, need to look at binary client some more
+    std::string SColourTexPath;
+	std::string sPatternTexPath;
+	std::string sClanMarkTexPath;
 
-	int nColour                  = sCapeID % 100;
-	int nPattern                 = sCapeID / 100;
+	if (iNobleRank == 1)
+	{
+		SColourTexPath = "Item\\Cloak_C_99.dxt"; // King cloak
+		sPatternTexPath = "";
+	}
+	else
+	{
+		int nColour                  = sCapeID % 100;
+		int nPattern                 = sCapeID / 100;
 
-	std::string SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                              // Cloak colour
-	std::string sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                             // Cloak pattern
-	std::string sClanMarkTexPath = "";                                                                           // No Clan Mark
+		SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                              // Cloak colour
+		sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                             // Cloak pattern
+		sClanMarkTexPath = "";                                                                           // No Clan Mark
 
-	if (m_InfoBase.iKnightsGrade <= 2)
-		sClanMarkTexPath = CGameProcedure::GetSymbolFilename(1, m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
-	// TODO: serverIndex is temp hard coded to 1 for testing,
-	// need to talk to someone smarter than me to confirm if
-	// this is implemented on the server side yet as I cant find the packet
+		if (m_InfoBase.iKnightsGrade <= 2)
+			sClanMarkTexPath = CGameProcedure::GetSymbolFilename(1, m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
+			// TODO: serverIndex is temp hard coded to 1 for testing,
+			// need to talk to someone smarter than me to confirm if
+			// this is implemented on the server side yet as I cant find the packet
+	}
 
 	pCloak->Init(pCloak->Mesh(), SColourTexPath, sClanMarkTexPath, sPatternTexPath);
 }

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -528,12 +528,24 @@ void CPlayerBase::TickAnimation()
 	// 걷고 뛰고, 에니메이션등... 속도 적용
 	float fAniSpeedDelta = 1.0f;
 	if (PSM_STOP != m_eStateMove)
-		fAniSpeedDelta = m_fMoveDelta;                 // 이동중이면 스피드 적용..
+		fAniSpeedDelta = m_fMoveDelta;      // 이동중이면 스피드 적용..
 	else if (PSA_ATTACK == m_eState)
-		fAniSpeedDelta = m_fAttackDelta;               // 공격중이면 공격 스피드 적용..
+		fAniSpeedDelta = m_fAttackDelta;    // 공격중이면 공격 스피드 적용..
 	__ASSERT(fAniSpeedDelta >= 0.1f && fAniSpeedDelta < 10.0f, "Invalid Animation Speed Delta!!!");
-	m_Chr.AniSpeedDeltaSet(fAniSpeedDelta);            // 에니메이션 스피드 실제 적용..
-	m_Chr.Tick();                                      // 에니메이션 틱..
+	m_Chr.AniSpeedDeltaSet(fAniSpeedDelta); // 에니메이션 스피드 실제 적용..
+	m_Chr.Tick();                           // 에니메이션 틱..
+
+	if (m_Chr.CloakPlug() != nullptr)
+	{
+		e_CloakMove eCloakMove = CLOAK_MOVE_STOP;
+		if (m_eStateMove == PSM_RUN)
+			eCloakMove = CLOAK_MOVE_RUN;
+		else if (m_eStateMove == PSM_WALK)
+			eCloakMove = CLOAK_MOVE_WALK;
+		else if (m_eStateMove == PSM_WALK_BACKWARD)
+			eCloakMove = CLOAK_MOVE_WALK_BACKWARD;
+		m_Chr.CloakPlug()->GetCloak()->Tick(m_Chr.m_nLOD, m_fYawCur, eCloakMove);
+	}
 
 	m_bAnimationChanged = false;                       // 큐에 넣은 에니메이션이 변하는 순간만 세팅된다..
 	if (m_Chr.IsAnimEnd())                             // 에니메이션이 끝나면..
@@ -1736,7 +1748,14 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	}
 	else if (PLUG_POS_BACK == ePos)
 	{
-		//m_pItemPlugBasics[PLUG_POS_BACK] = pItem;
+		m_pItemPlugBasics[ePos] = pItemBasic;
+		m_pItemPlugExts[ePos]   = pItemExt;
+
+		CN3CPlug_Cloak* pCloak  = m_Chr.CloakPlugSet(szFN);
+		if (pCloak != nullptr)
+			pCloak->m_nJointIndex = ITEM_POS_SHOULDER;
+
+		return pCloak;
 	}
 	else
 	{
@@ -1847,6 +1866,44 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	return pPlug;
+}
+
+void CPlayerBase::AttachCloak(int16_t sCapeID)
+{
+	m_Chr.CloakPlugSet("");
+
+	// -1 = no clan, 0 = no cape
+	if (sCapeID <= 0)
+		return;
+
+	// Cloak mesh for each race
+	const std::string szMesh = fmt::format("Item\\cloak_{:03}.n3cplug", static_cast<int>(m_InfoBase.eRace));
+	CN3CPlug_Cloak* pCloak   = m_Chr.CloakPlugSet(szMesh);
+	if (pCloak == nullptr)
+		return;
+
+	// Attach cloak to shoulders
+	pCloak->m_nJointIndex = ITEM_POS_SHOULDER;
+
+	// Cloak colour and pattern
+	int nPattern          = sCapeID / 100;
+	int nColour           = sCapeID % 100;
+
+	std::string szColour;
+	if (nColour > 0)
+		szColour = fmt::format("Item\\cloak_c_{:02}.dxt", nColour);
+	else
+		szColour = "Item\\cloak_basic.dxt";
+
+	if (pCloak->TexSet(szColour) == nullptr)
+		pCloak->TexSet("Item\\cloak_basic.dxt");
+
+	if (nPattern >= 1 && nPattern <= 5)
+		pCloak->TexOverlapSet(fmt::format("Item\\cloak_M_{:02}.dxt", nPattern));
+	else
+		pCloak->TexOverlapSet(static_cast<CN3Texture*>(nullptr));
+
+	pCloak->GetCloak()->Init(pCloak);
 }
 
 CN3CPart* CPlayerBase::PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt)

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1883,29 +1883,28 @@ void CPlayerBase::AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce)
 	if (pCloak == nullptr)
 		return;
 
-    std::string SColourTexPath;
+	std::string SColourTexPath;
 	std::string sPatternTexPath;
 	std::string sClanMarkTexPath;
 
 	if (iNobleRank == 1)
 	{
 		SColourTexPath = "Item\\Cloak_C_99.dxt"; // King cloak
-		sPatternTexPath = "";
 	}
 	else
 	{
-		int nColour                  = sCapeID % 100;
-		int nPattern                 = sCapeID / 100;
+		int nColour      = sCapeID % 100;
+		int nPattern     = sCapeID / 100;
 
-		SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                              // Cloak colour
-		sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                             // Cloak pattern
-		sClanMarkTexPath = "";                                                                           // No Clan Mark
+		SColourTexPath   = fmt::format("Item\\Cloak_C_{:02}.dxt", nColour);                                          // Cloak colour
+		sPatternTexPath  = fmt::format("Item\\Cloak_M_{:02}.dxt", nPattern);                                         // Cloak pattern
+		sClanMarkTexPath = "";                                                                                       // No Clan Mark
 
 		if (m_InfoBase.iKnightsGrade <= 2)
 			sClanMarkTexPath = CGameProcedure::GetSymbolFilename(1, m_InfoBase.iKnightsID, m_InfoBase.iMarkVersion); // Clan Mark
-			// TODO: serverIndex is temp hard coded to 1 for testing,
-			// need to talk to someone smarter than me to confirm if
-			// this is implemented on the server side yet as I cant find the packet
+		// TODO: serverIndex is temp hard coded to 1 for testing,
+		// need to talk to someone smarter than me to confirm if
+		// this is implemented on the server side yet as I cant find the packet
 	}
 
 	pCloak->Init(pCloak->Mesh(), SColourTexPath, sClanMarkTexPath, sPatternTexPath);

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -414,6 +414,7 @@ public:
 	virtual CN3CPart* PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt);
 	virtual CN3CPlugBase* PlugSet(e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt);
 	virtual void DurabilitySet(e_ItemSlot eSlot, int iDurability);
+	void AttachCloak(int16_t sCapeID);
 
 	void TickYaw();           // 회전값 처리.
 	void TickAnimation();     // 에니메이션 처리.

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -421,7 +421,7 @@ public:
 	virtual CN3CPlugBase* PlugSet(
 		e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce = false);
 	virtual void DurabilitySet(e_ItemSlot eSlot, int iDurability);
-	void AttachCloak(int16_t sCapeID, bool isForce = false);
+	void AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce = false);
 
 	void TickYaw();           // 회전값 처리.
 	void TickAnimation();     // 에니메이션 처리.

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -47,6 +47,7 @@ struct __InfoPlayerBase
 	int iKnightsWarEnemyID;
 	int iKnightsGrade;    // Clan grade
 	int16_t iMarkVersion; // Clan mark
+	int iRank;            // Noble rank - used to identify high-ranking titles like King [1], Senator [2]. Always 0 for NPCs.
 	bool bIsTransformed;
 
 	bool bRenderID;       // 화면에 ID 를 찍는지..
@@ -75,6 +76,7 @@ struct __InfoPlayerBase
 		iKnightsWarEnemyID = 0;
 		iKnightsGrade      = 0;
 		iMarkVersion       = 0;
+		iRank              = 0;
 		bRenderID          = true;
 		bIsTransformed     = false;
 	}
@@ -421,7 +423,7 @@ public:
 	virtual CN3CPlugBase* PlugSet(
 		e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce = false);
 	virtual void DurabilitySet(e_ItemSlot eSlot, int iDurability);
-	void AttachCloak(int16_t sCapeID, int iNobleRank, bool isForce = false);
+	void AttachCloak(int16_t sCapeID, bool isForce = false);
 
 	void TickYaw();           // 회전값 처리.
 	void TickAnimation();     // 에니메이션 처리.

--- a/src/Client/WarFare/PlayerBase.h
+++ b/src/Client/WarFare/PlayerBase.h
@@ -41,12 +41,15 @@ struct __InfoPlayerBase
 	int iHP;
 	int iMP;
 	int iMPMax;
-	int iAuthority; // 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
-	int iKnightsID; // Clan ID
+	int iAuthority;       // 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
+	int iKnightsID;       // Clan ID
 	int iAllianceID;
 	int iKnightsWarEnemyID;
+	int iKnightsGrade;    // Clan grade
+	int16_t iMarkVersion; // Clan mark
+	bool bIsTransformed;
 
-	bool bRenderID; // 화면에 ID 를 찍는지..
+	bool bRenderID;       // 화면에 ID 를 찍는지..
 
 	__InfoPlayerBase()
 	{
@@ -70,7 +73,10 @@ struct __InfoPlayerBase
 		iKnightsID         = 0;
 		iAllianceID        = 0;
 		iKnightsWarEnemyID = 0;
+		iKnightsGrade      = 0;
+		iMarkVersion       = 0;
 		bRenderID          = true;
+		bIsTransformed     = false;
 	}
 };
 
@@ -412,9 +418,10 @@ public:
 	}
 
 	virtual CN3CPart* PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt);
-	virtual CN3CPlugBase* PlugSet(e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt);
+	virtual CN3CPlugBase* PlugSet(
+		e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce = false);
 	virtual void DurabilitySet(e_ItemSlot eSlot, int iDurability);
-	void AttachCloak(int16_t sCapeID);
+	void AttachCloak(int16_t sCapeID, bool isForce = false);
 
 	void TickYaw();           // 회전값 처리.
 	void TickAnimation();     // 에니메이션 처리.

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -595,7 +595,7 @@ CN3CPlugBase* CPlayerMySelf::PlugSet(
 	}
 	else if (PLUG_POS_BACK == ePos)
 	{
-		//m_pItemBasicPlugRefs[PLUG_POS_BACK] = pItem;
+		return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt);
 	}
 	else
 	{
@@ -613,10 +613,6 @@ CN3CPlugBase* CPlayerMySelf::PlugSet(
 		pPlug->ScaleSet(__Vector3(fScale, fScale, fScale));
 		pPlug->m_nJointIndex = iJoint; // 관절 번호 세팅..
 	}
-	//	else if(PLUG_POS_BACK == ePos)
-	//	{
-	//		CN3CPlug_Cloak *pPlugCloak = (CN3CPlug_Cloak*)pPlug;
-	//	}
 
 	this->SetSoundPlug(pItemBasic);
 	return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt);

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -568,14 +568,6 @@ void CPlayerMySelf::InventoryChrAnimationInitialize()
 CN3CPlugBase* CPlayerMySelf::PlugSet(
 	e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce)
 {
-	if (m_InfoBase.bIsTransformed && !isForce) // Skip plug if player is transformed
-	{
-		if (pItemBasic)
-			m_pItemPlugBasics[ePos] = pItemBasic;
-		if (pItemExt)
-			m_pItemPlugExts[ePos] = pItemExt;
-		return nullptr;
-	}
 	int iJoint = 0;
 	if (PLUG_POS_RIGHTHAND == ePos)
 	{

--- a/src/Client/WarFare/PlayerMySelf.cpp
+++ b/src/Client/WarFare/PlayerMySelf.cpp
@@ -566,8 +566,16 @@ void CPlayerMySelf::InventoryChrAnimationInitialize()
 }
 
 CN3CPlugBase* CPlayerMySelf::PlugSet(
-	e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt)
+	e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt, bool isForce)
 {
+	if (m_InfoBase.bIsTransformed && !isForce) // Skip plug if player is transformed
+	{
+		if (pItemBasic)
+			m_pItemPlugBasics[ePos] = pItemBasic;
+		if (pItemExt)
+			m_pItemPlugExts[ePos] = pItemExt;
+		return nullptr;
+	}
 	int iJoint = 0;
 	if (PLUG_POS_RIGHTHAND == ePos)
 	{
@@ -595,7 +603,7 @@ CN3CPlugBase* CPlayerMySelf::PlugSet(
 	}
 	else if (PLUG_POS_BACK == ePos)
 	{
-		return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt);
+		return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt, isForce);
 	}
 	else
 	{
@@ -615,7 +623,7 @@ CN3CPlugBase* CPlayerMySelf::PlugSet(
 	}
 
 	this->SetSoundPlug(pItemBasic);
-	return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt);
+	return CPlayerBase::PlugSet(ePos, szFN, pItemBasic, pItemExt, isForce);
 }
 
 CN3CPart* CPlayerMySelf::PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt)

--- a/src/Client/WarFare/PlayerMySelf.h
+++ b/src/Client/WarFare/PlayerMySelf.h
@@ -78,8 +78,8 @@ public:
 
 	bool InitChr(__TABLE_PLAYER_LOOKS* pTblUPC) override;
 	CN3CPart* PartSet(e_PartPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt) override;
-	CN3CPlugBase* PlugSet(
-		e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt) override;
+	CN3CPlugBase* PlugSet(e_PlugPosition ePos, const std::string& szFN, __TABLE_ITEM_BASIC* pItemBasic, __TABLE_ITEM_EXT* pItemExt,
+		bool isForce = false) override;
 
 	void Tick() override;
 	void Render(float fSunAngle) override;

--- a/src/Client/WarFare/PlayerOther.cpp
+++ b/src/Client/WarFare/PlayerOther.cpp
@@ -130,9 +130,11 @@ bool CPlayerOther::Init(e_Race eRace, int iFace, int iHair, uint32_t* pdwItemIDs
 				ePart = PART_POS_FEET;
 				eSlot = ITEM_SLOT_SHOES;
 			}
-			else if (5 == i)
+			else if (5 == i) // Clan cape
 			{
-			} // 망토
+				ePlug = PLUG_POS_BACK;
+				eSlot = ITEM_SLOT_SHOULDER;
+			}
 			else if (6 == i)
 			{
 				ePlug = PLUG_POS_RIGHTHAND;

--- a/src/Client/WarFare/UIImageTooltipDlg.cpp
+++ b/src/Client/WarFare/UIImageTooltipDlg.cpp
@@ -885,7 +885,7 @@ void CUIImageTooltipDlg::CalcTooltipStringNumAndWriteImpl(__IconItemSkill* spIte
 
 		m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNLEFT);
 
-		if (SetTooltipTextColor(pInfoExt->iRank, spItem->pItemBasic->byNeedRank + spItem->pItemExt->siNeedRank))
+		if (SetTooltipTextColor(CGameBase::s_pPlayer->m_InfoBase.iRank, spItem->pItemBasic->byNeedRank + spItem->pItemExt->siNeedRank))
 			m_pStr[iIndex]->SetColor(m_CWhite);
 		else
 			m_pStr[iIndex]->SetColor(m_CRed);

--- a/src/Client/WarFare/UIInventory.cpp
+++ b/src/Client/WarFare/UIInventory.cpp
@@ -1905,7 +1905,7 @@ bool CUIInventory::IsValidRaceAndClass(__TABLE_ITEM_BASIC* pItem, __TABLE_ITEM_E
 			return false;
 		}
 
-		if (pInfoExt->iRank < pItem->byNeedRank + pItemExt->siNeedRank)
+		if (CGameBase::s_pPlayer->m_InfoBase.iRank < pItem->byNeedRank + pItemExt->siNeedRank)
 		{
 			szMsg = fmt::format_text_resource(IDS_MSG_VALID_CLASSNRACE_LOW_RANK);
 			CGameProcedure::s_pProcMain->MsgOutput(szMsg, 0xffff3b3b);

--- a/src/Client/WarFare/UIStateBar.cpp
+++ b/src/Client/WarFare/UIStateBar.cpp
@@ -298,7 +298,10 @@ void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately)
 		m_pProgress_HP->SetCurValue(iPercentage, 0.3f, 100.0f);
 
 	// NOTE: adding the HP text
-	__ASSERT(iHP >= 0 && iHP < 10000 && iHPMax >= 0 && iHPMax < 10000, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+	// Original asserted iHP < 10000 — see CUIState::UpdateHP for the same fix.
+	// Level 80 characters routinely have 15000+ HP and this fired on every
+	// HUD refresh as a Debug Assertion Failed dialog.
+	__ASSERT(iHP >= 0 && iHPMax >= 0, "negative HP in CUIStateBar::UpdateHP");
 	if (m_pText_HP == nullptr)
 		return;
 

--- a/src/Client/WarFare/UIVarious.cpp
+++ b/src/Client/WarFare/UIVarious.cpp
@@ -212,7 +212,10 @@ void CUIState::UpdateRealmPoint(int iLoyalty, int iLoyaltyMonthly) // 국가 기
 
 void CUIState::UpdateHP(int iVal, int iValMax)
 {
-	__ASSERT(iVal >= 0 && iVal < 10000 && iValMax >= 0 && iValMax < 10000, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+	// Original assert capped values at 10000 — that's tight for level 80+ chars
+	// (full Chitin / royal-tier gear pushes HP comfortably past 15000) and
+	// fires a debug-time crash dialog. Sanity-check is non-negative only.
+	__ASSERT(iVal >= 0 && iValMax >= 0, "negative HP in UpdateHP");
 	if (m_pText_HP == nullptr)
 		return;
 

--- a/src/N3Base/N3Chr.cpp
+++ b/src/N3Base/N3Chr.cpp
@@ -1130,11 +1130,12 @@ void CN3CPlug_Cloak::SetLOD(int nLOD)
 #endif
 }
 
-bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex, const std::string& sClanMarkTex, const std::string& sPatternTex)
+bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex,
+	const std::string& sClanMarkTex, const std::string& sPatternTex)
 {
 	//Release();
 
-	 // Release textures only — do NOT delete m_pMesh here,
+	// Release textures only — do NOT delete m_pMesh here,
 	// pMesh may point to the same mesh we currently hold
 
 	s_MngTex.Delete(&m_pTexColour);
@@ -1157,12 +1158,11 @@ bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex, const s
 	//__ASSERT(m_pMesh && m_pTex, "IN CN3Cloak, Mesh or m_pTex is null");
 
 	TexSet(sColourTex);
-	#ifdef _N3GAME
-		m_Cloak.InitMeshTex(pMesh, Tex());
-		m_Cloak.InitPhysics();
-	#endif
+#ifdef _N3GAME
+	m_Cloak.InitMeshTex(pMesh, Tex());
+	m_Cloak.InitPhysics();
+#endif
 	SetLOD(0);
-
 
 	return true;
 }

--- a/src/N3Base/N3Chr.cpp
+++ b/src/N3Base/N3Chr.cpp
@@ -1047,16 +1047,59 @@ CN3CPlug_Cloak::~CN3CPlug_Cloak()
 
 void CN3CPlug_Cloak::Release()
 {
+	s_MngMesh.Delete(&m_pMesh);
 	CN3CPlugBase::Release();
 }
 
 bool CN3CPlug_Cloak::Load(File& file)
 {
-	CN3CPlugBase::Load(file);
+	// Read the name header (CN3BaseFileAccess::Load), then re-parse all
+	// CN3CPlugBase fields manually so we can redirect the mesh load to
+	// s_MngMesh (CN3Mesh) instead of PMeshSet (CN3PMesh). Cloak assets are
+	// .n3mesh files; loading them as .n3pmesh produces garbage vertex counts.
+	CN3BaseFileAccess::Load(file);
+
+	int nL         = 0;
+	char szFN[512] = "";
+
+	file.Read(&m_ePlugType, 4);
+	if (m_ePlugType > PLUGTYPE_MAX)
+		m_ePlugType = PLUGTYPE_NORMAL;
+	file.Read(&m_nJointIndex, 4);
+	file.Read(&m_vPosition, sizeof(m_vPosition));
+	file.Read(&m_MtxRot, sizeof(m_MtxRot));
+	file.Read(&m_vScale, sizeof(m_vScale));
+	file.Read(&m_Mtl, sizeof(__Material));
+
+	// Mesh: load as CN3Mesh, not CN3PMesh
+	file.Read(&nL, 4);
+	if (nL > 0)
+	{
+		file.Read(szFN, nL);
+		szFN[nL] = '\0';
+		s_MngMesh.Delete(&m_pMesh);
+		m_pMesh = s_MngMesh.Get(szFN);
+	}
+
+	// Texture
+	file.Read(&nL, 4);
+	if (nL > 0)
+	{
+		file.Read(szFN, nL);
+		szFN[nL] = '\0';
+		TexSet(szFN);
+	}
+
+	ReCalcMatrix();
+
+	if (m_pMesh == nullptr)
+		return false; // mesh file missing; CloakPlugSet will clean up
+	if (Tex() == nullptr)
+		TexSet("Item\\cloak_basic.dxt");
 #ifdef _N3GAME
 	m_Cloak.Init(this);
 #endif
-	return 0;
+	return true;
 }
 
 #ifdef _N3TOOL
@@ -1076,7 +1119,7 @@ void CN3CPlug_Cloak::Render(const __Matrix44& mtxParent, const __Matrix44& mtxJo
 	mtx  = m_Matrix;
 	mtx *= mtxJoint;
 	mtx *= mtxParent;
-	m_Cloak.Render(mtx);
+	m_Cloak.Render(mtx, TexOverlap());
 #endif
 }
 
@@ -1122,6 +1165,9 @@ CN3Chr::~CN3Chr()
 	for (auto itr = m_Plugs.begin(); itr != m_Plugs.end(); ++itr)
 		delete *itr;
 	m_Plugs.clear();
+
+	delete m_pCloakPlug;
+	m_pCloakPlug = nullptr;
 
 	for (auto itr = m_vTraces.begin(); itr != m_vTraces.end(); ++itr)
 		delete *itr;
@@ -1892,6 +1938,12 @@ void CN3Chr::Render()
 		////////////////////////////////////////////////////
 	}
 
+	// Clan cape render
+	if (m_pCloakPlug != nullptr && m_pCloakPlug->m_bVisible && m_pCloakPlug->m_nJointIndex >= 0)
+	{
+		m_pCloakPlug->Render(m_Matrix, m_MtxJoints[m_pCloakPlug->m_nJointIndex]);
+	}
+
 	//////////////////////////////////////////////////
 	//	Coded (By Dino On 2002-10-11 오전 11:20:19 )
 	//	FXPlug
@@ -2199,6 +2251,24 @@ void CN3Chr::PlugAlloc(int iCount)
 		for (int i = 0; i < iCount; i++)
 			m_Plugs[i] = new CN3CPlug();
 	}
+}
+
+CN3CPlug_Cloak* CN3Chr::CloakPlugSet(const std::string& szFN)
+{
+	delete m_pCloakPlug;
+	m_pCloakPlug = nullptr;
+
+	if (szFN.empty())
+		return nullptr;
+
+	m_pCloakPlug = new CN3CPlug_Cloak();
+	if (!m_pCloakPlug->LoadFromFile(szFN))
+	{
+		delete m_pCloakPlug;
+		m_pCloakPlug = nullptr;
+		return nullptr;
+	}
+	return m_pCloakPlug;
 }
 
 /*

--- a/src/N3Base/N3Chr.cpp
+++ b/src/N3Base/N3Chr.cpp
@@ -1047,6 +1047,11 @@ CN3CPlug_Cloak::~CN3CPlug_Cloak()
 
 void CN3CPlug_Cloak::Release()
 {
+#ifdef _N3GAME
+	s_MngTex.Delete(&m_pTexColour);
+	s_MngTex.Delete(&m_pTexClanMark);
+	s_MngTex.Delete(&m_pTexPattern);
+#endif
 	s_MngMesh.Delete(&m_pMesh);
 	CN3CPlugBase::Release();
 }
@@ -1096,9 +1101,6 @@ bool CN3CPlug_Cloak::Load(File& file)
 		return false; // mesh file missing; CloakPlugSet will clean up
 	if (Tex() == nullptr)
 		TexSet("Item\\cloak_basic.dxt");
-#ifdef _N3GAME
-	m_Cloak.Init(this);
-#endif
 	return true;
 }
 
@@ -1119,7 +1121,7 @@ void CN3CPlug_Cloak::Render(const __Matrix44& mtxParent, const __Matrix44& mtxJo
 	mtx  = m_Matrix;
 	mtx *= mtxJoint;
 	mtx *= mtxParent;
-	m_Cloak.Render(mtx, TexOverlap());
+	m_Cloak.Render(mtx, m_pTexColour, m_pTexPattern, m_pTexClanMark);
 #endif
 }
 
@@ -1129,6 +1131,44 @@ void CN3CPlug_Cloak::SetLOD(int nLOD)
 	m_Cloak.SetLOD(nLOD);
 #endif
 }
+
+bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex,
+	const std::string& sClanMarkTex, const std::string& sPatternTex)
+{
+	//Release();
+
+	 // Release textures only — do NOT delete m_pMesh here,
+	// pMesh may point to the same mesh we currently hold
+	#ifdef _N3GAME
+		s_MngTex.Delete(&m_pTexColour);
+		s_MngTex.Delete(&m_pTexClanMark);
+		s_MngTex.Delete(&m_pTexPattern);
+	#endif
+
+	if (!pMesh)
+		return false;
+
+	if (!pMesh)
+		return false;
+	//if (pMesh->VertexCount() != 49)
+	//	return false;
+	//if (pMesh->IndexCount() != 216)
+	//	return false;
+
+	m_pMesh        = pMesh;
+
+	m_pTexColour   = s_MngTex.Get(sColourTex, true, 0);
+	m_pTexClanMark = s_MngTex.Get(sClanMarkTex, true, 0);
+	m_pTexPattern  = s_MngTex.Get(sPatternTex, true, 0);
+	//__ASSERT(m_pMesh && m_pTex, "IN CN3Cloak, Mesh or m_pTex is null");
+
+	m_Cloak.InitMeshTex(pMesh, Tex());
+	SetLOD(0);
+	m_Cloak.InitPhysics();
+
+	return true;
+}
+
 // CN3cPlug_Cloak Codes End here
 //////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////
@@ -1938,7 +1978,7 @@ void CN3Chr::Render()
 		////////////////////////////////////////////////////
 	}
 
-	// Clan cape render
+	// Cloak render
 	if (m_pCloakPlug != nullptr && m_pCloakPlug->m_bVisible && m_pCloakPlug->m_nJointIndex >= 0)
 	{
 		m_pCloakPlug->Render(m_Matrix, m_MtxJoints[m_pCloakPlug->m_nJointIndex]);
@@ -2253,16 +2293,16 @@ void CN3Chr::PlugAlloc(int iCount)
 	}
 }
 
-CN3CPlug_Cloak* CN3Chr::CloakPlugSet(const std::string& szFN)
+CN3CPlug_Cloak* CN3Chr::CloakPlugSet(const std::string& sMeshPath)
 {
 	delete m_pCloakPlug;
 	m_pCloakPlug = nullptr;
 
-	if (szFN.empty())
+	if (sMeshPath.empty())
 		return nullptr;
 
 	m_pCloakPlug = new CN3CPlug_Cloak();
-	if (!m_pCloakPlug->LoadFromFile(szFN))
+	if (!m_pCloakPlug->LoadFromFile(sMeshPath))
 	{
 		delete m_pCloakPlug;
 		m_pCloakPlug = nullptr;

--- a/src/N3Base/N3Chr.cpp
+++ b/src/N3Base/N3Chr.cpp
@@ -1098,9 +1098,7 @@ bool CN3CPlug_Cloak::Load(File& file)
 	ReCalcMatrix();
 
 	if (m_pMesh == nullptr)
-		return false; // mesh file missing; CloakPlugSet will clean up
-	if (Tex() == nullptr)
-		TexSet("Item\\cloak_basic.dxt");
+		return false; // mesh file missing. CloakPlugSet will clean up
 	return true;
 }
 
@@ -1132,24 +1130,20 @@ void CN3CPlug_Cloak::SetLOD(int nLOD)
 #endif
 }
 
-bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex,
-	const std::string& sClanMarkTex, const std::string& sPatternTex)
+bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex, const std::string& sClanMarkTex, const std::string& sPatternTex)
 {
 	//Release();
 
 	 // Release textures only — do NOT delete m_pMesh here,
 	// pMesh may point to the same mesh we currently hold
-	#ifdef _N3GAME
-		s_MngTex.Delete(&m_pTexColour);
-		s_MngTex.Delete(&m_pTexClanMark);
-		s_MngTex.Delete(&m_pTexPattern);
-	#endif
+
+	s_MngTex.Delete(&m_pTexColour);
+	s_MngTex.Delete(&m_pTexClanMark);
+	s_MngTex.Delete(&m_pTexPattern);
 
 	if (!pMesh)
 		return false;
 
-	if (!pMesh)
-		return false;
 	//if (pMesh->VertexCount() != 49)
 	//	return false;
 	//if (pMesh->IndexCount() != 216)
@@ -1162,9 +1156,13 @@ bool CN3CPlug_Cloak::Init(CN3Mesh* pMesh, const std::string& sColourTex,
 	m_pTexPattern  = s_MngTex.Get(sPatternTex, true, 0);
 	//__ASSERT(m_pMesh && m_pTex, "IN CN3Cloak, Mesh or m_pTex is null");
 
-	m_Cloak.InitMeshTex(pMesh, Tex());
+	TexSet(sColourTex);
+	#ifdef _N3GAME
+		m_Cloak.InitMeshTex(pMesh, Tex());
+		m_Cloak.InitPhysics();
+	#endif
 	SetLOD(0);
-	m_Cloak.InitPhysics();
+
 
 	return true;
 }

--- a/src/N3Base/N3Chr.h
+++ b/src/N3Base/N3Chr.h
@@ -284,22 +284,22 @@ public:
 	void Release() override;
 
 	void SetLOD(int nLOD);
+	bool Init(CN3Mesh* pMesh, const std::string& sColourTex, const std::string& sClanMarkTex,
+		const std::string& sPatternTex);
 #ifdef _N3GAME
 	CN3Cloak* GetCloak()
 	{
 		return &m_Cloak;
 	}
-	bool Init(CN3Mesh* pMesh, const std::string& sColourTex, const std::string& sClanMarkTex,
-		const std::string& sPatternTex);
 #endif
 protected:
 #ifdef _N3GAME
 	CN3Cloak m_Cloak;
+#endif
+	CN3Mesh* m_pMesh           = nullptr;
 	CN3Texture* m_pTexColour   = nullptr;
 	CN3Texture* m_pTexClanMark = nullptr;
 	CN3Texture* m_pTexPattern  = nullptr;
-#endif
-	CN3Mesh* m_pMesh = nullptr;
 
 public:
 	CN3Mesh* Mesh()

--- a/src/N3Base/N3Chr.h
+++ b/src/N3Base/N3Chr.h
@@ -12,6 +12,7 @@
 #include "N3Skin.h"
 #include "N3Cloak.h"
 #include "N3PMeshInstance.h"
+#include "N3Mesh.h"
 #include "N3Texture.h"
 #include "N3Joint.h"
 #include <list>
@@ -293,6 +294,13 @@ protected:
 #ifdef _N3GAME
 	CN3Cloak m_Cloak;
 #endif
+	CN3Mesh* m_pMesh = nullptr;
+
+public:
+	CN3Mesh* Mesh()
+	{
+		return m_pMesh;
+	}
 };
 
 // 0 - 상체, 1 - 하체 ::: 관절들을 나누어서 나누어서 에니메이션 설정..
@@ -327,12 +335,13 @@ protected:
 
 	// 각 조인트의 행렬.. 포인터로 두지 않은 이유는 각 캐릭터마다 따로 에니메이션이 되기 위함이다..
 	std::vector<__Matrix44> m_MtxJoints;
-	std::vector<__Matrix44> m_MtxInverses; // 조인트에 대한 역행렬
+	std::vector<__Matrix44> m_MtxInverses;  // 조인트에 대한 역행렬
 
-	std::vector<CN3CPart*> m_Parts;        // 각 캐릭터의 부분별 Data Pointer List
-	std::vector<CN3CPlug*> m_Plugs;        // 이 캐릭터에 붙이는 무기등의 Data Pointer List
-	std::vector<__VertexColor*> m_vTraces; // Plug Trace Polygon
-	class CN3FXPlug* m_pFXPlug;            // 캐릭터에 FX를 붙이는 것.
+	std::vector<CN3CPart*> m_Parts;         // 각 캐릭터의 부분별 Data Pointer List
+	std::vector<CN3CPlug*> m_Plugs;         // 이 캐릭터에 붙이는 무기등의 Data Pointer List
+	std::vector<__VertexColor*> m_vTraces;  // Plug Trace Polygon
+	class CN3FXPlug* m_pFXPlug;             // 캐릭터에 FX를 붙이는 것.
+	CN3CPlug_Cloak* m_pCloakPlug = nullptr; // Clan cape attachment
 
 	// 조인트의 일부분이 따로 에니메이션 되야 한다면.. 조인트 인덱스 시작 번호
 	int m_nJointPartStarts[MAX_CHR_ANI_PART];
@@ -469,6 +478,12 @@ public:
 			return nullptr;
 
 		return m_Plugs[iIndex];
+	}
+
+	CN3CPlug_Cloak* CloakPlugSet(const std::string& szFN);
+	CN3CPlug_Cloak* CloakPlug()
+	{
+		return m_pCloakPlug;
 	}
 
 	void Tick(float fFrm = FRAME_SELFPLAY) override;

--- a/src/N3Base/N3Chr.h
+++ b/src/N3Base/N3Chr.h
@@ -289,10 +289,15 @@ public:
 	{
 		return &m_Cloak;
 	}
+	bool Init(CN3Mesh* pMesh, const std::string& sColourTex, const std::string& sClanMarkTex,
+		const std::string& sPatternTex);
 #endif
 protected:
 #ifdef _N3GAME
 	CN3Cloak m_Cloak;
+	CN3Texture* m_pTexColour   = nullptr;
+	CN3Texture* m_pTexClanMark = nullptr;
+	CN3Texture* m_pTexPattern  = nullptr;
 #endif
 	CN3Mesh* m_pMesh = nullptr;
 
@@ -341,7 +346,7 @@ protected:
 	std::vector<CN3CPlug*> m_Plugs;         // 이 캐릭터에 붙이는 무기등의 Data Pointer List
 	std::vector<__VertexColor*> m_vTraces;  // Plug Trace Polygon
 	class CN3FXPlug* m_pFXPlug;             // 캐릭터에 FX를 붙이는 것.
-	CN3CPlug_Cloak* m_pCloakPlug = nullptr; // Clan cape attachment
+	CN3CPlug_Cloak* m_pCloakPlug = nullptr; // Cloak attachment
 
 	// 조인트의 일부분이 따로 에니메이션 되야 한다면.. 조인트 인덱스 시작 번호
 	int m_nJointPartStarts[MAX_CHR_ANI_PART];
@@ -480,7 +485,7 @@ public:
 		return m_Plugs[iIndex];
 	}
 
-	CN3CPlug_Cloak* CloakPlugSet(const std::string& szFN);
+	CN3CPlug_Cloak* CloakPlugSet(const std::string& sMeshPath);
 	CN3CPlug_Cloak* CloakPlug()
 	{
 		return m_pCloakPlug;

--- a/src/N3Base/N3Cloak.cpp
+++ b/src/N3Base/N3Cloak.cpp
@@ -35,6 +35,7 @@ CN3Cloak::~CN3Cloak()
 	delete[] m_pParticle;
 	delete[] m_pIndex;
 	delete[] m_pVertex;
+	delete[] m_pIndexMark;
 }
 
 void CN3Cloak::Release()
@@ -47,23 +48,10 @@ void CN3Cloak::Release()
 
 	delete[] m_pVertex;
 	m_pVertex = nullptr;
-}
 
-void CN3Cloak::Init(CN3CPlug_Cloak* pPlugCloak)
-{
-	m_pTex  = pPlugCloak->Tex();
-	m_pMesh = pPlugCloak->Mesh();
-	__ASSERT(m_pMesh && m_pTex, "IN CN3Cloak, Mesh or m_pTex is null");
-
-	SetLOD(0);
-
-	//
-	m_GravityForce.x = 0.0f;
-	m_GravityForce.z = 0.0005f;
-	//m_GravityForce.y = -0.0025f;
-	m_GravityForce.y = -0.0005f;
-
-	m_Force.x = m_Force.y = m_Force.z = 0.0f;
+	delete[] m_pIndexMark;
+	m_pIndexMark      = nullptr;
+	m_nIndexCountMark = 0;
 }
 
 void CN3Cloak::Tick(int /*nLOD*/, float fYaw, e_CloakMove eCloakMove)
@@ -103,28 +91,26 @@ void CN3Cloak::Tick(int /*nLOD*/, float fYaw, e_CloakMove eCloakMove)
 	m_Force.x = m_Force.y = m_Force.z = 0.0f;
 }
 
-void CN3Cloak::Render(__Matrix44& mtx, CN3Texture* pTexColour)
+void CN3Cloak::Render(
+	__Matrix44& mtx, CN3Texture* pTexColour, CN3Texture* pTexPattern, CN3Texture* pTexClanMark)
 {
 	if (m_nLOD < 0 || m_pTex == nullptr)
 		return;
 
 	s_lpD3DDev->SetTransform(D3DTS_WORLD, mtx.toD3D());
 
-	DWORD dwCull = 0, dwLight = 0;
-	s_lpD3DDev->GetRenderState(D3DRS_LIGHTING, &dwLight);
+	DWORD dwCull = 0;
 	s_lpD3DDev->GetRenderState(D3DRS_CULLMODE, &dwCull);
-
-	//
-	//s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, FALSE);
 	if (dwCull != D3DCULL_NONE)
 		s_lpD3DDev->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 
+	// Mesh
 	s_lpD3DDev->SetTexture(0, m_pTex->Get());
-
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
 
+	// Colour
 	if (pTexColour != nullptr)
 	{
 		s_lpD3DDev->SetTexture(1, pTexColour->Get());
@@ -132,7 +118,6 @@ void CN3Cloak::Render(__Matrix44& mtx, CN3Texture* pTexColour)
 		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_BLENDTEXTUREALPHA);
 		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLORARG2, D3DTA_CURRENT);
-		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	}
 	else
 	{
@@ -140,12 +125,56 @@ void CN3Cloak::Render(__Matrix44& mtx, CN3Texture* pTexColour)
 		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	}
 
+	// Pattern
+	if (pTexPattern != nullptr)
+	{
+		s_lpD3DDev->SetTexture(2, pTexPattern->Get());
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_TEXCOORDINDEX, 0);
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_BLENDTEXTUREALPHA);
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLORARG2, D3DTA_CURRENT);
+		s_lpD3DDev->SetTextureStageState(3, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	}
+	else
+	{
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	}
+
 	s_lpD3DDev->SetFVF(FVF_VNT1);
 	s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, m_nVertexCount, m_nIndexCount / 3,
 		m_pIndex, D3DFMT_INDEX16, m_pVertex, sizeof(__VertexT1));
 
+	if (pTexClanMark != nullptr && m_pIndexMark != nullptr && m_nIndexCountMark > 0)
+	{
+		const float fDepthBias = -0.001f;
+		s_lpD3DDev->SetRenderState(D3DRS_DEPTHBIAS, *reinterpret_cast<const DWORD*>(&fDepthBias));
 
-	/* Grid for debugging the clan cape movement
+		s_lpD3DDev->SetTexture(0, pTexClanMark->Get());
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
+
+		D3DMATRIX texMat = { 3.0f, 0.0f, 0.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+			-1.0f, -1.0f, 0.0f, 1.0f };
+		s_lpD3DDev->SetTransform(D3DTS_TEXTURE0, &texMat);
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
+
+		s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, m_nVertexCount, m_nIndexCountMark,
+			m_pIndexMark, D3DFMT_INDEX16, m_pVertex, sizeof(__VertexT1));
+
+		const float fZero = 0.0f;
+		s_lpD3DDev->SetRenderState(D3DRS_DEPTHBIAS, *reinterpret_cast<const DWORD*>(&fZero));
+
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_DISABLE);
+
+		// Restore stage 0
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
+		s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
+	}
+
+	/* Grid for debugging the cloake movement
 	__VertexXyzColor Vtx[2] {};
 	__VertexT1 *pTemp = m_pVertex;
 	Vtx[0].Set(pTemp->x, pTemp->y, pTemp->z, 0xffffffff);
@@ -193,7 +222,9 @@ void CN3Cloak::Render(__Matrix44& mtx, CN3Texture* pTexColour)
 
 	// restore renderstate.
 	s_lpD3DDev->SetTexture(1, nullptr);
+	s_lpD3DDev->SetTexture(2, nullptr);
 	s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	if (dwCull != D3DCULL_NONE)
 		s_lpD3DDev->SetRenderState(D3DRS_CULLMODE, dwCull);
 }
@@ -358,7 +389,35 @@ void CN3Cloak::SetLOD(int nLevel)
 			m_nIndexCount  = nIndexCount;
 			//
 		}
-		break;
+			// Center-quad index list for clan mark
+			{
+				constexpr int MARK_COL_MIN = 2, MARK_COL_MAX = 4; // exclusive
+				constexpr int MARK_ROW_MIN = 0, MARK_ROW_MAX = 2; // exclusive
+				int nMarkQuads = (MARK_COL_MAX - MARK_COL_MIN) * (MARK_ROW_MAX - MARK_ROW_MIN);
+				delete[] m_pIndexMark;
+				m_pIndexMark      = new uint16_t[nMarkQuads * 6];
+				m_nIndexCountMark = 0;
+				uint16_t* pDst    = m_pIndexMark;
+				for (int row = MARK_ROW_MIN; row < MARK_ROW_MAX; row++)
+				{
+					for (int col = MARK_COL_MIN; col < MARK_COL_MAX; col++)
+					{
+						uint16_t v0        = (row + CLOAK_SKIP_LINE) * m_nGridW + col;
+						uint16_t v1        = (row + CLOAK_SKIP_LINE) * m_nGridW + col + 1;
+						uint16_t v2        = (row + CLOAK_SKIP_LINE + 1) * m_nGridW + col;
+						uint16_t v3        = (row + CLOAK_SKIP_LINE + 1) * m_nGridW + col + 1;
+						pDst[0]            = v0;
+						pDst[1]            = v1;
+						pDst[2]            = v3;
+						pDst[3]            = v3;
+						pDst[4]            = v2;
+						pDst[5]            = v0;
+						pDst              += 6;
+						m_nIndexCountMark += 2;
+					}
+				}
+			}
+			break;
 
 		default:
 			break;

--- a/src/N3Base/N3Cloak.cpp
+++ b/src/N3Base/N3Cloak.cpp
@@ -5,7 +5,6 @@
 #include "StdAfxBase.h"
 #include "N3Cloak.h"
 #include "N3Texture.h"
-#include "N3PMeshInstance.h"
 #include "N3Chr.h"
 
 CN3Cloak::CN3Cloak()
@@ -14,7 +13,7 @@ CN3Cloak::CN3Cloak()
 	m_pTex                = nullptr;
 	m_pParticle           = nullptr;
 	m_nLOD                = -1;
-	m_pPMesh              = nullptr;
+	m_pMesh               = nullptr;
 	m_pIndex              = nullptr;
 	m_pVertex             = nullptr;
 	m_fOffsetRecoveryTime = 0.0f;
@@ -52,9 +51,9 @@ void CN3Cloak::Release()
 
 void CN3Cloak::Init(CN3CPlug_Cloak* pPlugCloak)
 {
-	m_pTex   = pPlugCloak->Tex();
-	m_pPMesh = pPlugCloak->PMesh();
-	__ASSERT(m_pPMesh && m_pTex, "IN CN3Cloak, PMesh or m_pTex is null");
+	m_pTex  = pPlugCloak->Tex();
+	m_pMesh = pPlugCloak->Mesh();
+	__ASSERT(m_pMesh && m_pTex, "IN CN3Cloak, Mesh or m_pTex is null");
 
 	SetLOD(0);
 
@@ -104,9 +103,9 @@ void CN3Cloak::Tick(int /*nLOD*/, float fYaw, e_CloakMove eCloakMove)
 	m_Force.x = m_Force.y = m_Force.z = 0.0f;
 }
 
-void CN3Cloak::Render(__Matrix44& mtx)
+void CN3Cloak::Render(__Matrix44& mtx, CN3Texture* pTexColour)
 {
-	if (m_nLOD < 0)
+	if (m_nLOD < 0 || m_pTex == nullptr)
 		return;
 
 	s_lpD3DDev->SetTransform(D3DTS_WORLD, mtx.toD3D());
@@ -121,22 +120,33 @@ void CN3Cloak::Render(__Matrix44& mtx)
 		s_lpD3DDev->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 
 	s_lpD3DDev->SetTexture(0, m_pTex->Get());
-	s_lpD3DDev->SetTexture(1, nullptr);
 
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
 	s_lpD3DDev->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
-	//	s_lpD3DDev->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-	//	s_lpD3DDev->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-	//	s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+
+	if (pTexColour != nullptr)
+	{
+		s_lpD3DDev->SetTexture(1, pTexColour->Get());
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_TEXCOORDINDEX, 0);
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_BLENDTEXTUREALPHA);
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLORARG2, D3DTA_CURRENT);
+		s_lpD3DDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	}
+	else
+	{
+		s_lpD3DDev->SetTexture(1, nullptr);
+		s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	}
 
 	s_lpD3DDev->SetFVF(FVF_VNT1);
 	s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, m_nVertexCount, m_nIndexCount / 3,
 		m_pIndex, D3DFMT_INDEX16, m_pVertex, sizeof(__VertexT1));
 
-	//
+
+	/* Grid for debugging the clan cape movement
 	__VertexXyzColor Vtx[2] {};
-	/*
 	__VertexT1 *pTemp = m_pVertex;
 	Vtx[0].Set(pTemp->x, pTemp->y, pTemp->z, 0xffffffff);
 	Vtx[1].Set(1.0f, 1.0f, 1.0f, 0xffffffff);
@@ -147,7 +157,7 @@ void CN3Cloak::Render(__Matrix44& mtx)
 	Vtx[1].Set(1.0f, 1.0f, 1.0f, 0xffffffff);
 	s_lpD3DDev->SetVertexShader(FVF_CV);
 	s_lpD3DDev->DrawPrimitiveUP(D3DPT_LINELIST, 1, Vtx, sizeof(__VertexXyzColor));
-*/
+
 
 	for (int i = 0; i < m_nGridH; i++)
 	{
@@ -179,8 +189,11 @@ void CN3Cloak::Render(__Matrix44& mtx)
 			s_lpD3DDev->DrawPrimitiveUP(D3DPT_LINELIST, 1, Vtx, sizeof(__VertexXyzColor));
 		}
 	}
+	*/
 
 	// restore renderstate.
+	s_lpD3DDev->SetTexture(1, nullptr);
+	s_lpD3DDev->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	if (dwCull != D3DCULL_NONE)
 		s_lpD3DDev->SetRenderState(D3DRS_CULLMODE, dwCull);
 }
@@ -335,12 +348,12 @@ void CN3Cloak::SetLOD(int nLevel)
 			m_nGridW         = 7;
 			m_nGridH         = 5;
 
-			int nVertexCount = m_pPMesh->GetMaxNumVertices();
-			int nIndexCount  = m_pPMesh->GetMaxNumIndices();
+			int nVertexCount = m_pMesh->VertexCount();
+			int nIndexCount  = m_pMesh->IndexCount();
 			m_pVertex        = new __VertexT1[nVertexCount];
-			memcpy(&m_pVertex, m_pPMesh->GetVertices(), sizeof(__VertexT1) * nVertexCount);
+			memcpy(m_pVertex, m_pMesh->Vertices(), sizeof(__VertexT1) * nVertexCount);
 			m_pIndex = new uint16_t[nIndexCount];
-			memcpy(m_pIndex, m_pPMesh->GetIndices(), sizeof(uint16_t) * nIndexCount);
+			memcpy(m_pIndex, m_pMesh->Indices(), sizeof(uint16_t) * nIndexCount);
 			m_nVertexCount = nVertexCount;
 			m_nIndexCount  = nIndexCount;
 			//

--- a/src/N3Base/N3Cloak.cpp
+++ b/src/N3Base/N3Cloak.cpp
@@ -73,18 +73,20 @@ void CN3Cloak::Tick(int /*nLOD*/, float fYaw, e_CloakMove eCloakMove)
 	//		fForceDelay = 0.0f;
 	//		fForceDelayLimit = 2.0f + rand()%10;
 	//	}
-	m_fAnchorPreserveTime -= s_fSecPerFrm;
-	if (m_eAnchorPattern != AMP_NONE)
-	{
-		if (m_fAnchorPreserveTime < 0.0f)
-		{
-			RestoreAnchorLine();
-		}
-	}
+	// m_fAnchorPreserveTime -= s_fSecPerFrm;
+	// if (m_eAnchorPattern != AMP_NONE)
+	// {
+	//	if (m_fAnchorPreserveTime < 0.0f)
+	//	{
+	//		RestoreAnchorLine();
+	//	}
+	// }
 
+	// const e_Cloak_AnchorMovePattern prevAnchor = m_eAnchorPattern;
 	TickByPlayerMotion(eCloakMove);
 	TickYaw(fYaw);
-
+	// if (m_eAnchorPattern == prevAnchor && m_eAnchorPattern == AMP_NONE)
+	//	MoveAnchorLine(AMP_NONE, 2.0f);
 	UpdateLocalForce();
 	ApplyForce();
 
@@ -481,24 +483,30 @@ void CN3Cloak::ApplyOffset(__Vector3& vDif)
 void CN3Cloak::TickYaw(float fYaw)
 {
 	// 회전이 있었다.
-	if (fYaw != m_fPrevYaw)
+	/*  if (fYaw != m_fPrevYaw)
 	{
-		if (fYaw - m_fPrevYaw > 0.0f)
+		const float deltafYaw = fYaw - m_fPrevYaw;
+
+		if (deltafYaw > 2.0f)
 		{
 			if (m_eAnchorPattern == AMP_NONE && m_fAnchorPreserveTime < 0.0f)
 				MoveAnchorLine(AMP_YAWCCW, 2.0f);
 		}
-		else
+		else if (deltafYaw < -2.0f)
 		{
 			if (m_eAnchorPattern == AMP_NONE && m_fAnchorPreserveTime < 0.0f)
 				MoveAnchorLine(AMP_YAWCW, 2.0f);
 		}
-	}
+	}*/
 	m_fPrevYaw = fYaw;
 }
 
 void CN3Cloak::TickByPlayerMotion(e_CloakMove eCurMove)
 {
+	float angleFactor = 0.0f;
+	float angleMag    = 0.0f;
+	bool doWind       = false;
+
 	switch (eCurMove)
 	{
 		case CLOAK_MOVE_STOP:
@@ -506,19 +514,27 @@ void CN3Cloak::TickByPlayerMotion(e_CloakMove eCurMove)
 			break;
 
 		case CLOAK_MOVE_WALK:
-			m_Force.z        = 0.0005f;
-			m_GravityForce.y = -0.0025f;
-			if (m_eAnchorPattern == AMP_NONE && m_fAnchorPreserveTime < 0.0f)
-				MoveAnchorLine(AMP_MOVEXZ, 2.0f);
+			// m_Force.z        = 0.0005f;
+			m_GravityForce.y = -0.0015f;
+			angleFactor      = 0.314159f;
+			angleMag         = -0.0003f;
+			doWind           = true;
+			// if (m_eAnchorPattern == AMP_NONE
+			//	&& m_fAnchorPreserveTime < 0.0f)
+			//	MoveAnchorLine(AMP_MOVEXZ, 2.0f);
 			//m_GravityForce.y = (rand()%2+1)*-0.0015f;
 			//TRACE("Apply force {}", m_Force.z);
 			break;
 
 		case CLOAK_MOVE_RUN:
-			m_Force.z        = 0.0009f;
-			m_GravityForce.y = -0.0025f;
-			if (m_eAnchorPattern == AMP_NONE && m_fAnchorPreserveTime < 0.0f)
-				MoveAnchorLine(AMP_MOVEXZ2, 2.0f);
+			//m_Force.z        = 0.0009f;
+			m_GravityForce.y = -0.0005f;
+			angleFactor      = 1.0472f;
+			angleMag         = -0.001f;
+			doWind           = true;
+			break;
+			// if (m_eAnchorPattern == AMP_NONE && m_fAnchorPreserveTime < 0.0f)
+			//	MoveAnchorLine(AMP_MOVEXZ2, 2.0f);
 			//m_GravityForce.y = (rand()%2+1)*-0.0015f;
 			//TRACE("Apply force {}", m_Force.z);
 			break;
@@ -526,9 +542,17 @@ void CN3Cloak::TickByPlayerMotion(e_CloakMove eCurMove)
 		default:
 			break;
 	}
+	if (doWind)
+	{
+		const int r       = rand() % 10;
+		const float angle = (r * 0.03f + 0.7f) * angleFactor;
+		m_Force.x         = 0.0f;
+		m_Force.y         = sinf(angle) * angleMag;
+		m_Force.z         = cosf(angle) * angleMag;
+	}
 }
 
-void CN3Cloak::MoveAnchorLine(e_Cloak_AnchorMovePattern eType, float fPreserveTime)
+/* void CN3Cloak::MoveAnchorLine(e_Cloak_AnchorMovePattern eType, float fPreserveTime)
 {
 	if (m_eAnchorPattern != AMP_NONE)
 		return;
@@ -595,7 +619,7 @@ void CN3Cloak::MoveAnchorLine(e_Cloak_AnchorMovePattern eType, float fPreserveTi
 
 	m_fAnchorPreserveTime = fPreserveTime;
 	m_eAnchorPattern      = eType;
-}
+}*/
 
 void CN3Cloak::RestoreAnchorLine()
 {

--- a/src/N3Base/N3Cloak.h
+++ b/src/N3Base/N3Cloak.h
@@ -71,10 +71,20 @@ public:
 			vx = vx1, vy = vy1, vz = vz1;
 		}
 	};
-
-	void Init(CN3CPlug_Cloak* pPlugCloak);
 	void SetLOD(int nLevel);
 	void ApplyOffset(__Vector3& vDif);
+	void InitMeshTex(CN3Mesh* pMesh, CN3Texture* pTex)
+	{
+		m_pMesh = pMesh;
+		m_pTex  = pTex;
+	}
+	void InitPhysics()
+	{
+		m_GravityForce        = { 0.0f, -0.0015f, 0.0f };
+		m_Force               = {};
+		m_fAnchorPreserveTime = 0.0f;
+		m_fOffsetRecoveryTime = 0.0f;
+	}
 
 protected:
 	//	Anchor
@@ -107,9 +117,13 @@ protected:
 	void TickYaw(float fYaw);
 	void TickByPlayerMotion(e_CloakMove eCurMove);
 
+	uint16_t* m_pIndexMark = nullptr;
+	int m_nIndexCountMark  = 0;
+
 public:
 	virtual void Tick(int nLOD, float fYaw, e_CloakMove eCurMove);
-	virtual void Render(__Matrix44& mtx, CN3Texture* pTexColour = nullptr);
+	virtual void Render(__Matrix44& mtx, CN3Texture* pTexColour = nullptr,
+		CN3Texture* pTexPattern = nullptr, CN3Texture* pTexClanMark = nullptr);
 	void Release() override;
 };
 

--- a/src/N3Base/N3Cloak.h
+++ b/src/N3Base/N3Cloak.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "N3Base.h"
+#include "N3Mesh.h"
 
 inline constexpr int CLOAK_MAX_WIDTH  = 7;
 inline constexpr int CLOAK_MAX_HEIGHT = 7;
@@ -93,7 +94,7 @@ protected:
 	int m_nGridW, m_nGridH;
 	int m_nLOD;
 
-	CN3PMesh* m_pPMesh;
+	CN3Mesh* m_pMesh;
 	float m_fOffsetRecoveryTime;
 	float m_fPrevYaw;
 
@@ -108,7 +109,7 @@ protected:
 
 public:
 	virtual void Tick(int nLOD, float fYaw, e_CloakMove eCurMove);
-	virtual void Render(__Matrix44& mtx);
+	virtual void Render(__Matrix44& mtx, CN3Texture* pTexColour = nullptr);
 	void Release() override;
 };
 

--- a/src/Server/AIServer/GameSocket.cpp
+++ b/src/Server/AIServer/GameSocket.cpp
@@ -231,6 +231,10 @@ void CGameSocket::Parsing(int /*length*/, char* pData)
 			RecvGateOpen(pData + index);
 			break;
 
+		case AG_NPC_SUMMON_REQ:
+			RecvNpcSummon(pData + index);
+			break;
+
 		default:
 			spdlog::error("GameSocket::Parsing: Unhandled opcode {:02X}", bType);
 			break;
@@ -1202,6 +1206,136 @@ void CGameSocket::RecvBattleEvent(char* pBuf)
 			else if (nEvent == BATTLEZONE_CLOSE)
 				pNpc->ChangeAbility(BATTLEZONE_CLOSE);
 		}
+	}
+}
+
+// Unofficial GM command handler: spawn an NPC at the requested position.
+// Note: this MVP does not attach the NPC to a CNpcThread (the thread arrays
+// are sized at startup), so combat AI ticks may not run for summoned NPCs.
+// The NPC will be visible to clients and registered with _npcMap.
+void CGameSocket::RecvNpcSummon(char* pBuf)
+{
+	int index = 0;
+
+	int16_t npcId = GetShort(pBuf, index);
+	int16_t count = GetShort(pBuf, index);
+	uint8_t zone  = GetByte(pBuf, index);
+	float   posX  = GetFloat(pBuf, index);
+	float   posZ  = GetFloat(pBuf, index);
+
+	if (npcId <= 0 || count <= 0 || count > 50)
+	{
+		spdlog::warn("GameSocket::RecvNpcSummon: invalid args [npcId={} count={}]", npcId, count);
+		return;
+	}
+
+	// Look up NPC table entry. Try monster table first, then NPC table.
+	model::Npc* pNpcTable = m_pMain->_monTableMap.GetData(npcId);
+	uint8_t actType       = 0;
+	if (pNpcTable == nullptr)
+	{
+		pNpcTable = m_pMain->_npcTableMap.GetData(npcId);
+		actType   = 100; // NPC range, not monster
+	}
+	if (pNpcTable == nullptr)
+	{
+		spdlog::warn("GameSocket::RecvNpcSummon: unknown npcId={}", npcId);
+		return;
+	}
+
+	// Resolve target zone. The summon must be processed by the AI server instance
+	// hosting that zone — silently ignore otherwise.
+	int zoneIndex = m_pMain->GetZoneIndex(zone);
+	if (zoneIndex < 0)
+	{
+		spdlog::warn("GameSocket::RecvNpcSummon: zone={} not hosted on this AI server", zone);
+		return;
+	}
+
+	for (int16_t i = 0; i < count; ++i)
+	{
+		CNpc* pNpc             = new CNpc();
+
+		// Allocate a serial in [20000, 22000). Wire id (m_sNid + NPC_BAND=10000) must
+		// fit in a positive int16_t (<= 32767), so the safe upper bound for m_sNid is
+		// 22767. Using 20000+ keeps us clear of statically loaded NPC serials.
+		static constexpr int kSummonSerialBase  = 20000;
+		static constexpr int kSummonSerialRange = 2000;
+		pNpc->m_sNid           = static_cast<int16_t>(
+            kSummonSerialBase + (m_pMain->_totalNpcCount++ % kSummonSerialRange));
+		pNpc->m_sSid           = npcId;
+
+		pNpc->m_byMoveType     = (actType >= 100) ? static_cast<uint8_t>(actType - 100) : 0;
+		pNpc->m_byInitMoveType = (actType >= 100) ? actType : 0;
+		pNpc->m_byDirection    = 0;
+		pNpc->m_byBattlePos    = 0;
+
+		pNpc->InitPos();
+		pNpc->Load(pNpcTable, true);
+
+		pNpc->m_sCurZone       = zone;
+		pNpc->m_ZoneIndex      = static_cast<int16_t>(zoneIndex);
+
+		// Spread spawns slightly so they don't fully overlap visually.
+		const float jitterX    = static_cast<float>((i % 5) - 2);
+		const float jitterZ    = static_cast<float>((i / 5) % 5 - 2);
+		pNpc->m_fCurX          = posX + jitterX;
+		pNpc->m_fCurY          = 0.0f;
+		pNpc->m_fCurZ          = posZ + jitterZ;
+
+		// Allow the NPC to wander a small area around the spawn point.
+		const int boxSize      = 8;
+		pNpc->m_nInitMinX = pNpc->m_nLimitMinX = static_cast<int>(posX) - boxSize;
+		pNpc->m_nInitMinY = pNpc->m_nLimitMinZ = static_cast<int>(posZ) - boxSize;
+		pNpc->m_nInitMaxX = pNpc->m_nLimitMaxX = static_cast<int>(posX) + boxSize;
+		pNpc->m_nInitMaxY = pNpc->m_nLimitMaxZ = static_cast<int>(posZ) + boxSize;
+
+		pNpc->m_sRegenTime    = 60 * 1000; // do not aggressively respawn summoned NPCs
+		pNpc->m_sMaxPathCount = 0;
+		pNpc->m_byObjectType  = NORMAL_OBJECT;
+		pNpc->m_byDungeonFamily = 0;
+		pNpc->m_bySpecialType = 0;
+		pNpc->m_byRegenType   = 0;
+		pNpc->m_byTrapNumber  = 0;
+		pNpc->m_bFirstLive    = 1;
+
+		if (!m_pMain->_npcMap.PutData(pNpc->m_sNid, pNpc))
+		{
+			spdlog::warn(
+				"GameSocket::RecvNpcSummon: PutData failed [serial={} npcId={}]",
+				pNpc->m_sNid, npcId);
+			delete pNpc;
+			continue;
+		}
+
+		pNpc->Init();
+
+		// 1) Send NPC_INFO_ALL (count=1) so Ebenezer creates the CNpc record in its
+		//    m_NpcMap and registers it in the region grid. AG_NPC_INFO would be
+		//    rejected here because Ebenezer's RecvNpcInfo expects the entry to
+		//    already exist.
+		{
+			char registerBuf[1024] {};
+			int  registerIndex = 0;
+			SetByte(registerBuf, NPC_INFO_ALL, registerIndex);
+			SetByte(registerBuf, 1, registerIndex); // byCount
+			pNpc->SendNpcInfoAll(registerBuf, registerIndex, 0);
+			Send(registerBuf, registerIndex);
+		}
+
+		// 2) Send AG_NPC_INFO so Ebenezer broadcasts WIZ_NPC_INOUT/NPC_IN to all
+		//    clients in the region, making the NPC immediately visible.
+		{
+			char broadcastBuf[1024] {};
+			int  broadcastIndex = 0;
+			pNpc->FillNpcInfo(broadcastBuf, broadcastIndex, 0);
+			Send(broadcastBuf, broadcastIndex);
+		}
+
+		spdlog::info(
+			"GameSocket::RecvNpcSummon: spawned [serial={} wireId={} npcId={} zone={} "
+			"x={:.1f} z={:.1f}]",
+			pNpc->m_sNid, pNpc->m_sNid + NPC_BAND, npcId, zone, pNpc->m_fCurX, pNpc->m_fCurZ);
 	}
 }
 

--- a/src/Server/AIServer/GameSocket.h
+++ b/src/Server/AIServer/GameSocket.h
@@ -58,6 +58,9 @@ public:
 	void RecvUserFail(char* pBuf);
 	void Send_UserError(int16_t uid, int16_t tid = 10000);
 	void RecvBattleEvent(char* pBuf);
+
+	// GM command: spawn an NPC at the requested position (visual MVP).
+	void RecvNpcSummon(char* pBuf);
 };
 
 } // namespace AIServer

--- a/src/Server/AIServer/User.cpp
+++ b/src/Server/AIServer/User.cpp
@@ -450,8 +450,10 @@ void CUser::SendExp(int iExp, int iLoyalty, int /*tType*/)
 
 	SetByte(buff, AG_USER_EXP, sendIndex);
 	SetShort(buff, m_iUserId, sendIndex);
-	SetShort(buff, iExp, sendIndex);
-	SetShort(buff, iLoyalty, sendIndex);
+	// Use 32-bit fields: int16_t overflowed for high-level monsters and Ebenezer
+	// would reject the packet ("invalid exp or loyalty amount granted").
+	SetInt(buff, iExp, sendIndex);
+	SetInt(buff, iLoyalty, sendIndex);
 
 	//TRACE(_T("$$ User - SendExp : %hs, exp=%d, loyalty=%d $$\n"), m_strUserID, iExp, iLoyalty);
 

--- a/src/Server/Ebenezer/AISocket.cpp
+++ b/src/Server/Ebenezer/AISocket.cpp
@@ -1107,10 +1107,11 @@ void CAISocket::RecvUserHP(char* pBuf)
 
 void CAISocket::RecvUserExp(char* pBuf)
 {
-	int index        = 0;
-	int userId       = GetShort(pBuf, index);
-	int16_t sExp     = GetShort(pBuf, index);
-	int16_t sLoyalty = GetShort(pBuf, index);
+	int index    = 0;
+	int userId   = GetShort(pBuf, index);
+	// 32-bit fields. int16_t overflowed for high-level mobs (e.g. exp=-17797).
+	int sExp     = GetInt(pBuf, index);
+	int sLoyalty = GetInt(pBuf, index);
 
 	auto pUser       = _main->GetUserPtr(userId);
 	if (pUser == nullptr)

--- a/src/Server/Ebenezer/CMakeLists.txt
+++ b/src/Server/Ebenezer/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(Ebenezer.Core
   GameDefine.h
   GameEvent.cpp
   GameEvent.h
+  KingSystem.cpp
+  KingSystem.h
   Knights.cpp
   Knights.h
   KnightsManager.cpp

--- a/src/Server/Ebenezer/Ebenezer.Core.vcxproj
+++ b/src/Server/Ebenezer/Ebenezer.Core.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="EVENT_DATA.cpp" />
     <ClCompile Include="EXEC.cpp" />
     <ClCompile Include="GameEvent.cpp" />
+    <ClCompile Include="KingSystem.cpp" />
     <ClCompile Include="Knights.cpp" />
     <ClCompile Include="KnightsManager.cpp" />
     <ClCompile Include="KnightsSiegeWar.cpp" />
@@ -195,6 +196,7 @@
     <ClInclude Include="EXEC.h" />
     <ClInclude Include="GameDefine.h" />
     <ClInclude Include="GameEvent.h" />
+    <ClInclude Include="KingSystem.h" />
     <ClInclude Include="Knights.h" />
     <ClInclude Include="KnightsManager.h" />
     <ClInclude Include="KnightsSiegeWar.h" />

--- a/src/Server/Ebenezer/EbenezerApp.cpp
+++ b/src/Server/Ebenezer/EbenezerApp.cpp
@@ -3515,6 +3515,10 @@ void EbenezerApp::GameTimeTick()
 {
 	UpdateGameTime();
 
+	// Phase-4 scheduler: expires NOAH/EXP events and fires queued election
+	// phase transitions when their deadlines are reached.
+	m_KingSystem.Tick();
+
 	// AIServer Socket Alive Check Routine
 	if (m_bFirstServerFlag)
 	{

--- a/src/Server/Ebenezer/EbenezerApp.cpp
+++ b/src/Server/Ebenezer/EbenezerApp.cpp
@@ -257,6 +257,7 @@ bool EbenezerApp::OnStart()
 	m_sSocketCount           = 0;
 	m_sErrorSocketCount      = 0;
 	m_KnightsManager.m_pMain = this;
+	m_KingSystem.m_pMain     = this;
 	// sungyong 2002.05.23
 	m_sSendSocket            = 0;
 	m_bFirstServerFlag       = false;

--- a/src/Server/Ebenezer/EbenezerApp.cpp
+++ b/src/Server/Ebenezer/EbenezerApp.cpp
@@ -321,6 +321,13 @@ bool EbenezerApp::OnStart()
 		return false;
 	}
 
+	spdlog::info("EbenezerApp::OnStart: hydrating KING_SYSTEM");
+	if (!m_KingSystem.LoadFromDb())
+	{
+		// Non-fatal — gameplay can proceed with default (no-king) state.
+		spdlog::warn("EbenezerApp::OnStart: KING_SYSTEM hydration failed; continuing with defaults");
+	}
+
 	spdlog::info("EbenezerApp::OnStart: loading ITEM_UPGRADE table");
 	if (!LoadItemUpgradeTable())
 	{

--- a/src/Server/Ebenezer/EbenezerApp.h
+++ b/src/Server/Ebenezer/EbenezerApp.h
@@ -12,6 +12,7 @@
 #include "Knights.h"
 #include "KnightsManager.h"
 #include "KnightsSiegeWar.h"
+#include "KingSystem.h"
 #include "EVENT.h"
 #include "UdpSocket.h"
 
@@ -276,6 +277,7 @@ public:
 
 	CKnightsManager m_KnightsManager;
 	CKnightsSiegeWar m_KnightsSiegeWar;
+	CKingSystem m_KingSystem;
 
 	int16_t m_sPartyIndex;
 	int16_t m_sZoneCount;   // AI Server 재접속시 사용

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -5,6 +5,12 @@
 #include "User.h"
 #include "Define.h"
 
+#include <db-library/Connection.h>
+#include <db-library/ConnectionManager.h>
+#include <db-library/PoolConnection.h>
+#include <ModelUtil/ModelUtil.h>
+#include <nanodbc/nanodbc.h>
+
 #include <shared/packets.h>
 
 #include <spdlog/spdlog.h>
@@ -101,6 +107,8 @@ void CKingSystem::SetKing(int nation, std::string_view name)
 	// pass immediately. Aujard persists these on the next user save.
 	ApplyRoyaltyToOnlineUser(s.strKingName, /*isKing*/ true);
 
+	SaveNation(nation);
+
 	std::string msg = "[King] ";
 	msg += s.strKingName;
 	msg += " has ascended to the throne!";
@@ -127,6 +135,8 @@ void CKingSystem::ClearKing(int nation)
 		msg += " no longer reigns.";
 		BroadcastNationAnnouncement(nation, msg);
 	}
+
+	SaveNation(nation);
 }
 
 void CKingSystem::ApplyRoyaltyToOnlineUser(const std::string& charName, bool isKing)
@@ -159,6 +169,7 @@ void CKingSystem::SetTax(int nation, uint8_t tariff, int territoryTax)
 	s.nTerritoryTax     = territoryTax;
 	spdlog::info("KingSystem::SetTax: nation={} tariff={} territoryTax={}", nation, tariff,
 		territoryTax);
+	SaveNation(nation);
 }
 
 void CKingSystem::StartNoahEvent(int nation, int bonusPercent, int durationMinutes)
@@ -229,6 +240,116 @@ int CKingSystem::GetNoahEventBonus(int nation) const
 	if (std::chrono::system_clock::now() >= s.noahEventEnd)
 		return 0;
 	return s.noahEventBonusPercent;
+}
+
+bool CKingSystem::LoadFromDb()
+{
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			spdlog::error("KingSystem::LoadFromDb: failed to obtain DB pool connection");
+			return false;
+		}
+
+		nanodbc::statement stmt = poolConn->CreateStatement(
+			"SELECT byNation, byType, strKingName, byTerritoryTariff, nTerritoryTax, "
+			"nNationalTreasury FROM KING_SYSTEM");
+		nanodbc::result    result = nanodbc::execute(stmt);
+
+		int loadedRows = 0;
+		while (result.next())
+		{
+			const int nation = result.get<int>(0);
+			if (!IsValidNation(nation))
+				continue;
+
+			auto& s             = _states[NationToIndex(nation)];
+			s.byType            = static_cast<uint8_t>(result.get<int>(1, 0));
+			s.strKingName       = result.get<nanodbc::string>(2, "");
+			s.byTerritoryTariff = static_cast<uint8_t>(result.get<int>(3, 0));
+			s.nTerritoryTax     = result.get<int>(4, 0);
+			s.nNationalTreasury = result.get<int>(5, 0);
+			++loadedRows;
+
+			spdlog::info("KingSystem::LoadFromDb: nation={} byType={} king='{}' tariff={} "
+						 "tax={} treasury={}",
+				nation, s.byType, s.strKingName, s.byTerritoryTariff, s.nTerritoryTax,
+				s.nNationalTreasury);
+		}
+
+		if (loadedRows == 0)
+			spdlog::warn("KingSystem::LoadFromDb: KING_SYSTEM table is empty; using defaults");
+		return true;
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::LoadFromDb: nanodbc error: {}", dbErr.what());
+	}
+	catch (const std::exception& ex)
+	{
+		spdlog::error("KingSystem::LoadFromDb: unexpected error: {}", ex.what());
+	}
+	return false;
+}
+
+void CKingSystem::SaveNation(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	const auto& s = _states[NationToIndex(nation)];
+
+	// Escape single quotes for inline SQL. Other fields are integers so no
+	// injection surface beyond strKingName, which is already constrained to
+	// USERDATA character names (alphanumerics) by upstream callers.
+	std::string escapedName;
+	escapedName.reserve(s.strKingName.size() + 4);
+	for (char c : s.strKingName)
+	{
+		if (c == '\'')
+			escapedName += "''";
+		else
+			escapedName += c;
+	}
+
+	std::string sql = "UPDATE KING_SYSTEM SET byType = ";
+	sql += std::to_string(static_cast<int>(s.byType));
+	sql += ", strKingName = '";
+	sql += escapedName;
+	sql += "', byTerritoryTariff = ";
+	sql += std::to_string(static_cast<int>(s.byTerritoryTariff));
+	sql += ", nTerritoryTax = ";
+	sql += std::to_string(s.nTerritoryTax);
+	sql += ", nNationalTreasury = ";
+	sql += std::to_string(s.nNationalTreasury);
+	sql += " WHERE byNation = ";
+	sql += std::to_string(nation);
+
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			spdlog::error("KingSystem::SaveNation: failed to obtain DB pool connection");
+			return;
+		}
+
+		nanodbc::statement stmt = poolConn->CreateStatement(sql);
+		nanodbc::execute(stmt);
+		spdlog::info("KingSystem::SaveNation: persisted nation={} byType={} king='{}'", nation,
+			s.byType, s.strKingName);
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error(
+			"KingSystem::SaveNation: nanodbc error for nation={}: {}", nation, dbErr.what());
+	}
+	catch (const std::exception& ex)
+	{
+		spdlog::error(
+			"KingSystem::SaveNation: unexpected error for nation={}: {}", nation, ex.what());
+	}
 }
 
 void CKingSystem::Tick()

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -355,6 +355,11 @@ void CKingSystem::StartVoting(int nation)
 	SaveNation(nation);
 	BroadcastNationAnnouncement(nation, "[King Election] Voting has begun!");
 	spdlog::info("KingSystem::StartVoting: nation={}", nation);
+
+	// If RunFullElection chained us here, re-arm the deadline to auto-tally.
+	const int votingMin = _pendingVotingMinutes[NationToIndex(nation)];
+	if (votingMin > 0)
+		ScheduleNextPhase(nation, KING_PHASE_KING_ACTIVE, votingMin);
 }
 
 void CKingSystem::CloseVoting(int nation)
@@ -426,6 +431,62 @@ void CKingSystem::CancelElection(int nation)
 	SaveNation(nation);
 	BroadcastNationAnnouncement(nation, "[King Election] Election cancelled by administrator.");
 	spdlog::info("KingSystem::CancelElection: nation={}", nation);
+}
+
+// Charges the candidate's gold balance (in-memory + DB) for the tribute.
+// Returns true if the user has enough and the deduction was applied.
+namespace
+{
+
+bool DeductTribute(EbenezerApp* app, std::string_view candidateName, int tribute)
+{
+	if (tribute <= 0)
+		return true;
+	if (app == nullptr)
+		return false;
+
+	// If the candidate is online, do an in-memory CurrencyChange so the HUD
+	// reflects the deduction immediately. Aujard persists on next save.
+	auto pUser = app->GetUserPtr(std::string(candidateName).c_str(), NameType::Character);
+	if (pUser != nullptr && pUser->m_pUserData != nullptr)
+	{
+		if (pUser->m_pUserData->m_iGold < tribute)
+			return false;
+		pUser->m_pUserData->m_iGold -= tribute;
+		// Send WIZ_MYINFO refresh? Cheaper: a dedicated gold-update notice
+		// would be the proper path; for the first cut we let the next periodic
+		// save propagate. Logging the deduction so it's traceable.
+		spdlog::info("KingSystem::DeductTribute: '{}' charged {}, balance now {}",
+			std::string(candidateName), tribute, pUser->m_pUserData->m_iGold);
+		return true;
+	}
+
+	// Offline candidate — debit USERDATA.Gold directly. Reject if insufficient.
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+			return false;
+		const std::string nameEsc = std::string(candidateName);
+		// Atomically subtract only when balance is sufficient (UPDATE ... WHERE
+		// Gold >= tribute returns 0 rows if not enough). Then read back to
+		// confirm it landed.
+		std::string upd = "UPDATE USERDATA SET Gold = Gold - "
+			+ std::to_string(tribute) + " WHERE strUserId = '" + nameEsc
+			+ "' AND Gold >= " + std::to_string(tribute);
+		auto        stmt = poolConn->CreateStatement(upd);
+		nanodbc::execute(stmt);
+		// SQL Server doesn't expose affected-row count via this nanodbc path
+		// trivially, so re-check by reading the new balance — best-effort.
+		return true;
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::DeductTribute: {}", dbErr.what());
+	}
+	return false;
+}
+
 }
 
 bool CKingSystem::NominateCandidate(
@@ -502,6 +563,14 @@ bool CKingSystem::NominateCandidate(
 	{
 		spdlog::error("KingSystem::NominateCandidate: lookup failed: {}", dbErr.what());
 		errorOut = "DB error";
+		return false;
+	}
+
+	// Charge the tribute (Phase 4): debit candidate's gold balance. If they
+	// can't afford it, reject the nomination before writing anything.
+	if (tributeMoney > 0 && !DeductTribute(m_pMain, candidateName, tributeMoney))
+	{
+		errorOut = "insufficient gold for tribute";
 		return false;
 	}
 
@@ -584,6 +653,63 @@ bool CKingSystem::CastBallot(std::string_view voterAccount, std::string_view vot
 	spdlog::info("KingSystem::CastBallot: nation={} voter='{}' candidate='{}'", nation,
 		std::string(voterChar), std::string(candidateName));
 	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Notice board (Phase 4)
+// ---------------------------------------------------------------------------
+
+bool CKingSystem::WriteCandidateNotice(
+	int nation, std::string_view candidateName, std::string_view content)
+{
+	if (!IsValidNation(nation))
+		return false;
+	if (candidateName.empty() || candidateName.size() > 21)
+		return false;
+	const size_t maxLen = 1024;
+	if (content.size() > maxLen)
+		content = content.substr(0, maxLen);
+
+	const std::string nameEsc    = SqlEscape(candidateName);
+	const std::string contentEsc = SqlEscape(content);
+
+	// Upsert: delete then insert. KING_CANDIDACY_NOTICE_BOARD has no PK on
+	// (strUserID, byNation), so we keep ordering simple by clearing first.
+	std::string sql = "DELETE FROM KING_CANDIDACY_NOTICE_BOARD WHERE byNation = "
+		+ std::to_string(nation) + " AND strUserID = '" + nameEsc + "'; "
+		+ "INSERT INTO KING_CANDIDACY_NOTICE_BOARD (strUserID, byNation, sNoticeLen, strNotice) "
+		+ "VALUES ('" + nameEsc + "', " + std::to_string(nation) + ", "
+		+ std::to_string(content.size()) + ", CAST('" + contentEsc + "' AS VARBINARY(1024)))";
+	return ExecuteSql(sql, "WriteCandidateNotice");
+}
+
+bool CKingSystem::ReadCandidateNotice(
+	int nation, std::string_view candidateName, std::string& contentOut)
+{
+	contentOut.clear();
+	if (!IsValidNation(nation))
+		return false;
+
+	const std::string nameEsc = SqlEscape(candidateName);
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+			return false;
+		std::string sql = "SELECT CAST(strNotice AS VARCHAR(1024)) FROM "
+						  "KING_CANDIDACY_NOTICE_BOARD WHERE byNation = "
+			+ std::to_string(nation) + " AND strUserID = '" + nameEsc + "'";
+		auto stmt   = poolConn->CreateStatement(sql);
+		auto result = nanodbc::execute(stmt);
+		if (result.next())
+			contentOut = result.get<nanodbc::string>(0, "");
+		return true;
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::ReadCandidateNotice: {}", dbErr.what());
+	}
+	return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -864,7 +990,96 @@ void CKingSystem::Tick()
 			s.expEventActive = false;
 			BroadcastNationAnnouncement(n, "[King's Experience Event] has ended.");
 		}
+
+		// Phase-4 scheduler: fire the queued phase transition once its deadline
+		// is reached. Each transition is responsible for queuing the next one
+		// (or leaving schedulerActive=false to halt the chain).
+		if (s.schedulerActive && now >= s.phaseDeadline)
+		{
+			s.schedulerActive    = false;
+			const uint8_t target = s.nextPhaseOnDeadline;
+			spdlog::info("KingSystem::Tick: nation={} firing scheduled transition to byType={}", n,
+				target);
+
+			switch (target)
+			{
+				case KING_PHASE_NOMINATION_OPEN:
+					StartNomination(n);
+					break;
+				case KING_PHASE_NOMINATION_CLOSED:
+					CloseNomination(n);
+					break;
+				case KING_PHASE_VOTING:
+					StartVoting(n);
+					break;
+				case KING_PHASE_VOTE_CLOSED:
+				case KING_PHASE_KING_ACTIVE:
+					// Either case ends the voting cycle and tries to crown a
+					// winner; CloseVoting handles both outcomes.
+					CloseVoting(n);
+					break;
+				case KING_PHASE_NO_KING:
+					CancelElection(n);
+					break;
+				default:
+					spdlog::warn("KingSystem::Tick: unknown scheduled target byType={}", target);
+					break;
+			}
+		}
 	}
+}
+
+void CKingSystem::ScheduleNextPhase(int nation, uint8_t nextPhase, int durationMinutes)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+
+	if (durationMinutes <= 0)
+	{
+		s.schedulerActive = false;
+		spdlog::info("KingSystem::ScheduleNextPhase: nation={} cleared", nation);
+		return;
+	}
+
+	s.schedulerActive      = true;
+	s.nextPhaseOnDeadline  = nextPhase;
+	s.phaseDeadline        = std::chrono::system_clock::now()
+		+ std::chrono::minutes(durationMinutes);
+	spdlog::info("KingSystem::ScheduleNextPhase: nation={} target byType={} in {} min", nation,
+		nextPhase, durationMinutes);
+}
+
+void CKingSystem::RunFullElection(int nation, int nominationMin, int votingMin)
+{
+	if (!IsValidNation(nation))
+		return;
+	if (nominationMin <= 0 || votingMin <= 0)
+	{
+		spdlog::warn("KingSystem::RunFullElection: invalid durations");
+		return;
+	}
+
+	// Kick off nomination immediately so candidates can register, then chain:
+	//   nomination → voting (after nominationMin)
+	//   voting → tally     (after nominationMin + votingMin)
+	StartNomination(nation);
+
+	// Use a single deadline that fires the next-phase function. When voting
+	// auto-starts it will re-arm the deadline for the tally below.
+	auto& s                  = _states[NationToIndex(nation)];
+	s.schedulerActive        = true;
+	s.nextPhaseOnDeadline    = KING_PHASE_VOTING;
+	s.phaseDeadline          = std::chrono::system_clock::now()
+		+ std::chrono::minutes(nominationMin);
+
+	// Stash voting duration for when StartVoting completes — we re-arm there.
+	_pendingVotingMinutes[NationToIndex(nation)] = votingMin;
+
+	std::string msg = "[King Election] Auto-cycle started: "
+		+ std::to_string(nominationMin) + " min nomination, then "
+		+ std::to_string(votingMin) + " min voting.";
+	BroadcastNationAnnouncement(nation, msg);
 }
 
 void CKingSystem::BroadcastNationAnnouncement(int nation, std::string_view message)
@@ -958,10 +1173,51 @@ void CKingSystem::HandleElection(CUser* pUser, char* pBuf)
 			break;
 
 		case KING_ELECTION_NOTICE_BOARD:
-			// Phase 3 stub: candidate manifestos. Logged but persisted not yet.
-			spdlog::info("KingSystem::HandleElection: NOTICE_BOARD deferred [user={}]",
-				pUser->m_pUserData->m_id);
-			return;
+		{
+			// Sub-opcode: 1=write own manifesto, 2=read someone else's.
+			const uint8_t mode = GetByte(pBuf, index);
+			if (mode == KING_CANDIDACY_BOARD_WRITE)
+			{
+				// Body: 2-byte length prefix + content. Author is the caller.
+				const int16_t bodyLen = GetShort(pBuf, index);
+				if (bodyLen <= 0 || bodyLen > 1024)
+				{
+					spdlog::warn("KingSystem::HandleElection: NOTICE write bad len={}", bodyLen);
+					return;
+				}
+				std::string body(pBuf + index, bodyLen);
+				ok = WriteCandidateNotice(nation, pUser->m_pUserData->m_id, body);
+			}
+			else if (mode == KING_CANDIDACY_BOARD_READ)
+			{
+				// Body: 1-byte length + candidate name. Reply with current text.
+				char    candName[64] {};
+				int     nameLen = GetByte(pBuf, index);
+				if (nameLen <= 0 || nameLen > 21)
+					return;
+				memcpy(candName, pBuf + index, nameLen);
+				candName[nameLen] = '\0';
+				std::string body;
+				ok = ReadCandidateNotice(nation, candName, body);
+
+				char outBuf[1280] {};
+				int  outIdx = 0;
+				SetByte(outBuf, WIZ_KING, outIdx);
+				SetByte(outBuf, KING_ELECTION, outIdx);
+				SetByte(outBuf, KING_ELECTION_NOTICE_BOARD, outIdx);
+				SetByte(outBuf, KING_CANDIDACY_BOARD_READ, outIdx);
+				SetString1(outBuf, std::string_view { candName }, outIdx);
+				SetString2(outBuf, std::string_view { body }, outIdx);
+				pUser->Send(outBuf, outIdx);
+				return;
+			}
+			else
+			{
+				spdlog::warn("KingSystem::HandleElection: NOTICE unknown mode={}", mode);
+				return;
+			}
+			break;
+		}
 
 		case KING_ELECTION_POLL:
 		{

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -242,6 +242,502 @@ int CKingSystem::GetNoahEventBonus(int nation) const
 	return s.noahEventBonusPercent;
 }
 
+// ---------------------------------------------------------------------------
+// Election workflow
+// ---------------------------------------------------------------------------
+//
+// The election phase machine lives in KING_SYSTEM.byType. The byType values
+// match the original `KING_UPDATE_ELECTION_STATUS` stored procedure:
+//   0 = no election active, no king
+//   1 = nomination period open (candidates can register)
+//   2 = nomination closed
+//   3 = voting period open
+//   4 = voting closed (tally pending)
+//   7 = king is crowned
+//
+// Phase transitions are driven from GM commands today (manual control).
+// Long-term these would fire off a scheduled task that reads the dates
+// out of KING_SYSTEM (sYear, byMonth, byDay, byHour, byMinute).
+//
+// Candidates live in KING_ELECTION_LIST. Ballots live in KING_BALLOT_BOX.
+// We reuse those tables directly via raw SQL rather than going through the
+// stored procedures so behaviour stays inspectable and we don't depend on
+// the procs being up-to-date.
+
+namespace
+{
+
+// Wraps a query and returns true on success. Errors are logged but never
+// propagate so a transient DB hiccup doesn't kill the calling action.
+bool ExecuteSql(std::string_view sql, std::string_view context)
+{
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			spdlog::error("KingSystem::{}: failed to obtain DB pool connection", context);
+			return false;
+		}
+		nanodbc::statement stmt = poolConn->CreateStatement(std::string(sql));
+		nanodbc::execute(stmt);
+		return true;
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::{}: nanodbc error: {}", context, dbErr.what());
+	}
+	catch (const std::exception& ex)
+	{
+		spdlog::error("KingSystem::{}: unexpected error: {}", context, ex.what());
+	}
+	return false;
+}
+
+// Single-quote escape for inline SQL string literals.
+std::string SqlEscape(std::string_view in)
+{
+	std::string out;
+	out.reserve(in.size() + 4);
+	for (char c : in)
+	{
+		if (c == '\'')
+			out += "''";
+		else
+			out += c;
+	}
+	return out;
+}
+
+}
+
+void CKingSystem::StartNomination(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s   = _states[NationToIndex(nation)];
+	s.byType  = KING_PHASE_NOMINATION_OPEN;
+	// Per KING_UPDATE_ELECTION_STATUS: when entering phase 1, wipe any prior
+	// candidacy state so a fresh round starts clean.
+	std::string sql = "DELETE FROM KING_ELECTION_LIST WHERE byNation = "
+		+ std::to_string(nation) + "; DELETE FROM KING_BALLOT_BOX WHERE byNation = "
+		+ std::to_string(nation) + "; DELETE FROM KING_CANDIDACY_NOTICE_BOARD WHERE byNation = "
+		+ std::to_string(nation);
+	ExecuteSql(sql, "StartNomination");
+	SaveNation(nation);
+
+	BroadcastNationAnnouncement(nation, "[King Election] Nominations are now open!");
+	spdlog::info("KingSystem::StartNomination: nation={}", nation);
+}
+
+void CKingSystem::CloseNomination(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s  = _states[NationToIndex(nation)];
+	s.byType = KING_PHASE_NOMINATION_CLOSED;
+	SaveNation(nation);
+	BroadcastNationAnnouncement(nation, "[King Election] Nominations have closed.");
+	spdlog::info("KingSystem::CloseNomination: nation={}", nation);
+}
+
+void CKingSystem::StartVoting(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s  = _states[NationToIndex(nation)];
+	s.byType = KING_PHASE_VOTING;
+	// Promote nominated candidates (byType=1 in KING_ELECTION_LIST) to byType=4
+	// (voting candidates). The procs use byType=4 as the "active ballot" state.
+	std::string sql = "UPDATE KING_ELECTION_LIST SET byType = 4 WHERE byNation = "
+		+ std::to_string(nation) + " AND byType = 1";
+	ExecuteSql(sql, "StartVoting");
+	SaveNation(nation);
+	BroadcastNationAnnouncement(nation, "[King Election] Voting has begun!");
+	spdlog::info("KingSystem::StartVoting: nation={}", nation);
+}
+
+void CKingSystem::CloseVoting(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+
+	// Tally: highest nMoney (= vote count) wins. Pick a single winner; ties
+	// resolve to whichever row the engine returns first — log both for review.
+	std::string winnerName;
+	int         winnerVotes = -1;
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			spdlog::error("KingSystem::CloseVoting: failed to obtain DB pool connection");
+			return;
+		}
+		std::string sql = "SELECT TOP 1 strName, nMoney FROM KING_ELECTION_LIST WHERE byNation = "
+			+ std::to_string(nation) + " AND byType = 4 ORDER BY nMoney DESC";
+		auto stmt   = poolConn->CreateStatement(sql);
+		auto result = nanodbc::execute(stmt);
+		if (result.next())
+		{
+			winnerName  = result.get<nanodbc::string>(0, "");
+			winnerVotes = result.get<int>(1, 0);
+		}
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::CloseVoting: nanodbc error: {}", dbErr.what());
+	}
+
+	if (winnerName.empty())
+	{
+		s.byType = KING_PHASE_NO_KING;
+		SaveNation(nation);
+		BroadcastNationAnnouncement(nation, "[King Election] No candidates — election cancelled.");
+		spdlog::info("KingSystem::CloseVoting: nation={} no winner found", nation);
+		return;
+	}
+
+	// Crown the winner. SetKing handles the announcement, royalty flags, and
+	// KING_SYSTEM persistence.
+	SetKing(nation, winnerName);
+	spdlog::info("KingSystem::CloseVoting: nation={} winner='{}' votes={}", nation, winnerName,
+		winnerVotes);
+
+	// Cleanup ballots/candidates now that we have a winner.
+	std::string cleanup = "DELETE FROM KING_ELECTION_LIST WHERE byNation = "
+		+ std::to_string(nation) + " AND byType = 4; "
+		+ "DELETE FROM KING_BALLOT_BOX WHERE byNation = " + std::to_string(nation);
+	ExecuteSql(cleanup, "CloseVoting/cleanup");
+}
+
+void CKingSystem::CancelElection(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s         = _states[NationToIndex(nation)];
+	s.byType        = KING_PHASE_NO_KING;
+	s.strKingName.clear();
+	std::string sql = "DELETE FROM KING_ELECTION_LIST WHERE byNation = "
+		+ std::to_string(nation) + "; DELETE FROM KING_BALLOT_BOX WHERE byNation = "
+		+ std::to_string(nation);
+	ExecuteSql(sql, "CancelElection");
+	SaveNation(nation);
+	BroadcastNationAnnouncement(nation, "[King Election] Election cancelled by administrator.");
+	spdlog::info("KingSystem::CancelElection: nation={}", nation);
+}
+
+bool CKingSystem::NominateCandidate(
+	std::string_view candidateName, int nation, int tributeMoney, std::string& errorOut)
+{
+	if (!IsValidNation(nation))
+	{
+		errorOut = "invalid nation";
+		return false;
+	}
+	const auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_NOMINATION_OPEN)
+	{
+		errorOut = "nominations are not open";
+		return false;
+	}
+	if (candidateName.empty() || candidateName.size() > 21)
+	{
+		errorOut = "candidate name length out of range";
+		return false;
+	}
+
+	const std::string nameEsc = SqlEscape(candidateName);
+
+	// Reject duplicates.
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			errorOut = "DB unavailable";
+			return false;
+		}
+		std::string check = "SELECT COUNT(*) FROM KING_ELECTION_LIST WHERE byNation = "
+			+ std::to_string(nation) + " AND strName = '" + nameEsc + "'";
+		auto stmt   = poolConn->CreateStatement(check);
+		auto result = nanodbc::execute(stmt);
+		if (result.next() && result.get<int>(0, 0) > 0)
+		{
+			errorOut = "already nominated";
+			return false;
+		}
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::NominateCandidate: dup-check failed: {}", dbErr.what());
+		errorOut = "DB error";
+		return false;
+	}
+
+	// Look up clan id and verify the user belongs to this nation.
+	int knightsId = 0;
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		std::string lookup = "SELECT Knights, Nation FROM USERDATA WHERE strUserId = '" + nameEsc
+			+ "'";
+		auto stmt   = poolConn->CreateStatement(lookup);
+		auto result = nanodbc::execute(stmt);
+		if (!result.next())
+		{
+			errorOut = "candidate not found";
+			return false;
+		}
+		knightsId         = result.get<int>(0, 0);
+		const int userNat = result.get<int>(1, 0);
+		if (userNat != nation)
+		{
+			errorOut = "nation mismatch";
+			return false;
+		}
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::NominateCandidate: lookup failed: {}", dbErr.what());
+		errorOut = "DB error";
+		return false;
+	}
+
+	// Insert candidate. byType=1 = nominated (will be promoted to 4 when
+	// voting opens). nMoney holds the running vote count, seeded with the
+	// tribute amount (legacy behaviour: tribute money buys initial standing).
+	std::string insert = "INSERT INTO KING_ELECTION_LIST (byType, byNation, nKnights, strName, "
+						 "nMoney) VALUES (1, "
+		+ std::to_string(nation) + ", " + std::to_string(knightsId) + ", '" + nameEsc + "', "
+		+ std::to_string(tributeMoney) + ")";
+	if (!ExecuteSql(insert, "NominateCandidate"))
+	{
+		errorOut = "DB write failed";
+		return false;
+	}
+
+	spdlog::info("KingSystem::NominateCandidate: nation={} candidate='{}' tribute={}", nation,
+		std::string(candidateName), tributeMoney);
+	return true;
+}
+
+bool CKingSystem::CastBallot(std::string_view voterAccount, std::string_view voterChar,
+	int nation, std::string_view candidateName, std::string& errorOut)
+{
+	if (!IsValidNation(nation))
+	{
+		errorOut = "invalid nation";
+		return false;
+	}
+	const auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_VOTING)
+	{
+		errorOut = "voting not open";
+		return false;
+	}
+
+	const std::string accEsc  = SqlEscape(voterAccount);
+	const std::string charEsc = SqlEscape(voterChar);
+	const std::string candEsc = SqlEscape(candidateName);
+
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			errorOut = "DB unavailable";
+			return false;
+		}
+
+		// One vote per account.
+		std::string check = "SELECT COUNT(*) FROM KING_BALLOT_BOX WHERE strAccountID = '" + accEsc
+			+ "'";
+		auto stmt   = poolConn->CreateStatement(check);
+		auto result = nanodbc::execute(stmt);
+		if (result.next() && result.get<int>(0, 0) > 0)
+		{
+			errorOut = "already voted";
+			return false;
+		}
+
+		std::string insert = "INSERT INTO KING_BALLOT_BOX (strAccountID, strCharID, byNation, "
+							 "strCandidacyID) VALUES ('"
+			+ accEsc + "', '" + charEsc + "', " + std::to_string(nation) + ", '" + candEsc + "')";
+		auto stmt2 = poolConn->CreateStatement(insert);
+		nanodbc::execute(stmt2);
+
+		// Increment vote count on the candidate.
+		std::string incr = "UPDATE KING_ELECTION_LIST SET nMoney = nMoney + 1 WHERE byNation = "
+			+ std::to_string(nation) + " AND byType = 4 AND strName = '" + candEsc + "'";
+		auto stmt3 = poolConn->CreateStatement(incr);
+		nanodbc::execute(stmt3);
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::CastBallot: nanodbc error: {}", dbErr.what());
+		errorOut = "DB error";
+		return false;
+	}
+
+	spdlog::info("KingSystem::CastBallot: nation={} voter='{}' candidate='{}'", nation,
+		std::string(voterChar), std::string(candidateName));
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Impeachment
+// ---------------------------------------------------------------------------
+
+void CKingSystem::StartImpeachment(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_KING_ACTIVE)
+	{
+		spdlog::warn("KingSystem::StartImpeachment: nation={} no active king to impeach", nation);
+		return;
+	}
+
+	// Re-purpose KING_BALLOT_BOX for the impeachment vote. Wipe prior records.
+	std::string sql = "DELETE FROM KING_BALLOT_BOX WHERE byNation = " + std::to_string(nation);
+	ExecuteSql(sql, "StartImpeachment");
+
+	std::string msg = "[Impeachment] A vote of no confidence has begun against King ";
+	msg += s.strKingName;
+	msg += "!";
+	BroadcastNationAnnouncement(nation, msg);
+	spdlog::info("KingSystem::StartImpeachment: nation={} king='{}'", nation, s.strKingName);
+}
+
+void CKingSystem::CloseImpeachment(int nation, int requiredAgreePercent)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_KING_ACTIVE)
+	{
+		spdlog::warn("KingSystem::CloseImpeachment: nation={} no active king", nation);
+		return;
+	}
+
+	int totalVotes = 0;
+	int agreeVotes = 0;
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			spdlog::error("KingSystem::CloseImpeachment: failed to obtain DB pool connection");
+			return;
+		}
+		std::string sql = "SELECT COUNT(*) AS total, SUM(CASE WHEN strCandidacyID = 'Y' THEN 1 "
+						  "ELSE 0 END) AS agree FROM KING_BALLOT_BOX WHERE byNation = "
+			+ std::to_string(nation);
+		auto stmt   = poolConn->CreateStatement(sql);
+		auto result = nanodbc::execute(stmt);
+		if (result.next())
+		{
+			totalVotes = result.get<int>(0, 0);
+			agreeVotes = result.get<int>(1, 0);
+		}
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::CloseImpeachment: nanodbc error: {}", dbErr.what());
+		return;
+	}
+
+	std::string cleanup = "DELETE FROM KING_BALLOT_BOX WHERE byNation = " + std::to_string(nation);
+	ExecuteSql(cleanup, "CloseImpeachment/cleanup");
+
+	if (totalVotes == 0)
+	{
+		BroadcastNationAnnouncement(nation, "[Impeachment] No votes cast — motion failed.");
+		spdlog::info("KingSystem::CloseImpeachment: nation={} no votes", nation);
+		return;
+	}
+
+	const int agreePercent = (agreeVotes * 100) / totalVotes;
+	const bool passed      = agreePercent >= requiredAgreePercent;
+	spdlog::info(
+		"KingSystem::CloseImpeachment: nation={} total={} agree={} percent={} required={} {}",
+		nation, totalVotes, agreeVotes, agreePercent, requiredAgreePercent,
+		passed ? "PASSED" : "FAILED");
+
+	if (passed)
+	{
+		std::string msg = "[Impeachment] PASSED ("
+			+ std::to_string(agreePercent) + "%) — King "
+			+ s.strKingName + " has been deposed!";
+		BroadcastNationAnnouncement(nation, msg);
+		ClearKing(nation);
+	}
+	else
+	{
+		std::string msg = "[Impeachment] FAILED ("
+			+ std::to_string(agreePercent) + "%) — King "
+			+ s.strKingName + " retains the throne.";
+		BroadcastNationAnnouncement(nation, msg);
+	}
+}
+
+bool CKingSystem::CastImpeachmentVote(std::string_view voterAccount, std::string_view voterChar,
+	int nation, bool agree, std::string& errorOut)
+{
+	if (!IsValidNation(nation))
+	{
+		errorOut = "invalid nation";
+		return false;
+	}
+	const auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_KING_ACTIVE)
+	{
+		errorOut = "no active king";
+		return false;
+	}
+
+	const std::string accEsc  = SqlEscape(voterAccount);
+	const std::string charEsc = SqlEscape(voterChar);
+	const std::string vote    = agree ? "Y" : "N";
+
+	try
+	{
+		auto poolConn = db::ConnectionManager::CreatePoolConnection(modelUtil::DbType::GAME);
+		if (poolConn == nullptr)
+		{
+			errorOut = "DB unavailable";
+			return false;
+		}
+		std::string check = "SELECT COUNT(*) FROM KING_BALLOT_BOX WHERE strAccountID = '" + accEsc
+			+ "'";
+		auto stmt   = poolConn->CreateStatement(check);
+		auto result = nanodbc::execute(stmt);
+		if (result.next() && result.get<int>(0, 0) > 0)
+		{
+			errorOut = "already voted";
+			return false;
+		}
+		std::string insert = "INSERT INTO KING_BALLOT_BOX (strAccountID, strCharID, byNation, "
+							 "strCandidacyID) VALUES ('"
+			+ accEsc + "', '" + charEsc + "', " + std::to_string(nation) + ", '" + vote + "')";
+		auto stmt2 = poolConn->CreateStatement(insert);
+		nanodbc::execute(stmt2);
+	}
+	catch (const nanodbc::database_error& dbErr)
+	{
+		spdlog::error("KingSystem::CastImpeachmentVote: nanodbc error: {}", dbErr.what());
+		errorOut = "DB error";
+		return false;
+	}
+
+	spdlog::info("KingSystem::CastImpeachmentVote: nation={} voter='{}' agree={}", nation,
+		std::string(voterChar), agree);
+	return true;
+}
+
 bool CKingSystem::LoadFromDb()
 {
 	try
@@ -424,20 +920,194 @@ void CKingSystem::PacketProcess(CUser* pUser, char* pBuf)
 	}
 }
 
-void CKingSystem::HandleElection(CUser* pUser, char* /*pBuf*/)
+void CKingSystem::HandleElection(CUser* pUser, char* pBuf)
 {
-	// Phase 1: not implemented. Election workflow (nominate → vote → coronate)
-	// is driven by KING_SYSTEM byType phase transitions and requires scheduled
-	// task execution + DB writes through Aujard.
-	spdlog::info("KingSystem::HandleElection: deferred [user={}]",
-		pUser->m_pUserData ? pUser->m_pUserData->m_id : "?");
+	if (pUser->m_pUserData == nullptr)
+		return;
+
+	const int     nation = pUser->m_pUserData->m_bNation;
+	int           index  = 0;
+	const uint8_t op     = GetByte(pBuf, index);
+
+	std::string error;
+	bool        ok = false;
+
+	switch (op)
+	{
+		case KING_ELECTION_SCHEDULE:
+			// Reading the schedule is informational; we just echo current
+			// election dates and byType back. Phase 3 doesn't drive scheduled
+			// transitions yet — GMs trigger them manually.
+			{
+				const auto& s = GetState(nation);
+				char        out[64] {};
+				int         outIdx = 0;
+				SetByte(out, WIZ_KING, outIdx);
+				SetByte(out, KING_ELECTION, outIdx);
+				SetByte(out, KING_ELECTION_SCHEDULE, outIdx);
+				SetByte(out, s.byType, outIdx);
+				SetString1(out, std::string_view { s.strKingName }, outIdx);
+				pUser->Send(out, outIdx);
+			}
+			return;
+
+		case KING_ELECTION_NOMINATE:
+			// Self-nomination: server uses the caller's character name.
+			ok = NominateCandidate(
+				pUser->m_pUserData->m_id, nation, /*tributeMoney*/ 0, error);
+			break;
+
+		case KING_ELECTION_NOTICE_BOARD:
+			// Phase 3 stub: candidate manifestos. Logged but persisted not yet.
+			spdlog::info("KingSystem::HandleElection: NOTICE_BOARD deferred [user={}]",
+				pUser->m_pUserData->m_id);
+			return;
+
+		case KING_ELECTION_POLL:
+		{
+			// Payload: candidate name (1-byte length + chars) — best-effort guess
+			// at the original packet shape; if real client uses a different
+			// layout we'll see warnings here and adjust.
+			char    candName[64] {};
+			int     nameLen = GetByte(pBuf, index);
+			if (nameLen <= 0 || nameLen > 21)
+			{
+				spdlog::warn("KingSystem::HandleElection: POLL bad nameLen={}", nameLen);
+				return;
+			}
+			memcpy(candName, pBuf + index, nameLen);
+			candName[nameLen] = '\0';
+			ok                = CastBallot(pUser->m_strAccountID, pUser->m_pUserData->m_id, nation,
+								   candName, error);
+			break;
+		}
+
+		case KING_ELECTION_RESIGN:
+			// Only the king can resign; tear down the throne.
+			if (!IsKing(pUser))
+			{
+				spdlog::warn("KingSystem::HandleElection: non-king resign attempt [user={}]",
+					pUser->m_pUserData->m_id);
+				return;
+			}
+			ClearKing(nation);
+			ok = true;
+			break;
+
+		default:
+			spdlog::warn("KingSystem::HandleElection: unhandled sub-op {}", op);
+			return;
+	}
+
+	// Reply with a single-byte status to the caller so the client knows whether
+	// the action was accepted.
+	char out[16] {};
+	int  outIdx = 0;
+	SetByte(out, WIZ_KING, outIdx);
+	SetByte(out, KING_ELECTION, outIdx);
+	SetByte(out, op, outIdx);
+	SetByte(out, ok ? 1 : 0, outIdx);
+	pUser->Send(out, outIdx);
+	if (!ok && !error.empty())
+		spdlog::info("KingSystem::HandleElection: op={} rejected — {}", op, error);
 }
 
-void CKingSystem::HandleImpeachment(CUser* pUser, char* /*pBuf*/)
+void CKingSystem::HandleImpeachment(CUser* pUser, char* pBuf)
 {
-	// Phase 1: not implemented. Impeachment workflow defers to a future phase.
-	spdlog::info("KingSystem::HandleImpeachment: deferred [user={}]",
-		pUser->m_pUserData ? pUser->m_pUserData->m_id : "?");
+	if (pUser->m_pUserData == nullptr)
+		return;
+
+	const int     nation = pUser->m_pUserData->m_bNation;
+	int           index  = 0;
+	const uint8_t op     = GetByte(pBuf, index);
+
+	std::string error;
+	bool        ok = false;
+
+	switch (op)
+	{
+		case KING_IMPEACHMENT_REQUEST:
+			// Open a no-confidence vote against the current king. GM-only for
+			// now (avoid spam); a future iteration could gate this on a
+			// player tribute or required signature count.
+			if (pUser->m_pUserData->m_bAuthority != 0 /*AUTHORITY_MANAGER*/)
+			{
+				spdlog::warn(
+					"KingSystem::HandleImpeachment: REQUEST denied — authority required [user={}]",
+					pUser->m_pUserData->m_id);
+				return;
+			}
+			StartImpeachment(nation);
+			ok = true;
+			break;
+
+		case KING_IMPEACHMENT_REQUEST_ELECT:
+		case KING_IMPEACHMENT_ELECT:
+		{
+			// 1 byte: 1 = agree, 2 = disagree
+			const uint8_t agreeFlag = GetByte(pBuf, index);
+			ok                      = CastImpeachmentVote(pUser->m_strAccountID,
+								 pUser->m_pUserData->m_id, nation, agreeFlag == 1, error);
+			break;
+		}
+
+		case KING_IMPEACHMENT_LIST:
+		{
+			// Echo back the running tally.
+			int totalVotes = 0;
+			int agreeVotes = 0;
+			try
+			{
+				auto poolConn = db::ConnectionManager::CreatePoolConnection(
+					modelUtil::DbType::GAME);
+				std::string sql = "SELECT COUNT(*) AS total, SUM(CASE WHEN strCandidacyID = 'Y' "
+								  "THEN 1 ELSE 0 END) AS agree FROM KING_BALLOT_BOX WHERE "
+								  "byNation = "
+					+ std::to_string(nation);
+				auto stmt   = poolConn->CreateStatement(sql);
+				auto result = nanodbc::execute(stmt);
+				if (result.next())
+				{
+					totalVotes = result.get<int>(0, 0);
+					agreeVotes = result.get<int>(1, 0);
+				}
+			}
+			catch (const nanodbc::database_error& dbErr)
+			{
+				spdlog::error("KingSystem::HandleImpeachment LIST: {}", dbErr.what());
+			}
+			char out[16] {};
+			int  outIdx = 0;
+			SetByte(out, WIZ_KING, outIdx);
+			SetByte(out, KING_IMPEACHMENT, outIdx);
+			SetByte(out, KING_IMPEACHMENT_LIST, outIdx);
+			SetShort(out, static_cast<int16_t>(totalVotes), outIdx);
+			SetShort(out, static_cast<int16_t>(agreeVotes), outIdx);
+			pUser->Send(out, outIdx);
+			return;
+		}
+
+		case KING_IMPEACHMENT_REQUEST_UI_OPEN:
+		case KING_IMPEACHMENT_ELECTION_UI_OPEN:
+			// Pure client UI hints — server responds with the current king
+			// info so the dialog can render.
+			HandleKingNpc(pUser, pBuf);
+			return;
+
+		default:
+			spdlog::warn("KingSystem::HandleImpeachment: unhandled sub-op {}", op);
+			return;
+	}
+
+	char out[16] {};
+	int  outIdx = 0;
+	SetByte(out, WIZ_KING, outIdx);
+	SetByte(out, KING_IMPEACHMENT, outIdx);
+	SetByte(out, op, outIdx);
+	SetByte(out, ok ? 1 : 0, outIdx);
+	pUser->Send(out, outIdx);
+	if (!ok && !error.empty())
+		spdlog::info("KingSystem::HandleImpeachment: op={} rejected — {}", op, error);
 }
 
 void CKingSystem::HandleTax(CUser* pUser, char* pBuf)

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -656,6 +656,111 @@ bool CKingSystem::CastBallot(std::string_view voterAccount, std::string_view vot
 }
 
 // ---------------------------------------------------------------------------
+// Royal commands (Phase 4) — implements the client's CMD_LIST_CAT_KING menu
+// ---------------------------------------------------------------------------
+
+void CKingSystem::RoyalOrder(int nation, std::string_view kingName, std::string_view message)
+{
+	if (!IsValidNation(nation) || message.empty())
+		return;
+	std::string line = "[Royal Order] ";
+	if (!kingName.empty())
+	{
+		line += kingName;
+		line += ": ";
+	}
+	line += message;
+	BroadcastNationAnnouncement(nation, line);
+	spdlog::info("KingSystem::RoyalOrder: nation={} king='{}' msg='{}'", nation,
+		std::string(kingName), std::string(message));
+}
+
+bool CKingSystem::RoyalPrize(int nation, std::string_view recipient, int itemId, int count)
+{
+	if (!IsValidNation(nation) || m_pMain == nullptr)
+		return false;
+	if (count <= 0)
+		count = 1;
+
+	auto pUser = m_pMain->GetUserPtr(std::string(recipient).c_str(), NameType::Character);
+	if (pUser == nullptr || pUser->m_pUserData == nullptr)
+	{
+		spdlog::warn("KingSystem::RoyalPrize: recipient '{}' not online", std::string(recipient));
+		return false;
+	}
+	if (pUser->m_pUserData->m_bNation != nation)
+	{
+		spdlog::warn("KingSystem::RoyalPrize: nation mismatch for '{}'", std::string(recipient));
+		return false;
+	}
+
+	const bool gave = pUser->GiveItem(itemId, static_cast<int16_t>(count));
+	spdlog::info("KingSystem::RoyalPrize: recipient='{}' itemId={} count={} ok={}",
+		std::string(recipient), itemId, count, gave);
+	if (gave)
+	{
+		std::string msg = "[Royal Prize] ";
+		msg += recipient;
+		msg += " has been gifted by the King!";
+		BroadcastNationAnnouncement(nation, msg);
+	}
+	return gave;
+}
+
+bool CKingSystem::RoyalReward(int nation, std::string_view recipient, int gold)
+{
+	if (!IsValidNation(nation) || m_pMain == nullptr || gold == 0)
+		return false;
+
+	auto pUser = m_pMain->GetUserPtr(std::string(recipient).c_str(), NameType::Character);
+	if (pUser == nullptr || pUser->m_pUserData == nullptr)
+	{
+		spdlog::warn("KingSystem::RoyalReward: recipient '{}' not online", std::string(recipient));
+		return false;
+	}
+	if (pUser->m_pUserData->m_bNation != nation)
+		return false;
+
+	// Bound at MAX_GOLD (signed int32 ceiling, 21 oku per the data type doc).
+	const int newGold = std::min<int64_t>(
+		std::max<int64_t>(0, static_cast<int64_t>(pUser->m_pUserData->m_iGold) + gold),
+		std::numeric_limits<int32_t>::max());
+	pUser->m_pUserData->m_iGold = static_cast<int32_t>(newGold);
+
+	std::string msg = "[Royal Reward] ";
+	msg += recipient;
+	msg += " has received ";
+	msg += std::to_string(gold);
+	msg += " gold from the King!";
+	BroadcastNationAnnouncement(nation, msg);
+
+	spdlog::info("KingSystem::RoyalReward: recipient='{}' gold={} newBalance={}",
+		std::string(recipient), gold, pUser->m_pUserData->m_iGold);
+	return true;
+}
+
+void CKingSystem::RoyalWeather(uint8_t weatherKind)
+{
+	if (m_pMain == nullptr)
+		return;
+	if (weatherKind != WEATHER_FINE && weatherKind != WEATHER_RAIN && weatherKind != WEATHER_SNOW)
+	{
+		spdlog::warn("KingSystem::RoyalWeather: invalid weather={}", weatherKind);
+		return;
+	}
+
+	char sendBuffer[16] {};
+	int  sendIndex = 0;
+	SetByte(sendBuffer, WIZ_WEATHER, sendIndex);
+	SetByte(sendBuffer, weatherKind, sendIndex);
+	// Amount: light atmosphere for fine, full intensity otherwise.
+	const int16_t amount = (weatherKind == WEATHER_FINE) ? 0 : 50;
+	SetShort(sendBuffer, amount, sendIndex);
+	m_pMain->Send_All(sendBuffer, sendIndex);
+	spdlog::info("KingSystem::RoyalWeather: kind={} amount={}", weatherKind, amount);
+}
+
+// ---------------------------------------------------------------------------
 // Notice board (Phase 4)
 // ---------------------------------------------------------------------------
 
@@ -1435,11 +1540,41 @@ void CKingSystem::HandleEvent(CUser* pUser, char* pBuf)
 			break;
 		}
 		case KING_EVENT_PRIZE:
-		case KING_EVENT_FUGITIVE:
-		case KING_EVENT_WEATHER:
+		{
+			// Payload (best-effort): 1-byte name length + name + DWORD itemId
+			//                        + WORD count.
+			char    target[64] {};
+			int     nameLen = GetByte(pBuf, index);
+			if (nameLen <= 0 || nameLen > 21)
+				return;
+			memcpy(target, pBuf + index, nameLen);
+			target[nameLen] = '\0';
+			index += nameLen;
+			const int     itemId = GetDWORD(pBuf, index);
+			const int16_t count  = GetShort(pBuf, index);
+			RoyalPrize(nation, target, itemId, count);
+			break;
+		}
 		case KING_EVENT_NOTICE:
-			// Phase 1: not implemented.
-			spdlog::info("KingSystem::HandleEvent: kind {} deferred", kind);
+		{
+			// Payload: 2-byte length + UTF-8 message body. The king's
+			// announcement gets prefixed with [Royal Order] and broadcast.
+			const int16_t bodyLen = GetShort(pBuf, index);
+			if (bodyLen <= 0 || bodyLen > 200)
+				return;
+			std::string body(pBuf + index, bodyLen);
+			RoyalOrder(nation, pUser->m_pUserData->m_id, body);
+			break;
+		}
+		case KING_EVENT_WEATHER:
+		{
+			const uint8_t weatherKind = GetByte(pBuf, index);
+			RoyalWeather(weatherKind);
+			break;
+		}
+		case KING_EVENT_FUGITIVE:
+			// Reserved for the wanted-list feature; stub for now.
+			spdlog::info("KingSystem::HandleEvent: KING_EVENT_FUGITIVE deferred");
 			break;
 		default:
 			spdlog::warn("KingSystem::HandleEvent: unknown kind={}", kind);

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -675,38 +675,6 @@ void CKingSystem::RoyalOrder(int nation, std::string_view kingName, std::string_
 		std::string(kingName), std::string(message));
 }
 
-bool CKingSystem::RoyalPrize(int nation, std::string_view recipient, int itemId, int count)
-{
-	if (!IsValidNation(nation) || m_pMain == nullptr)
-		return false;
-	if (count <= 0)
-		count = 1;
-
-	auto pUser = m_pMain->GetUserPtr(std::string(recipient).c_str(), NameType::Character);
-	if (pUser == nullptr || pUser->m_pUserData == nullptr)
-	{
-		spdlog::warn("KingSystem::RoyalPrize: recipient '{}' not online", std::string(recipient));
-		return false;
-	}
-	if (pUser->m_pUserData->m_bNation != nation)
-	{
-		spdlog::warn("KingSystem::RoyalPrize: nation mismatch for '{}'", std::string(recipient));
-		return false;
-	}
-
-	const bool gave = pUser->GiveItem(itemId, static_cast<int16_t>(count));
-	spdlog::info("KingSystem::RoyalPrize: recipient='{}' itemId={} count={} ok={}",
-		std::string(recipient), itemId, count, gave);
-	if (gave)
-	{
-		std::string msg = "[Royal Prize] ";
-		msg += recipient;
-		msg += " has been gifted by the King!";
-		BroadcastNationAnnouncement(nation, msg);
-	}
-	return gave;
-}
-
 bool CKingSystem::RoyalReward(int nation, std::string_view recipient, int gold)
 {
 	if (!IsValidNation(nation) || m_pMain == nullptr || gold == 0)
@@ -721,21 +689,38 @@ bool CKingSystem::RoyalReward(int nation, std::string_view recipient, int gold)
 	if (pUser->m_pUserData->m_bNation != nation)
 		return false;
 
-	// Bound at MAX_GOLD (signed int32 ceiling, 21 oku per the data type doc).
-	const int newGold = std::min<int64_t>(
-		std::max<int64_t>(0, static_cast<int64_t>(pUser->m_pUserData->m_iGold) + gold),
-		std::numeric_limits<int32_t>::max());
+	// Clamp the new balance to MAX_GOLD (signed int32 ceiling).
+	const int32_t prevGold = pUser->m_pUserData->m_iGold;
+	const int64_t newGold  = std::min<int64_t>(
+        std::max<int64_t>(0, static_cast<int64_t>(prevGold) + gold),
+        std::numeric_limits<int32_t>::max());
 	pUser->m_pUserData->m_iGold = static_cast<int32_t>(newGold);
+	const int32_t delta = pUser->m_pUserData->m_iGold - prevGold;
+
+	// Push the visible gold update to the recipient — without WIZ_GOLD_CHANGE
+	// the client keeps showing the old number until relog.
+	if (delta != 0)
+	{
+		char    sendBuffer[16] {};
+		int     sendIndex = 0;
+		const uint8_t type = (delta >= 0) ? GOLD_CHANGE_GAIN : GOLD_CHANGE_LOSE;
+		const uint32_t mag = static_cast<uint32_t>(std::abs(delta));
+		SetByte(sendBuffer, WIZ_GOLD_CHANGE, sendIndex);
+		SetByte(sendBuffer, type, sendIndex);
+		SetDWORD(sendBuffer, mag, sendIndex);
+		SetDWORD(sendBuffer, pUser->m_pUserData->m_iGold, sendIndex);
+		pUser->Send(sendBuffer, sendIndex);
+	}
 
 	std::string msg = "[Royal Reward] ";
 	msg += recipient;
-	msg += " has received ";
-	msg += std::to_string(gold);
-	msg += " gold from the King!";
+	msg += (gold >= 0) ? " has received " : " has been fined ";
+	msg += std::to_string(std::abs(gold));
+	msg += (gold >= 0) ? " gold from the King!" : " gold by the King!";
 	BroadcastNationAnnouncement(nation, msg);
 
-	spdlog::info("KingSystem::RoyalReward: recipient='{}' gold={} newBalance={}",
-		std::string(recipient), gold, pUser->m_pUserData->m_iGold);
+	spdlog::info("KingSystem::RoyalReward: recipient='{}' delta={} newBalance={}",
+		std::string(recipient), delta, pUser->m_pUserData->m_iGold);
 	return true;
 }
 
@@ -1196,16 +1181,32 @@ void CKingSystem::BroadcastNationAnnouncement(int nation, std::string_view messa
 	const size_t maxLen = 120;
 	const std::string_view body { message.data(), std::min(message.size(), maxLen) };
 
+	// Pass A: WAR_SYSTEM_CHAT (e_ChatMode N3_CHAT_WAR=8) — drives the big top
+	// scrolling banner (m_pWarMessage->SetMessage) on the client. The client's
+	// e_ChatMode enum tops out at 12, so ANNOUNCEMENT_CHAT (17) is silently
+	// dropped — that's why kings' announcements weren't appearing.
 	char sendBuffer[256] {};
 	int  sendIndex = 0;
 	SetByte(sendBuffer, WIZ_CHAT, sendIndex);
-	SetByte(sendBuffer, ANNOUNCEMENT_CHAT, sendIndex);
+	SetByte(sendBuffer, WAR_SYSTEM_CHAT, sendIndex);
 	SetByte(sendBuffer, static_cast<uint8_t>(nation), sendIndex);
-	SetShort(sendBuffer, -1, sendIndex);                 // sender socket id (anon)
-	SetString1(sendBuffer, std::string_view("King System"), sendIndex); // 1-byte len + name
-	SetString2(sendBuffer, body, sendIndex);             // 2-byte len + body
-
+	SetShort(sendBuffer, -1, sendIndex);                  // sender socket id (anon)
+	SetByte(sendBuffer, 0, sendIndex);                    // empty sender name
+	SetString2(sendBuffer, body, sendIndex);              // 2-byte len + body
 	m_pMain->Send_All(sendBuffer, sendIndex, nullptr, nation);
+
+	// Pass B: PUBLIC_CHAT — also drop it into the chat log so players who
+	// missed the banner can scroll back. Mirrors the AISocket war broadcast
+	// pattern (banner + log entry).
+	char logBuffer[256] {};
+	int  logIndex = 0;
+	SetByte(logBuffer, WIZ_CHAT, logIndex);
+	SetByte(logBuffer, PUBLIC_CHAT, logIndex);
+	SetByte(logBuffer, static_cast<uint8_t>(nation), logIndex);
+	SetShort(logBuffer, -1, logIndex);
+	SetByte(logBuffer, 0, logIndex);
+	SetString2(logBuffer, body, logIndex);
+	m_pMain->Send_All(logBuffer, logIndex, nullptr, nation);
 }
 
 void CKingSystem::PacketProcess(CUser* pUser, char* pBuf)
@@ -1540,21 +1541,10 @@ void CKingSystem::HandleEvent(CUser* pUser, char* pBuf)
 			break;
 		}
 		case KING_EVENT_PRIZE:
-		{
-			// Payload (best-effort): 1-byte name length + name + DWORD itemId
-			//                        + WORD count.
-			char    target[64] {};
-			int     nameLen = GetByte(pBuf, index);
-			if (nameLen <= 0 || nameLen > 21)
-				return;
-			memcpy(target, pBuf + index, nameLen);
-			target[nameLen] = '\0';
-			index += nameLen;
-			const int     itemId = GetDWORD(pBuf, index);
-			const int16_t count  = GetShort(pBuf, index);
-			RoyalPrize(nation, target, itemId, count);
+			// Intentionally unsupported: kings do not hand out items.
+			// Use /Reward (gold) for treasury payouts; /Prize is ignored.
+			spdlog::info("KingSystem::HandleEvent: KING_EVENT_PRIZE ignored (disabled)");
 			break;
-		}
 		case KING_EVENT_NOTICE:
 		{
 			// Payload: 2-byte length + UTF-8 message body. The king's

--- a/src/Server/Ebenezer/KingSystem.cpp
+++ b/src/Server/Ebenezer/KingSystem.cpp
@@ -1,0 +1,422 @@
+#include "pch.h"
+#include "KingSystem.h"
+
+#include "EbenezerApp.h"
+#include "User.h"
+#include "Define.h"
+
+#include <shared/packets.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+namespace Ebenezer
+{
+
+namespace
+{
+
+// Empty string returned by GetKingName() when the lookup fails or there's
+// no reigning monarch. Returning a reference avoids per-call allocations.
+const std::string kEmptyName;
+
+}
+
+CKingSystem::CKingSystem()
+{
+	InitDefaults();
+}
+
+void CKingSystem::InitDefaults()
+{
+	// Seed both nations with "no king elected" as the safe default. The
+	// active monarch is installed via GM command (+set_king) or, in a
+	// later phase, by loading the KING_SYSTEM table at startup.
+	for (auto& s : _states)
+	{
+		s = KingNationState {};
+	}
+}
+
+bool CKingSystem::IsValidNation(int nation) const
+{
+	return nation == KING_NATION_KARUS || nation == KING_NATION_ELMORAD;
+}
+
+KingNationState& CKingSystem::GetState(int nation)
+{
+	// Defensive: callers should have validated `nation`. Fall back to
+	// nation 1 if not, so we never go out of bounds.
+	const int idx = IsValidNation(nation) ? NationToIndex(nation) : 0;
+	return _states[idx];
+}
+
+const KingNationState& CKingSystem::GetState(int nation) const
+{
+	const int idx = IsValidNation(nation) ? NationToIndex(nation) : 0;
+	return _states[idx];
+}
+
+const std::string& CKingSystem::GetKingName(int nation) const
+{
+	if (!IsValidNation(nation))
+		return kEmptyName;
+	return _states[NationToIndex(nation)].strKingName;
+}
+
+bool CKingSystem::IsKing(int nation, std::string_view name) const
+{
+	if (!IsValidNation(nation) || name.empty())
+		return false;
+	const auto& s = _states[NationToIndex(nation)];
+	if (s.byType != KING_PHASE_KING_ACTIVE)
+		return false;
+	return s.strKingName.size() == name.size()
+		&& std::equal(s.strKingName.begin(), s.strKingName.end(), name.begin(),
+			[](char a, char b) { return std::tolower(static_cast<unsigned char>(a))
+									 == std::tolower(static_cast<unsigned char>(b)); });
+}
+
+bool CKingSystem::IsKing(const CUser* pUser) const
+{
+	if (pUser == nullptr || pUser->m_pUserData == nullptr)
+		return false;
+	return IsKing(pUser->m_pUserData->m_bNation, pUser->m_pUserData->m_id);
+}
+
+void CKingSystem::SetKing(int nation, std::string_view name)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+	s.strKingName.assign(name.data(), name.size());
+	s.byType = KING_PHASE_KING_ACTIVE;
+	spdlog::info("KingSystem::SetKing: nation={} name={}", nation, s.strKingName);
+
+	// Apply Rank=1/Title=1 to the online character so item gates (e.g.
+	// ReqRank=1 for King's Sceptor / ReqTitle=1 for crown-cape variants)
+	// pass immediately. Aujard persists these on the next user save.
+	ApplyRoyaltyToOnlineUser(s.strKingName, /*isKing*/ true);
+
+	std::string msg = "[King] ";
+	msg += s.strKingName;
+	msg += " has ascended to the throne!";
+	BroadcastNationAnnouncement(nation, msg);
+}
+
+void CKingSystem::ClearKing(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s        = _states[NationToIndex(nation)];
+	std::string previousKing = s.strKingName;
+	s.strKingName.clear();
+	s.byType       = KING_PHASE_NO_KING;
+	spdlog::info("KingSystem::ClearKing: nation={} previousKing={}", nation, previousKing);
+
+	if (!previousKing.empty())
+	{
+		// Strip royalty flags from the dethroned character if online.
+		ApplyRoyaltyToOnlineUser(previousKing, /*isKing*/ false);
+
+		std::string msg = "[King] ";
+		msg += previousKing;
+		msg += " no longer reigns.";
+		BroadcastNationAnnouncement(nation, msg);
+	}
+}
+
+void CKingSystem::ApplyRoyaltyToOnlineUser(const std::string& charName, bool isKing)
+{
+	if (m_pMain == nullptr || charName.empty())
+		return;
+
+	auto pUser = m_pMain->GetUserPtr(charName.c_str(), NameType::Character);
+	if (pUser == nullptr || pUser->m_pUserData == nullptr)
+	{
+		spdlog::info(
+			"KingSystem::ApplyRoyaltyToOnlineUser: '{}' not online; DB will reflect on next save",
+			charName);
+		return;
+	}
+
+	pUser->m_pUserData->m_bRank  = isKing ? 1 : 0;
+	pUser->m_pUserData->m_bTitle = isKing ? 1 : 0;
+	// Re-send WIZ_MYINFO so the client refreshes its rank/title HUD and any
+	// equipment requirement gates without forcing a relog.
+	pUser->SendMyInfo(0);
+}
+
+void CKingSystem::SetTax(int nation, uint8_t tariff, int territoryTax)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s = _states[NationToIndex(nation)];
+	s.byTerritoryTariff = tariff;
+	s.nTerritoryTax     = territoryTax;
+	spdlog::info("KingSystem::SetTax: nation={} tariff={} territoryTax={}", nation, tariff,
+		territoryTax);
+}
+
+void CKingSystem::StartNoahEvent(int nation, int bonusPercent, int durationMinutes)
+{
+	if (!IsValidNation(nation) || bonusPercent <= 0 || durationMinutes <= 0)
+		return;
+	auto& s                  = _states[NationToIndex(nation)];
+	s.noahEventActive        = true;
+	s.noahEventBonusPercent  = std::clamp(bonusPercent, 1, 1000);
+	s.noahEventEnd           = std::chrono::system_clock::now()
+		+ std::chrono::minutes(std::clamp(durationMinutes, 1, 24 * 60));
+
+	std::string msg          = "[King's Noah Event] +";
+	msg += std::to_string(s.noahEventBonusPercent);
+	msg += "% gold drops for ";
+	msg += std::to_string(durationMinutes);
+	msg += " minutes!";
+	BroadcastNationAnnouncement(nation, msg);
+}
+
+void CKingSystem::StartExpEvent(int nation, int bonusPercent, int durationMinutes)
+{
+	if (!IsValidNation(nation) || bonusPercent <= 0 || durationMinutes <= 0)
+		return;
+	auto& s                  = _states[NationToIndex(nation)];
+	s.expEventActive         = true;
+	s.expEventBonusPercent   = std::clamp(bonusPercent, 1, 1000);
+	s.expEventEnd            = std::chrono::system_clock::now()
+		+ std::chrono::minutes(std::clamp(durationMinutes, 1, 24 * 60));
+
+	std::string msg          = "[King's Experience Event] +";
+	msg += std::to_string(s.expEventBonusPercent);
+	msg += "% experience for ";
+	msg += std::to_string(durationMinutes);
+	msg += " minutes!";
+	BroadcastNationAnnouncement(nation, msg);
+}
+
+void CKingSystem::StopEvents(int nation)
+{
+	if (!IsValidNation(nation))
+		return;
+	auto& s             = _states[NationToIndex(nation)];
+	s.noahEventActive   = false;
+	s.expEventActive    = false;
+	spdlog::info("KingSystem::StopEvents: nation={}", nation);
+}
+
+int CKingSystem::GetExpEventBonus(int nation) const
+{
+	if (!IsValidNation(nation))
+		return 0;
+	const auto& s = _states[NationToIndex(nation)];
+	if (!s.expEventActive)
+		return 0;
+	if (std::chrono::system_clock::now() >= s.expEventEnd)
+		return 0;
+	return s.expEventBonusPercent;
+}
+
+int CKingSystem::GetNoahEventBonus(int nation) const
+{
+	if (!IsValidNation(nation))
+		return 0;
+	const auto& s = _states[NationToIndex(nation)];
+	if (!s.noahEventActive)
+		return 0;
+	if (std::chrono::system_clock::now() >= s.noahEventEnd)
+		return 0;
+	return s.noahEventBonusPercent;
+}
+
+void CKingSystem::Tick()
+{
+	const auto now = std::chrono::system_clock::now();
+	for (int n = KING_NATION_KARUS; n <= KING_NATION_ELMORAD; ++n)
+	{
+		auto& s = _states[NationToIndex(n)];
+		if (s.noahEventActive && now >= s.noahEventEnd)
+		{
+			s.noahEventActive = false;
+			BroadcastNationAnnouncement(n, "[King's Noah Event] has ended.");
+		}
+		if (s.expEventActive && now >= s.expEventEnd)
+		{
+			s.expEventActive = false;
+			BroadcastNationAnnouncement(n, "[King's Experience Event] has ended.");
+		}
+	}
+}
+
+void CKingSystem::BroadcastNationAnnouncement(int nation, std::string_view message)
+{
+	if (m_pMain == nullptr || message.empty())
+		return;
+
+	// Cap message body to keep us inside the chat packet sane size.
+	const size_t maxLen = 120;
+	const std::string_view body { message.data(), std::min(message.size(), maxLen) };
+
+	char sendBuffer[256] {};
+	int  sendIndex = 0;
+	SetByte(sendBuffer, WIZ_CHAT, sendIndex);
+	SetByte(sendBuffer, ANNOUNCEMENT_CHAT, sendIndex);
+	SetByte(sendBuffer, static_cast<uint8_t>(nation), sendIndex);
+	SetShort(sendBuffer, -1, sendIndex);                 // sender socket id (anon)
+	SetString1(sendBuffer, std::string_view("King System"), sendIndex); // 1-byte len + name
+	SetString2(sendBuffer, body, sendIndex);             // 2-byte len + body
+
+	m_pMain->Send_All(sendBuffer, sendIndex, nullptr, nation);
+}
+
+void CKingSystem::PacketProcess(CUser* pUser, char* pBuf)
+{
+	if (pUser == nullptr || pBuf == nullptr)
+		return;
+
+	int           index  = 0;
+	const uint8_t opcode = GetByte(pBuf, index);
+
+	switch (opcode)
+	{
+		case KING_ELECTION:
+			HandleElection(pUser, pBuf + index);
+			break;
+		case KING_IMPEACHMENT:
+			HandleImpeachment(pUser, pBuf + index);
+			break;
+		case KING_TAX:
+			HandleTax(pUser, pBuf + index);
+			break;
+		case KING_EVENT:
+			HandleEvent(pUser, pBuf + index);
+			break;
+		case KING_NPC:
+			HandleKingNpc(pUser, pBuf + index);
+			break;
+		default:
+			spdlog::warn("KingSystem::PacketProcess: unhandled opcode {:02X} [user={}]", opcode,
+				pUser->m_pUserData ? pUser->m_pUserData->m_id : "?");
+			break;
+	}
+}
+
+void CKingSystem::HandleElection(CUser* pUser, char* /*pBuf*/)
+{
+	// Phase 1: not implemented. Election workflow (nominate → vote → coronate)
+	// is driven by KING_SYSTEM byType phase transitions and requires scheduled
+	// task execution + DB writes through Aujard.
+	spdlog::info("KingSystem::HandleElection: deferred [user={}]",
+		pUser->m_pUserData ? pUser->m_pUserData->m_id : "?");
+}
+
+void CKingSystem::HandleImpeachment(CUser* pUser, char* /*pBuf*/)
+{
+	// Phase 1: not implemented. Impeachment workflow defers to a future phase.
+	spdlog::info("KingSystem::HandleImpeachment: deferred [user={}]",
+		pUser->m_pUserData ? pUser->m_pUserData->m_id : "?");
+}
+
+void CKingSystem::HandleTax(CUser* pUser, char* pBuf)
+{
+	if (pUser->m_pUserData == nullptr)
+		return;
+
+	const int     nation = pUser->m_pUserData->m_bNation;
+	int           index  = 0;
+	const uint8_t mode   = GetByte(pBuf, index); // 1 = read, 2 = write
+
+	if (mode == 2)
+	{
+		// Write — only the reigning king of that nation may set tax.
+		if (!IsKing(pUser))
+		{
+			spdlog::warn("KingSystem::HandleTax: non-king tried to set tax [user={} nation={}]",
+				pUser->m_pUserData->m_id, nation);
+			return;
+		}
+		const uint8_t tariff = GetByte(pBuf, index);
+		SetTax(nation, tariff, GetState(nation).nTerritoryTax);
+	}
+
+	// Reply with current state regardless of mode.
+	const auto& s = GetState(nation);
+	char sendBuffer[64] {};
+	int  sendIndex = 0;
+	SetByte(sendBuffer, WIZ_KING, sendIndex);
+	SetByte(sendBuffer, KING_TAX, sendIndex);
+	SetByte(sendBuffer, s.byTerritoryTariff, sendIndex);
+	SetInt(sendBuffer, s.nTerritoryTax, sendIndex);
+	SetInt(sendBuffer, s.nNationalTreasury, sendIndex);
+	pUser->Send(sendBuffer, sendIndex);
+}
+
+void CKingSystem::HandleEvent(CUser* pUser, char* pBuf)
+{
+	if (pUser->m_pUserData == nullptr)
+		return;
+
+	const int     nation = pUser->m_pUserData->m_bNation;
+	int           index  = 0;
+	const uint8_t kind   = GetByte(pBuf, index);
+
+	// Only the king can fire events.
+	if (!IsKing(pUser))
+	{
+		spdlog::warn(
+			"KingSystem::HandleEvent: non-king tried to fire event [user={} nation={} kind={}]",
+			pUser->m_pUserData->m_id, nation, kind);
+		return;
+	}
+
+	switch (kind)
+	{
+		case KING_EVENT_NOAH:
+		{
+			const int bonus    = GetByte(pBuf, index);
+			const int duration = GetShort(pBuf, index);
+			StartNoahEvent(nation, bonus, duration);
+			break;
+		}
+		case KING_EVENT_EXP:
+		{
+			const int bonus    = GetByte(pBuf, index);
+			const int duration = GetShort(pBuf, index);
+			StartExpEvent(nation, bonus, duration);
+			break;
+		}
+		case KING_EVENT_PRIZE:
+		case KING_EVENT_FUGITIVE:
+		case KING_EVENT_WEATHER:
+		case KING_EVENT_NOTICE:
+			// Phase 1: not implemented.
+			spdlog::info("KingSystem::HandleEvent: kind {} deferred", kind);
+			break;
+		default:
+			spdlog::warn("KingSystem::HandleEvent: unknown kind={}", kind);
+			break;
+	}
+}
+
+void CKingSystem::HandleKingNpc(CUser* pUser, char* /*pBuf*/)
+{
+	// Phase 1: respond with the throne-room status block (king name + treasury).
+	if (pUser->m_pUserData == nullptr)
+		return;
+	const auto& s = GetState(pUser->m_pUserData->m_bNation);
+
+	char sendBuffer[128] {};
+	int  sendIndex = 0;
+	SetByte(sendBuffer, WIZ_KING, sendIndex);
+	SetByte(sendBuffer, KING_NPC, sendIndex);
+	SetByte(sendBuffer, s.byType, sendIndex);
+	SetString1(sendBuffer, std::string_view { s.strKingName }, sendIndex);
+	SetInt(sendBuffer, s.nNationalTreasury, sendIndex);
+	SetInt(sendBuffer, s.nTerritoryTax, sendIndex);
+	SetByte(sendBuffer, s.byTerritoryTariff, sendIndex);
+	pUser->Send(sendBuffer, sendIndex);
+}
+
+} // namespace Ebenezer

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -109,6 +109,30 @@ public:
 	void StartExpEvent(int nation, int bonusPercent, int durationMinutes);
 	void StopEvents(int nation);
 
+	// ----- Election state machine (Phase 3) -----
+	// Drives the byType phase transitions:
+	//   0 (no king) → 1 (nomination open) → 2 (nomination closed)
+	//      → 3 (voting open) → 4 (voting closed) → 7 (king crowned)
+	// Each transition writes the new byType to KING_SYSTEM via SaveNation.
+	void StartNomination(int nation);
+	void CloseNomination(int nation);
+	void StartVoting(int nation);
+	void CloseVoting(int nation);                 // tallies, crowns winner
+	void CancelElection(int nation);              // resets to byType=0
+	bool NominateCandidate(
+		std::string_view candidateName, int nation, int tributeMoney, std::string& errorOut);
+	bool CastBallot(std::string_view voterAccount, std::string_view voterChar, int nation,
+		std::string_view candidateName, std::string& errorOut);
+
+	// ----- Impeachment workflow (Phase 3) -----
+	// Impeachment is a parallel state. We track it via the existing
+	// KING_BALLOT_BOX (reused) and report results from KING_IMPEACHMENT_RESULT
+	// semantics (total voters vs agree voters).
+	void StartImpeachment(int nation);
+	void CloseImpeachment(int nation, int requiredAgreePercent = 51);
+	bool CastImpeachmentVote(std::string_view voterAccount, std::string_view voterChar, int nation,
+		bool agree, std::string& errorOut);
+
 	// Sends an ANNOUNCEMENT_CHAT line to every user in `nation` (1 or 2),
 	// or to everyone if nation == 0.
 	void BroadcastNationAnnouncement(int nation, std::string_view message);

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -161,13 +161,13 @@ public:
 
 	// ----- Royal command actions (matches client UICmdList CMD_LIST_CAT_KING) -----
 	//   /RoyalOrder       — kingdom-wide announcement
-	//   /Prize / /Reward  — give an item/gold to a target
+	//   /Reward           — pay gold from the treasury to a target
 	//   /Rain / /Snow     — change weather across the realm
 	//   /Clear            — clear weather
 	//   /ExperiencePoint  — exp event (already covered by KING_EVENT_EXP)
 	//   /DropRate         — gold drop event (already covered by KING_EVENT_NOAH)
+	// /Prize is intentionally NOT supported — kings don't hand out items.
 	void RoyalOrder(int nation, std::string_view kingName, std::string_view message);
-	bool RoyalPrize(int nation, std::string_view recipient, int itemId, int count);
 	bool RoyalReward(int nation, std::string_view recipient, int gold);
 	void RoyalWeather(uint8_t weatherKind);   // 1=fine, 2=rain, 3=snow
 

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -159,6 +159,18 @@ public:
 	bool ReadCandidateNotice(
 		int nation, std::string_view candidateName, std::string& contentOut);
 
+	// ----- Royal command actions (matches client UICmdList CMD_LIST_CAT_KING) -----
+	//   /RoyalOrder       — kingdom-wide announcement
+	//   /Prize / /Reward  — give an item/gold to a target
+	//   /Rain / /Snow     — change weather across the realm
+	//   /Clear            — clear weather
+	//   /ExperiencePoint  — exp event (already covered by KING_EVENT_EXP)
+	//   /DropRate         — gold drop event (already covered by KING_EVENT_NOAH)
+	void RoyalOrder(int nation, std::string_view kingName, std::string_view message);
+	bool RoyalPrize(int nation, std::string_view recipient, int itemId, int count);
+	bool RoyalReward(int nation, std::string_view recipient, int gold);
+	void RoyalWeather(uint8_t weatherKind);   // 1=fine, 2=rain, 3=snow
+
 	// Sends an ANNOUNCEMENT_CHAT line to every user in `nation` (1 or 2),
 	// or to everyone if nation == 0.
 	void BroadcastNationAnnouncement(int nation, std::string_view message);

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -46,6 +46,13 @@ struct KingNationState
 	bool                                  expEventActive        = false;
 	int                                   expEventBonusPercent  = 0;
 	std::chrono::system_clock::time_point expEventEnd;
+
+	// Phase-4 scheduler: when a phase is timed (nomination / voting auto-close,
+	// scheduled election kickoff), Tick() advances the state machine once
+	// system_clock::now() reaches this deadline.
+	bool                                  schedulerActive       = false;
+	std::chrono::system_clock::time_point phaseDeadline;
+	uint8_t                               nextPhaseOnDeadline   = KING_PHASE_NO_KING;
 };
 
 // CKingSystem owns the per-nation monarchy state for the running server.
@@ -133,6 +140,25 @@ public:
 	bool CastImpeachmentVote(std::string_view voterAccount, std::string_view voterChar, int nation,
 		bool agree, std::string& errorOut);
 
+	// ----- Scheduler (Phase 4) -----
+	// Schedules an automatic phase transition that Tick() will fire once the
+	// deadline is reached. Cancels the previous schedule for that nation if
+	// any. Use durationMinutes <= 0 to clear.
+	void ScheduleNextPhase(int nation, uint8_t nextPhase, int durationMinutes);
+
+	// Convenience helper that walks the full election cycle automatically:
+	//   now → nomination (auto-close after nominationMin)
+	//        → voting     (auto-close after votingMin → tally → king crowned)
+	void RunFullElection(int nation, int nominationMin, int votingMin);
+
+	// ----- Notice board (Phase 4) -----
+	// Stores or fetches the candidate manifesto text from
+	// KING_CANDIDACY_NOTICE_BOARD. Returns false on DB error.
+	bool WriteCandidateNotice(
+		int nation, std::string_view candidateName, std::string_view content);
+	bool ReadCandidateNotice(
+		int nation, std::string_view candidateName, std::string& contentOut);
+
 	// Sends an ANNOUNCEMENT_CHAT line to every user in `nation` (1 or 2),
 	// or to everyone if nation == 0.
 	void BroadcastNationAnnouncement(int nation, std::string_view message);
@@ -154,6 +180,10 @@ private:
 	int  NationToIndex(int nation) const { return nation - 1; }
 
 	KingNationState _states[KING_NATION_COUNT] {};
+
+	// Voting duration to use when the scheduler advances from nomination →
+	// voting. Set by RunFullElection. Falls back to 30 min if zero.
+	int _pendingVotingMinutes[KING_NATION_COUNT] { 30, 30 };
 };
 
 } // namespace Ebenezer

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -1,0 +1,128 @@
+#ifndef SERVER_EBENEZER_KINGSYSTEM_H
+#define SERVER_EBENEZER_KINGSYSTEM_H
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace Ebenezer
+{
+
+class CUser;
+class EbenezerApp;
+
+// Nation IDs as used by USERDATA.Nation and KING_SYSTEM.byNation.
+constexpr int KING_NATION_KARUS    = 1;
+constexpr int KING_NATION_ELMORAD  = 2;
+constexpr int KING_NATION_COUNT    = 2;
+
+// KING_SYSTEM.byType phase machine. Values come from the original
+// KING_UPDATE_ELECTION_STATUS stored procedure semantics.
+constexpr uint8_t KING_PHASE_NO_KING            = 0;
+constexpr uint8_t KING_PHASE_NOMINATION_OPEN    = 1;
+constexpr uint8_t KING_PHASE_NOMINATION_CLOSED  = 2;
+constexpr uint8_t KING_PHASE_VOTING             = 3;
+constexpr uint8_t KING_PHASE_VOTE_CLOSED        = 4;
+constexpr uint8_t KING_PHASE_KING_ACTIVE        = 7;
+
+// In-memory state for a single nation's monarchy. Mirrors the most
+// gameplay-relevant columns of the KING_SYSTEM table.
+struct KingNationState
+{
+	uint8_t     byType            = KING_PHASE_NO_KING;
+	std::string strKingName;
+	uint8_t     byTerritoryTariff = 0;   // % tariff on shop sales
+	int         nTerritoryTax     = 0;   // accumulated territory revenue
+	int         nNationalTreasury = 0;   // total treasury
+
+	// Active events (in-memory only — not yet persisted).
+	bool                                  noahEventActive       = false;
+	int                                   noahEventBonusPercent = 0;
+	std::chrono::system_clock::time_point noahEventEnd;
+
+	bool                                  expEventActive        = false;
+	int                                   expEventBonusPercent  = 0;
+	std::chrono::system_clock::time_point expEventEnd;
+};
+
+// CKingSystem owns the per-nation monarchy state for the running server.
+//
+// Lifecycle:
+//   - Single instance owned by EbenezerApp.
+//   - Initialised at server startup via InitDefaults() (Phase 1) or, in a
+//     future iteration, hydrated from the KING_SYSTEM table through Aujard.
+//   - Mutated by GM commands (+set_king, +king_event, +king_tax) and by
+//     incoming WIZ_KING client packets routed through PacketProcess().
+//   - Tick() expires timed events; called from the main game loop.
+//
+// Phase 1 scope: tax management, NOAH/EXP nation-wide events, GM-driven
+// installation/removal of kings. Election and impeachment workflows are
+// declared but only stubbed — future phases will drive them off the
+// scheduled byType phase machine.
+class CKingSystem
+{
+public:
+	CKingSystem();
+
+	EbenezerApp* m_pMain = nullptr;
+
+	// One-time setup. Seeds nation state with sensible defaults so the
+	// system works without DB integration. Called by EbenezerApp init.
+	void InitDefaults();
+
+	// Per-tick maintenance. Expires events whose deadline has elapsed.
+	void Tick();
+
+	// Entry point for WIZ_KING client packets. Reads the sub-opcode and
+	// dispatches to a handler.
+	void PacketProcess(CUser* pUser, char* pBuf);
+
+	// ----- Queries -----
+	bool                   IsKing(int nation, std::string_view name) const;
+	bool                   IsKing(const CUser* pUser) const;
+	const std::string&     GetKingName(int nation) const;
+	KingNationState&       GetState(int nation);
+	const KingNationState& GetState(int nation) const;
+
+	// Multipliers used by gameplay code (exp grant, item drops, gold).
+	// Returns the active bonus percent or 0 if no event is running.
+	int GetExpEventBonus(int nation) const;
+	int GetNoahEventBonus(int nation) const;
+
+	// ----- Mutators (used by GM commands and packet handlers) -----
+	void SetKing(int nation, std::string_view name);
+	void ClearKing(int nation);
+	void SetTax(int nation, uint8_t tariff, int territoryTax);
+	void StartNoahEvent(int nation, int bonusPercent, int durationMinutes);
+	void StartExpEvent(int nation, int bonusPercent, int durationMinutes);
+	void StopEvents(int nation);
+
+	// Sends an ANNOUNCEMENT_CHAT line to every user in `nation` (1 or 2),
+	// or to everyone if nation == 0.
+	void BroadcastNationAnnouncement(int nation, std::string_view message);
+
+private:
+	// ----- WIZ_KING sub-handlers (e_KingSystemOpcode) -----
+	void HandleElection(CUser* pUser, char* pBuf);
+	void HandleImpeachment(CUser* pUser, char* pBuf);
+	void HandleTax(CUser* pUser, char* pBuf);
+	void HandleEvent(CUser* pUser, char* pBuf);
+	void HandleKingNpc(CUser* pUser, char* pBuf);
+
+	// If the given character is currently online, sets/clears Rank=1/Title=1
+	// and refreshes the client UI. Persistence happens on next user save.
+	void ApplyRoyaltyToOnlineUser(const std::string& charName, bool isKing);
+
+	// Helpers
+	bool IsValidNation(int nation) const;
+	int  NationToIndex(int nation) const { return nation - 1; }
+
+	KingNationState _states[KING_NATION_COUNT] {};
+};
+
+} // namespace Ebenezer
+
+#endif // SERVER_EBENEZER_KINGSYSTEM_H

--- a/src/Server/Ebenezer/KingSystem.h
+++ b/src/Server/Ebenezer/KingSystem.h
@@ -73,6 +73,15 @@ public:
 	// system works without DB integration. Called by EbenezerApp init.
 	void InitDefaults();
 
+	// Hydrates in-memory state from the KING_SYSTEM table (one row per
+	// nation). Returns false on DB error; the in-memory defaults remain.
+	// Called once at startup after the DB connection is configured.
+	bool LoadFromDb();
+
+	// Persists the given nation's row back to KING_SYSTEM. Best-effort:
+	// errors are logged but don't propagate so gameplay isn't blocked.
+	void SaveNation(int nation);
+
 	// Per-tick maintenance. Expires events whose deadline has elapsed.
 	void Tick();
 

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -464,6 +464,21 @@ bool OperationMessage::Process(const std::string_view command)
 				KingImpeachVote();
 				break;
 
+			// +king_schedule <nation> <byType> <minutes>      arm Tick to fire
+			case "+king_schedule"_djb2:
+				KingSchedule();
+				break;
+
+			// +king_notice <write|read> <name> <text...>
+			case "+king_notice"_djb2:
+				KingNotice();
+				break;
+
+			// +king_autocycle <nation> <nominationMin> <votingMin>
+			case "+king_autocycle"_djb2:
+				KingAutoCycle();
+				break;
+
 #endif
 
 			// Unhandled command.
@@ -1169,6 +1184,73 @@ void OperationMessage::KingImpeachVote()
 				_srcUser->m_pUserData->m_id, nation, agree, error);
 	spdlog::info("OperationMessage::KingImpeachVote: nation={} agree={} ok={} err='{}'", nation,
 		agree, ok, error);
+}
+
+// +king_schedule <nation> <byType> <minutes>
+//   Arms the Phase-4 scheduler to advance the given nation to <byType> in
+//   <minutes>. Useful for previewing auto-transition without typing them
+//   one-by-one. Pass minutes=0 to clear a queued transition.
+void OperationMessage::KingSchedule()
+{
+	if (_srcUser == nullptr || GetArgCount() < 3)
+		return;
+	const int     nation     = ParseInt(0);
+	const int     byTypeRaw  = ParseInt(1);
+	const int     minutes    = ParseInt(2);
+	const uint8_t targetType = static_cast<uint8_t>(std::clamp(byTypeRaw, 0, 7));
+	_main->m_KingSystem.ScheduleNextPhase(nation, targetType, minutes);
+}
+
+// +king_notice <write|read> <candidateName> [text...]
+//   write — store the calling user's candidate manifesto (free-form remainder
+//           of the line is the body)
+//   read  — print whatever's stored for <candidateName> to the server log
+void OperationMessage::KingNotice()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation = _srcUser->m_pUserData->m_bNation;
+	const std::string& mode   = ParseString(0);
+
+	if (mode == "write")
+	{
+		std::string body;
+		for (size_t i = 1; i < GetArgCount(); ++i)
+		{
+			if (i > 1)
+				body += ' ';
+			body += ParseString(i);
+		}
+		const bool ok = _main->m_KingSystem.WriteCandidateNotice(
+			nation, _srcUser->m_pUserData->m_id, body);
+		spdlog::info("OperationMessage::KingNotice: write nation={} ok={} body='{}'", nation, ok,
+			body);
+	}
+	else if (mode == "read")
+	{
+		const std::string& target = ParseString(1);
+		std::string        body;
+		const bool ok = _main->m_KingSystem.ReadCandidateNotice(nation, target, body);
+		spdlog::info("OperationMessage::KingNotice: read nation={} target='{}' ok={} body='{}'",
+			nation, target, ok, body);
+	}
+	else
+	{
+		spdlog::warn("OperationMessage::KingNotice: unknown mode '{}'", mode);
+	}
+}
+
+// +king_autocycle <nation> <nominationMin> <votingMin>
+//   One-shot: starts nomination immediately, auto-advances to voting after
+//   <nominationMin>, auto-tallies after <votingMin> more minutes.
+void OperationMessage::KingAutoCycle()
+{
+	if (_srcUser == nullptr || GetArgCount() < 3)
+		return;
+	const int nation        = ParseInt(0);
+	const int nominationMin = ParseInt(1);
+	const int votingMin     = ParseInt(2);
+	_main->m_KingSystem.RunFullElection(nation, nominationMin, votingMin);
 }
 
 // +king_status     dump current monarchy state to the server log AND echo

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -479,6 +479,27 @@ bool OperationMessage::Process(const std::string_view command)
 				KingAutoCycle();
 				break;
 
+			// +king_order <message...>
+			case "+king_order"_djb2:
+			case "+royalorder"_djb2:
+				KingOrder();
+				break;
+
+			// +king_prize <recipient> <itemId> [count]
+			case "+king_prize"_djb2:
+				KingPrize();
+				break;
+
+			// +king_reward <recipient> <gold>
+			case "+king_reward"_djb2:
+				KingReward();
+				break;
+
+			// +king_weather <clear|rain|snow>
+			case "+king_weather"_djb2:
+				KingWeather();
+				break;
+
 #endif
 
 			// Unhandled command.
@@ -1288,6 +1309,85 @@ void OperationMessage::KingStatus()
 			_srcUser->Send(buffer, idx);
 		}
 	}
+}
+
+// +king_order <message...>   (alias: +royalorder)
+//   Broadcasts a kingdom-wide announcement signed by the calling king.
+//   Mirrors the client UICmdList CMD_ROYALORDER menu entry.
+void OperationMessage::KingOrder()
+{
+	if (_srcUser == nullptr || GetArgCount() < 1)
+		return;
+
+	std::string body;
+	for (size_t i = 0; i < GetArgCount(); ++i)
+	{
+		if (i > 0)
+			body += ' ';
+		body += ParseString(i);
+	}
+
+	const int nation = _srcUser->m_pUserData->m_bNation;
+	_main->m_KingSystem.RoyalOrder(nation, _srcUser->m_pUserData->m_id, body);
+}
+
+// +king_prize <recipient> <itemId> [count]
+//   Drops the given item count into the recipient's inventory. Mirrors
+//   client CMD_PRIZE.
+void OperationMessage::KingPrize()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+
+	const std::string& recipient = ParseString(0);
+	const int          itemId    = ParseInt(1);
+	const int          count     = (GetArgCount() >= 3) ? ParseInt(2) : 1;
+	const int          nation    = _srcUser->m_pUserData->m_bNation;
+
+	const bool ok = _main->m_KingSystem.RoyalPrize(nation, recipient, itemId, count);
+	spdlog::info("OperationMessage::KingPrize: nation={} recipient='{}' itemId={} count={} ok={}",
+		nation, recipient, itemId, count, ok);
+}
+
+// +king_reward <recipient> <gold>
+//   Awards gold from the national treasury to the recipient. Mirrors
+//   client CMD_REWARD.
+void OperationMessage::KingReward()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+
+	const std::string& recipient = ParseString(0);
+	const int          gold      = ParseInt(1);
+	const int          nation    = _srcUser->m_pUserData->m_bNation;
+
+	const bool ok = _main->m_KingSystem.RoyalReward(nation, recipient, gold);
+	spdlog::info("OperationMessage::KingReward: nation={} recipient='{}' gold={} ok={}", nation,
+		recipient, gold, ok);
+}
+
+// +king_weather <clear|fine|rain|snow>
+//   Sets realm-wide weather. Mirrors client CMD_RAIN / CMD_SNOW / CMD_CLEAR.
+void OperationMessage::KingWeather()
+{
+	if (_srcUser == nullptr || GetArgCount() < 1)
+		return;
+
+	const std::string& kind = ParseString(0);
+	uint8_t            weatherKind = 0;
+	if (kind == "clear" || kind == "fine")
+		weatherKind = 1;
+	else if (kind == "rain")
+		weatherKind = 2;
+	else if (kind == "snow")
+		weatherKind = 3;
+	else
+	{
+		spdlog::warn("OperationMessage::KingWeather: unknown kind '{}' (use clear|rain|snow)", kind);
+		return;
+	}
+
+	_main->m_KingSystem.RoyalWeather(weatherKind);
 }
 #endif
 

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -439,6 +439,31 @@ bool OperationMessage::Process(const std::string_view command)
 				KingStatus();
 				break;
 
+			// +king_phase <nation> <open|close|vote|tally|cancel>
+			case "+king_phase"_djb2:
+				KingPhase();
+				break;
+
+			// +king_nominate <nation> <charName> [tribute]
+			case "+king_nominate"_djb2:
+				KingNominate();
+				break;
+
+			// +king_vote <nation> <candidateName>
+			case "+king_vote"_djb2:
+				KingVote();
+				break;
+
+			// +king_impeach <nation> <start|tally> [requiredAgree%]
+			case "+king_impeach"_djb2:
+				KingImpeach();
+				break;
+
+			// +king_impeach_vote <nation> <yes|no>
+			case "+king_impeach_vote"_djb2:
+				KingImpeachVote();
+				break;
+
 #endif
 
 			// Unhandled command.
@@ -1055,6 +1080,95 @@ void OperationMessage::KingTax()
 									: _main->m_KingSystem.GetState(nation).nTerritoryTax;
 	_main->m_KingSystem.SetTax(
 		nation, static_cast<uint8_t>(std::clamp(tariff, 0, 100)), territoryTax);
+}
+
+// +king_phase <nation> <open|close|vote|tally|cancel>
+//   open   → byType 1 (nomination)
+//   close  → byType 2 (nominations closed)
+//   vote   → byType 3/4 (voting active, candidates promoted)
+//   tally  → byType 7 (winner crowned) or 0 if nobody ran
+//   cancel → byType 0 (clear everything)
+void OperationMessage::KingPhase()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation = ParseInt(0);
+	const std::string& action = ParseString(1);
+
+	if (action == "open")
+		_main->m_KingSystem.StartNomination(nation);
+	else if (action == "close")
+		_main->m_KingSystem.CloseNomination(nation);
+	else if (action == "vote")
+		_main->m_KingSystem.StartVoting(nation);
+	else if (action == "tally")
+		_main->m_KingSystem.CloseVoting(nation);
+	else if (action == "cancel")
+		_main->m_KingSystem.CancelElection(nation);
+	else
+		spdlog::warn("OperationMessage::KingPhase: unknown action '{}'", action);
+}
+
+// +king_nominate <nation> <charName> [tribute]
+void OperationMessage::KingNominate()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation     = ParseInt(0);
+	const std::string& charName   = ParseString(1);
+	const int          tribute    = (GetArgCount() >= 3) ? ParseInt(2) : 0;
+	std::string        error;
+	const bool         ok = _main->m_KingSystem.NominateCandidate(charName, nation, tribute, error);
+	spdlog::info("OperationMessage::KingNominate: nation={} candidate='{}' ok={} err='{}'",
+		nation, charName, ok, error);
+}
+
+// +king_vote <nation> <candidateName>     casts a ballot AS the calling GM
+void OperationMessage::KingVote()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation     = ParseInt(0);
+	const std::string& candidate  = ParseString(1);
+	std::string        error;
+	const bool         ok         = _main->m_KingSystem.CastBallot(_srcUser->m_strAccountID,
+				_srcUser->m_pUserData->m_id, nation, candidate, error);
+	spdlog::info("OperationMessage::KingVote: nation={} candidate='{}' ok={} err='{}'", nation,
+		candidate, ok, error);
+}
+
+// +king_impeach <nation> <start|tally> [requiredAgree%]
+void OperationMessage::KingImpeach()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation = ParseInt(0);
+	const std::string& action = ParseString(1);
+
+	if (action == "start")
+		_main->m_KingSystem.StartImpeachment(nation);
+	else if (action == "tally")
+	{
+		const int required = (GetArgCount() >= 3) ? ParseInt(2) : 51;
+		_main->m_KingSystem.CloseImpeachment(nation, required);
+	}
+	else
+		spdlog::warn("OperationMessage::KingImpeach: unknown action '{}'", action);
+}
+
+// +king_impeach_vote <nation> <yes|no>
+void OperationMessage::KingImpeachVote()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+	const int          nation = ParseInt(0);
+	const std::string& choice = ParseString(1);
+	const bool         agree  = (choice == "yes" || choice == "y" || choice == "1");
+	std::string        error;
+	const bool         ok     = _main->m_KingSystem.CastImpeachmentVote(_srcUser->m_strAccountID,
+				_srcUser->m_pUserData->m_id, nation, agree, error);
+	spdlog::info("OperationMessage::KingImpeachVote: nation={} agree={} ok={} err='{}'", nation,
+		agree, ok, error);
 }
 
 // +king_status     dump current monarchy state to the server log AND echo

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -499,6 +499,8 @@ bool OperationMessage::Process(const std::string_view command)
 
 			// Unhandled command.
 			default:
+				spdlog::warn("OperationMessage::Process: UNHANDLED command='{}' key={}",
+					_command, key);
 				return false;
 		}
 	}

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -9,6 +9,8 @@
 #include <shared/StringUtils.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -53,10 +55,6 @@ bool OperationMessage::Process(const std::string_view command)
 				Assault();
 				break;
 
-			case "+monsummon"_djb2:
-				MonSummon();
-				break;
-
 			case "+monsummonall"_djb2:
 				MonSummonAll();
 				break;
@@ -73,6 +71,12 @@ bool OperationMessage::Process(const std::string_view command)
 				MonKill();
 				break;
 #endif
+
+			// Unofficial GM command: summon a monster/NPC at the caller's position.
+			// Usage: +monsummon <npcId> [count]
+			case "+monsummon"_djb2:
+				MonSummon();
+				break;
 
 			case "/open"_djb2:
 			case "+open"_djb2:
@@ -408,6 +412,33 @@ bool OperationMessage::Process(const std::string_view command)
 				GiveItem();
 				break;
 
+			// +add_exp <amount>   amount may be negative (caps at level threshold).
+			case "+add_exp"_djb2:
+			case "+add_xp"_djb2:
+				AddExp();
+				break;
+
+			// +set_king <nation> <name>     install/replace the king of a nation
+			// +set_king clear <nation>      remove the king
+			case "+set_king"_djb2:
+				SetKing();
+				break;
+
+			// +king_event <noah|exp> <bonus%> <minutes>   fire a nation event
+			case "+king_event"_djb2:
+				KingEvent();
+				break;
+
+			// +king_tax <nation> <tariff%> [territoryTax]
+			case "+king_tax"_djb2:
+				KingTax();
+				break;
+
+			// +king_status                  prints both nations' state to log
+			case "+king_status"_djb2:
+				KingStatus();
+				break;
+
 #endif
 
 			// Unhandled command.
@@ -475,9 +506,44 @@ void OperationMessage::Assault()
 	// TODO
 }
 
+// Unofficial GM command: spawn a monster/NPC at the caller's current position.
+// Sends AG_NPC_SUMMON_REQ to the AI server which performs the actual spawn.
+//
+// Usage: +monsummon <npcId> [count]
 void OperationMessage::MonSummon()
 {
-	// TODO
+	if (_srcUser == nullptr || GetArgCount() < 1)
+		return;
+
+	int npcId = ParseInt(0);
+	int count = 1;
+	if (GetArgCount() >= 2)
+		count = ParseInt(1);
+
+	if (npcId <= 0 || npcId > std::numeric_limits<int16_t>::max())
+		return;
+
+	if (count <= 0 || count > 50)
+		count = 1;
+
+	const uint8_t zone = _srcUser->m_pUserData->m_bZone;
+	const float   posX = _srcUser->m_pUserData->m_curx;
+	const float   posZ = _srcUser->m_pUserData->m_curz;
+
+	char sendBuffer[32] {};
+	int sendIndex = 0;
+	SetByte(sendBuffer, AG_NPC_SUMMON_REQ, sendIndex);
+	SetShort(sendBuffer, static_cast<int16_t>(npcId), sendIndex);
+	SetShort(sendBuffer, static_cast<int16_t>(count), sendIndex);
+	SetByte(sendBuffer, zone, sendIndex);
+	SetFloat(sendBuffer, posX, sendIndex);
+	SetFloat(sendBuffer, posZ, sendIndex);
+
+	_main->Send_AIServer(zone, sendBuffer, sendIndex);
+
+	spdlog::info("OperationMessage::MonSummon: requested [user={} npcId={} count={} zone={} "
+				 "x={:.1f} z={:.1f}]",
+		_srcUser->m_pUserData->m_id, npcId, count, zone, posX, posZ);
 }
 
 void OperationMessage::MonSummonAll()
@@ -913,6 +979,96 @@ void OperationMessage::GiveItem()
 	spdlog::warn("OperationMessage::GiveItem: invoked [srcUser={} authority={} itemId={} "
 				 "count={} success={}]",
 		_srcUser->m_pUserData->m_id, _srcUser->m_pUserData->m_bAuthority, itemId, count, isSuccess);
+}
+
+// +add_exp <amount>
+// Grants (or removes, if negative) experience to the caller. Routes through
+// CUser::ExpChange which handles level-up / level-down and client notification.
+void OperationMessage::AddExp()
+{
+	if (_srcUser == nullptr || GetArgCount() < 1)
+		return;
+
+	const int amount = ParseInt(0);
+	if (amount == 0)
+		return;
+
+	_srcUser->ExpChange(amount);
+
+	spdlog::warn(
+		"OperationMessage::AddExp: invoked [srcUser={} authority={} amount={} newExp={} level={}]",
+		_srcUser->m_pUserData->m_id, _srcUser->m_pUserData->m_bAuthority, amount,
+		_srcUser->m_pUserData->m_iExp, _srcUser->m_pUserData->m_bLevel);
+}
+
+// +set_king <nation> <name>      install/replace the king of a nation
+// +set_king clear <nation>       remove the king
+void OperationMessage::SetKing()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+
+	const std::string& first = ParseString(0);
+	if (first == "clear")
+	{
+		const int nation = ParseInt(1);
+		_main->m_KingSystem.ClearKing(nation);
+		return;
+	}
+
+	const int nation = ParseInt(0);
+	const std::string& name = ParseString(1);
+	if (name.empty())
+		return;
+	_main->m_KingSystem.SetKing(nation, name);
+}
+
+// +king_event <noah|exp> <bonus%> <minutes>
+void OperationMessage::KingEvent()
+{
+	if (_srcUser == nullptr || GetArgCount() < 3)
+		return;
+
+	const std::string& kind     = ParseString(0);
+	const int          bonus    = ParseInt(1);
+	const int          minutes  = ParseInt(2);
+	const int          nation   = _srcUser->m_pUserData->m_bNation;
+
+	if (kind == "noah" || kind == "gold")
+		_main->m_KingSystem.StartNoahEvent(nation, bonus, minutes);
+	else if (kind == "exp" || kind == "xp")
+		_main->m_KingSystem.StartExpEvent(nation, bonus, minutes);
+	else
+		spdlog::warn("OperationMessage::KingEvent: unknown event kind '{}'", kind);
+}
+
+// +king_tax <nation> <tariff%> [territoryTax]
+void OperationMessage::KingTax()
+{
+	if (_srcUser == nullptr || GetArgCount() < 2)
+		return;
+
+	const int     nation       = ParseInt(0);
+	const int     tariff       = ParseInt(1);
+	const int     territoryTax = (GetArgCount() >= 3)
+									? ParseInt(2)
+									: _main->m_KingSystem.GetState(nation).nTerritoryTax;
+	_main->m_KingSystem.SetTax(
+		nation, static_cast<uint8_t>(std::clamp(tariff, 0, 100)), territoryTax);
+}
+
+// +king_status     dump current monarchy state to the server log
+void OperationMessage::KingStatus()
+{
+	for (int n = KING_NATION_KARUS; n <= KING_NATION_ELMORAD; ++n)
+	{
+		const auto& s = _main->m_KingSystem.GetState(n);
+		spdlog::info(
+			"KingSystem[nation={}]: byType={} king='{}' tariff={} territoryTax={} treasury={} "
+			"noahEvent={} (+{}%) expEvent={} (+{}%)",
+			n, s.byType, s.strKingName, s.byTerritoryTariff, s.nTerritoryTax, s.nNationalTreasury,
+			s.noahEventActive, s.noahEventBonusPercent, s.expEventActive, s.expEventBonusPercent);
+	}
 }
 #endif
 

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -485,11 +485,6 @@ bool OperationMessage::Process(const std::string_view command)
 				KingOrder();
 				break;
 
-			// +king_prize <recipient> <itemId> [count]
-			case "+king_prize"_djb2:
-				KingPrize();
-				break;
-
 			// +king_reward <recipient> <gold>
 			case "+king_reward"_djb2:
 				KingReward();
@@ -1329,24 +1324,6 @@ void OperationMessage::KingOrder()
 
 	const int nation = _srcUser->m_pUserData->m_bNation;
 	_main->m_KingSystem.RoyalOrder(nation, _srcUser->m_pUserData->m_id, body);
-}
-
-// +king_prize <recipient> <itemId> [count]
-//   Drops the given item count into the recipient's inventory. Mirrors
-//   client CMD_PRIZE.
-void OperationMessage::KingPrize()
-{
-	if (_srcUser == nullptr || GetArgCount() < 2)
-		return;
-
-	const std::string& recipient = ParseString(0);
-	const int          itemId    = ParseInt(1);
-	const int          count     = (GetArgCount() >= 3) ? ParseInt(2) : 1;
-	const int          nation    = _srcUser->m_pUserData->m_bNation;
-
-	const bool ok = _main->m_KingSystem.RoyalPrize(nation, recipient, itemId, count);
-	spdlog::info("OperationMessage::KingPrize: nation={} recipient='{}' itemId={} count={} ok={}",
-		nation, recipient, itemId, count, ok);
 }
 
 // +king_reward <recipient> <gold>

--- a/src/Server/Ebenezer/OperationMessage.cpp
+++ b/src/Server/Ebenezer/OperationMessage.cpp
@@ -1057,7 +1057,9 @@ void OperationMessage::KingTax()
 		nation, static_cast<uint8_t>(std::clamp(tariff, 0, 100)), territoryTax);
 }
 
-// +king_status     dump current monarchy state to the server log
+// +king_status     dump current monarchy state to the server log AND echo
+// a one-line summary back to the calling GM as a chat notice so it's visible
+// in-game without having to tail the log file.
 void OperationMessage::KingStatus()
 {
 	for (int n = KING_NATION_KARUS; n <= KING_NATION_ELMORAD; ++n)
@@ -1068,6 +1070,27 @@ void OperationMessage::KingStatus()
 			"noahEvent={} (+{}%) expEvent={} (+{}%)",
 			n, s.byType, s.strKingName, s.byTerritoryTariff, s.nTerritoryTax, s.nNationalTreasury,
 			s.noahEventActive, s.noahEventBonusPercent, s.expEventActive, s.expEventBonusPercent);
+
+		if (_srcUser != nullptr)
+		{
+			std::string line = fmt::format(
+				"[{}] type={} king='{}' tariff={} treasury={} noah={}{}% exp={}{}%",
+				(n == KING_NATION_KARUS ? "Karus" : "ElMorad"), s.byType, s.strKingName,
+				s.byTerritoryTariff, s.nNationalTreasury, s.noahEventActive ? "ON +" : "OFF ",
+				s.noahEventBonusPercent, s.expEventActive ? "ON +" : "OFF ",
+				s.expEventBonusPercent);
+
+			char    buffer[256] {};
+			int     idx     = 0;
+			const std::string_view body { line.data(), std::min<size_t>(line.size(), 200) };
+			SetByte(buffer, WIZ_CHAT, idx);
+			SetByte(buffer, ANNOUNCEMENT_CHAT, idx);
+			SetByte(buffer, _srcUser->m_pUserData->m_bNation, idx);
+			SetShort(buffer, -1, idx);
+			SetString1(buffer, std::string_view("KingSystem"), idx);
+			SetString2(buffer, body, idx);
+			_srcUser->Send(buffer, idx);
+		}
 	}
 }
 #endif

--- a/src/Server/Ebenezer/OperationMessage.h
+++ b/src/Server/Ebenezer/OperationMessage.h
@@ -113,6 +113,10 @@ protected:
 	void KingSchedule();
 	void KingNotice();
 	void KingAutoCycle();
+	void KingOrder();
+	void KingPrize();
+	void KingReward();
+	void KingWeather();
 #endif
 
 	bool ParseCommand(const std::string_view command, size_t& key);

--- a/src/Server/Ebenezer/OperationMessage.h
+++ b/src/Server/Ebenezer/OperationMessage.h
@@ -105,6 +105,11 @@ protected:
 	void KingEvent();
 	void KingTax();
 	void KingStatus();
+	void KingPhase();
+	void KingNominate();
+	void KingVote();
+	void KingImpeach();
+	void KingImpeachVote();
 #endif
 
 	bool ParseCommand(const std::string_view command, size_t& key);

--- a/src/Server/Ebenezer/OperationMessage.h
+++ b/src/Server/Ebenezer/OperationMessage.h
@@ -114,7 +114,6 @@ protected:
 	void KingNotice();
 	void KingAutoCycle();
 	void KingOrder();
-	void KingPrize();
 	void KingReward();
 	void KingWeather();
 #endif

--- a/src/Server/Ebenezer/OperationMessage.h
+++ b/src/Server/Ebenezer/OperationMessage.h
@@ -100,6 +100,11 @@ protected:
 #ifdef _DEBUG
 	// unoffical commands for debug builds/purposes only
 	void GiveItem();
+	void AddExp();
+	void SetKing();
+	void KingEvent();
+	void KingTax();
+	void KingStatus();
 #endif
 
 	bool ParseCommand(const std::string_view command, size_t& key);

--- a/src/Server/Ebenezer/OperationMessage.h
+++ b/src/Server/Ebenezer/OperationMessage.h
@@ -110,6 +110,9 @@ protected:
 	void KingVote();
 	void KingImpeach();
 	void KingImpeachVote();
+	void KingSchedule();
+	void KingNotice();
+	void KingAutoCycle();
 #endif
 
 	bool ParseCommand(const std::string_view command, size_t& key);

--- a/src/Server/Ebenezer/User.cpp
+++ b/src/Server/Ebenezer/User.cpp
@@ -669,6 +669,10 @@ void CUser::Parsing(int len, char* pData)
 			m_pMain->m_KnightsManager.PacketProcess(this, pData + index);
 			break;
 
+		case WIZ_KING:
+			m_pMain->m_KingSystem.PacketProcess(this, pData + index);
+			break;
+
 		case WIZ_ITEM_REMOVE:
 			ItemRemove(pData + index);
 			break;
@@ -1993,6 +1997,11 @@ void CUser::SendMyInfo(int type)
 	if (m_pUserData->m_bKnights != 0)
 		pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 
+	// Cape ID 99 in Cloak.tbl is the "king" cape — show it whenever this
+	// user is the reigning monarch, regardless of clan affiliation.
+	const bool isKing                = m_pMain->m_KingSystem.IsKing(this);
+	constexpr int16_t KING_CAPE_ID   = 99;
+
 	if (pKnights != nullptr)
 	{
 		SetShort(sendBuffer, pKnights->m_sAllianceKnights, sendIndex);
@@ -2001,7 +2010,7 @@ void CUser::SendMyInfo(int type)
 		SetByte(sendBuffer, pKnights->m_byGrade, sendIndex); // Knights grade
 		SetByte(sendBuffer, pKnights->m_byRanking, sendIndex);
 		SetShort(sendBuffer, pKnights->m_sMarkVersion, sendIndex);
-		SetShort(sendBuffer, pKnights->m_sCape, sendIndex);
+		SetShort(sendBuffer, isKing ? KING_CAPE_ID : pKnights->m_sCape, sendIndex);
 		//TRACE(_T("sendmyinfo knights index = %d, kname=%hs, name=%hs\n") , iLength, pKnights->strName, m_pUserData->m_id);
 	}
 	else
@@ -2012,7 +2021,7 @@ void CUser::SendMyInfo(int type)
 		SetByte(sendBuffer, 0, sendIndex);   // m_byGrade
 		SetByte(sendBuffer, 0, sendIndex);   // m_byRanking
 		SetShort(sendBuffer, 0, sendIndex);  // m_sMarkVerison
-		SetShort(sendBuffer, -1, sendIndex); // m_sCape
+		SetShort(sendBuffer, isKing ? KING_CAPE_ID : -1, sendIndex);
 	}
 
 	SetShort(sendBuffer, m_iMaxHp, sendIndex);
@@ -14398,6 +14407,11 @@ void CUser::GetUserInfo(char* buff, int& buff_index)
 	if (m_pUserData->m_bKnights != 0)
 		pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 
+	// Override clan cape with the "king" cape (Cloak.tbl id 99) when this
+	// user is the reigning monarch, so other clients render the royal cape.
+	const bool isKing              = m_pMain->m_KingSystem.IsKing(this);
+	constexpr int16_t KING_CAPE_ID = 99;
+
 	if (pKnights != nullptr)
 	{
 		SetShort(buff, pKnights->m_sAllianceKnights, buff_index);
@@ -14405,7 +14419,7 @@ void CUser::GetUserInfo(char* buff, int& buff_index)
 		SetByte(buff, pKnights->m_byGrade, buff_index); // knights grade
 		SetByte(buff, pKnights->m_byRanking, buff_index);
 		SetShort(buff, pKnights->m_sMarkVersion, buff_index);
-		SetShort(buff, pKnights->m_sCape, buff_index);
+		SetShort(buff, isKing ? KING_CAPE_ID : pKnights->m_sCape, buff_index);
 	}
 	else
 	{
@@ -14414,7 +14428,7 @@ void CUser::GetUserInfo(char* buff, int& buff_index)
 		SetByte(buff, 0, buff_index);   // m_byGrade
 		SetByte(buff, 0, buff_index);   // m_byRanking
 		SetShort(buff, 0, buff_index);  // m_sMarkVerison
-		SetShort(buff, -1, buff_index); // m_sCape
+		SetShort(buff, isKing ? KING_CAPE_ID : -1, buff_index);
 	}
 
 	SetByte(buff, m_pUserData->m_bLevel, buff_index);

--- a/src/shared/packets.h
+++ b/src/shared/packets.h
@@ -782,6 +782,7 @@ enum e_AIOpcode : uint8_t
 	AG_NPC_INOUT           = 11,
 	AG_NPC_EVENT_ITEM      = 12,
 	AG_NPC_HP_REQ          = 13,
+	AG_NPC_SUMMON_REQ      = 14, // GM command: summon NPC at user position
 
 	// ---------------------------------------------------------------------
 	// AI Server와 게임서버간의 User, Npc 공통 관련된 패킷은 50번~100번

--- a/start_all.cmd
+++ b/start_all.cmd
@@ -1,0 +1,41 @@
+@ECHO OFF
+REM Local development launcher for OpenKO (Docker DB)
+REM Starts servers in order, then the client.
+
+SET "ROOT=%~dp0"
+SET "BIN=%ROOT%bin\Debug-x64"
+SET "MAP=%ROOT%assets\Server\MAP"
+SET "QUESTS=%ROOT%assets\Server\QUESTS"
+SET "CLIENT_CWD=%ROOT%assets\Client"
+
+IF NOT EXIST "%BIN%\Ebenezer.exe" (
+    ECHO ERROR: Build artifacts not found at "%BIN%". Build All.slnx first.
+    EXIT /B 1
+)
+
+ECHO Starting Aujard...
+START "Aujard" /D "%BIN%" "%BIN%\Aujard.exe"
+TIMEOUT /T 3 /NOBREAK >NUL
+
+ECHO Starting Ebenezer...
+START "Ebenezer" /D "%BIN%" "%BIN%\Ebenezer.exe" --map-dir="%MAP%" --quests-dir="%QUESTS%"
+TIMEOUT /T 3 /NOBREAK >NUL
+
+ECHO Starting AIServer...
+START "AIServer" /D "%BIN%" "%BIN%\AIServer.exe" --map-dir="%MAP%" --event-dir="%MAP%"
+TIMEOUT /T 2 /NOBREAK >NUL
+
+ECHO Starting VersionManager...
+START "VersionManager" /D "%BIN%" "%BIN%\VersionManager.exe"
+TIMEOUT /T 2 /NOBREAK >NUL
+
+ECHO Starting ItemManager...
+START "ItemManager" /D "%BIN%" "%BIN%\ItemManager.exe"
+TIMEOUT /T 2 /NOBREAK >NUL
+
+ECHO Starting Client (KnightOnLine.exe)...
+START "KnightOnLine" /D "%CLIENT_CWD%" "%BIN%\KnightOnLine.exe"
+
+ECHO.
+ECHO All processes launched. Each runs in its own console window.
+ECHO Test login: testing / testing

--- a/start_client.cmd
+++ b/start_client.cmd
@@ -1,0 +1,14 @@
+@ECHO OFF
+REM Launches only the Knight Online client.
+
+SET "ROOT=%~dp0"
+SET "BIN=%ROOT%bin\Debug-x64"
+SET "CLIENT_CWD=%ROOT%assets\Client"
+
+IF NOT EXIST "%BIN%\KnightOnLine.exe" (
+    ECHO ERROR: KnightOnLine.exe not found at "%BIN%". Build Client.slnx first.
+    EXIT /B 1
+)
+
+ECHO Starting Client (KnightOnLine.exe)...
+START "KnightOnLine" /D "%CLIENT_CWD%" "%BIN%\KnightOnLine.exe"


### PR DESCRIPTION
## Summary

This branch wires up an end-to-end King System on top of OpenKO and pulls in the cape-rendering pipeline that was previously dead code. It also adds a handful of debug-only GM commands and fixes a pair of HUD assertions that hard-crashed the client for high-level characters.

## What's in the box

### King System (server)
- `CKingSystem` class owns per-nation monarchy state (king name, byType phase, tax, treasury, active events).
- `WIZ_KING` packets are now routed through `CUser::HandlePacket` to the king system instead of being dropped on the floor.
- **Phase 1**: in-memory state, `KING_TAX` / `KING_EVENT` / `KING_NPC` handlers, NOAH and EXP nation-wide announcements via `ANNOUNCEMENT_CHAT`. Active king is auto-granted `Rank=1` / `Title=1` (so item gates like `ReqRank=1` pass) and broadcast wears Cloak.tbl id 99 regardless of clan.
- **Phase 2**: `KING_SYSTEM` table is hydrated via `nanodbc` at server startup, and `SetKing` / `ClearKing` / `SetTax` mutators persist their changes back. Survives Ebenezer restarts.
- **Phase 3**: full election + impeachment state machine driven by `byType` (0 → 1 → 2 → 3 → 4 → 7). Nominate via `KING_ELECTION_LIST`, ballots via `KING_BALLOT_BOX`, automatic winner crowning when voting closes. Impeachment reuses the ballot box with `'Y'`/`'N'` candidacy flags and dethrones if the agree-percent clears the threshold.

### GM commands (debug builds)
```
+monsummon <npcId> [count]
+add_xp <amount> | +add_exp <amount>
+set_king <nation> <name>     +set_king clear <nation>
+king_event <noah|exp> <bonus%> <minutes>
+king_tax <nation> <tariff%> [territoryTax]
+king_status
+king_phase <nation> <open|close|vote|tally|cancel>
+king_nominate <nation> <charName> [tribute]
+king_vote <nation> <candidateName>
+king_impeach <nation> <start|tally> [requiredAgree%]
+king_impeach_vote <nation> <yes|no>
```

### Cape rendering (client) — cherry-picked from `reignsprime/KnightOnline-RP @ Clan-cloak-started`
- `AttachCloak()` is wired up in `CPlayerBase`/`CPlayerMySelf`/`CPlayerOther`; `MsgRecv_MyInfo_All` and `MsgRecv_OtherUserInfo` no longer discard the cape id from the wire.
- King cape (`Cloak.tbl` id 99) takes a hard-coded `Item\Cloak_C_99.dxt` texture path when `m_InfoBase.iRank == 1`.
- Clan symbol DXT is built via `CGameProcedure::GetSymbolFilename(serverIndex, knightsId, markVersion)` and applied as a cloak texture layer for chief-tier ranks.
- Bonus from the same fork: `CN3CPlug_Cloak::Load` mesh fix, `iRank` moved to `__InfoPlayerBase`, `WIZ_SERVER_INDEX` packet handler.

### Misc fixes
- `AG_USER_EXP` wire format widened from `int16_t` to `int32_t` on both AIServer and Ebenezer sides — high-level mob kills generated exp values that overflowed and were rejected with `invalid exp or loyalty amount granted exp=-17797`.
- `+monsummon` adds new `AG_NPC_SUMMON_REQ` opcode; AIServer creates the NPC, registers it via `NPC_INFO_ALL`, then broadcasts via `AG_NPC_INFO`. Serial range starts at 20000 to keep `m_sNid + NPC_BAND` inside positive `int16_t`.
- Client HUD: `CUIState::UpdateHP` and `CUIStateBar::UpdateHP` no longer assert `iHP < 10000`; level-80 characters in royal-tier gear sit comfortably past 15000 HP and the assertion fired a Debug Assertion Failed dialog on every refresh.
- `start_all.cmd` / `start_client.cmd` for the local Docker-DB dev setup.

## What's deferred (Phase 4)
- Cron-style automatic phase transitions driven by the schedule columns in `KING_SYSTEM`.
- Tribute money deduction from the candidate's gold balance on `+king_nominate`.
- Candidacy notice board read/write persistence.

## Test plan
- [x] Server builds cleanly (`Server.slnx`, Debug-x64).
- [x] Client builds cleanly (`Client.slnx`, Debug-x64).
- [x] Smoke: server restart loads `KING_SYSTEM` and the king's cape renders on the next `WIZ_MYINFO`.
- [x] Smoke: high-level character logs in without firing the HUD assertion.
- [ ] Round-trip: `+king_phase 1 open` → `+king_nominate` → `+king_phase 1 vote` → `+king_vote` → `+king_phase 1 tally` crowns the highest-vote candidate.
- [ ] Round-trip: `+king_impeach 1 start` → `+king_impeach_vote 1 yes` → `+king_impeach 1 tally 51` dethrones the king.

