### PR TITLE
Fix mage AoE area visual emission

### DIFF
--- a/src/Server/AIServer/MagicProcess.cpp
+++ b/src/Server/AIServer/MagicProcess.cpp
@@ -23,6 +23,66 @@ CMagicProcess::~CMagicProcess()
 {
 }
 
+bool CMagicProcess::UsesAreaCenteredAnimation(const model::Magic* pMagic) const
+{
+	if (pMagic == nullptr)
+		return false;
+
+	// TargetEffect 2900-2999 are large ground-area FX (e.g. novas).
+	// If sent per target, the client draws the big center effect on every damaged unit.
+	return (pMagic->Moral == MORAL_AREA_ENEMY || pMagic->Moral == MORAL_AREA_ALL
+			   || pMagic->Moral == MORAL_SELF_AREA)
+		   && pMagic->FlyingEffect == 0 && pMagic->TargetEffect >= 2900
+		   && pMagic->TargetEffect < 3000;
+}
+
+bool CMagicProcess::UsesPerTargetAnimation(const model::Magic* pMagic) const
+{
+	return !UsesAreaCenteredAnimation(pMagic);
+}
+
+void CMagicProcess::SendAreaCenteredAnimation(
+	int magicid, int moral, int data1, int data2, int data3) const
+{
+	int sendIndex = 0;
+	char sendBuffer[128] {};
+
+	SetByte(sendBuffer, AG_MAGIC_ATTACK_RESULT, sendIndex);
+	SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
+	SetDWORD(sendBuffer, magicid, sendIndex);
+	SetShort(sendBuffer, m_pSrcUser->m_iUserId, sendIndex);
+	SetShort(sendBuffer, -1, sendIndex);
+	SetShort(sendBuffer, data1, sendIndex);
+	SetShort(sendBuffer, data2, sendIndex);
+	SetShort(sendBuffer, data3, sendIndex);
+	SetShort(sendBuffer, moral, sendIndex);
+	SetShort(sendBuffer, 0, sendIndex);
+	SetShort(sendBuffer, 0, sendIndex);
+
+	m_pMain->Send(sendBuffer, sendIndex, m_pSrcUser->m_curZone);
+}
+
+void CMagicProcess::SendPerTargetAnimation(
+	int magicid, int targetId, int data1, int result, int data3, int moral) const
+{
+	int sendIndex = 0;
+	char sendBuffer[128] {};
+
+	SetByte(sendBuffer, AG_MAGIC_ATTACK_RESULT, sendIndex);
+	SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
+	SetDWORD(sendBuffer, magicid, sendIndex);
+	SetShort(sendBuffer, m_pSrcUser->m_iUserId, sendIndex);
+	SetShort(sendBuffer, targetId, sendIndex);
+	SetShort(sendBuffer, data1, sendIndex);
+	SetShort(sendBuffer, result, sendIndex);
+	SetShort(sendBuffer, data3, sendIndex);
+	SetShort(sendBuffer, moral, sendIndex);
+	SetShort(sendBuffer, 0, sendIndex);
+	SetShort(sendBuffer, 0, sendIndex);
+
+	m_pMain->Send(sendBuffer, sendIndex, m_pSrcUser->m_curZone);
+}
+
 void CMagicProcess::MagicPacket(char* pBuf)
 {
 	int index = 0, magicid = 0, sid = -1, tid = -1, TotalDex = 0, righthand_damage = 0;
@@ -667,13 +727,22 @@ int16_t CMagicProcess::GetMagicDamage(
 int16_t CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1, int data2,
 	int data3, int dexpoint, int righthand_damage)
 {
-	model::MagicType3* pType3 = nullptr;
-	model::MagicType4* pType4 = nullptr;
-	model::MagicType7* pType7 = nullptr;
-	int radius                = 0;
+	model::MagicType3* pType3      = nullptr;
+	model::MagicType4* pType4      = nullptr;
+	model::MagicType7* pType7      = nullptr;
+	model::Magic* pMagic           = nullptr;
+	bool usesAreaCenteredAnimation = false;
+	int radius                     = 0;
 
 	if (magictype == 3)
 	{
+		pMagic = m_pMain->_magicTableMap.GetData(magicid);
+		if (pMagic == nullptr)
+		{
+			spdlog::error("MagicProcess::AreaAttack: No MAGIC definition [magicId={}]", magicid);
+			return 0;
+		}
+
 		pType3 = m_pMain->_magicType3TableMap.GetData(magicid);
 		if (pType3 == nullptr)
 		{
@@ -682,7 +751,9 @@ int16_t CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int dat
 			return 0;
 		}
 
-		radius = pType3->Radius;
+		radius                    = pType3->Radius;
+
+		usesAreaCenteredAnimation = UsesAreaCenteredAnimation(pMagic);
 	}
 	else if (magictype == 4)
 	{
@@ -756,6 +827,9 @@ int16_t CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int dat
 				dexpoint, righthand_damage);
 	}
 
+	if (magictype == 3 && usesAreaCenteredAnimation)
+		SendAreaCenteredAnimation(magicid, moral, data1, data2, data3);
+
 	//damage = GetMagicDamage(tid, pType->FirstDamage, pType->bAttribute);
 
 	return 1;
@@ -795,6 +869,8 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 		spdlog::error("MagicProcess::AreaAttackDamage: No MAGIC definition [magicId={}]", magicid);
 		return;
 	}
+
+	const bool usesPerTargetAnimation = UsesPerTargetAnimation(pMagic);
 
 	if (magictype == 3)
 	{
@@ -918,26 +994,11 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 				}
 			}
 
-			memset(sendBuffer, 0, sizeof(sendBuffer));
-			sendIndex = 0;
-
 			// 패킷 전송.....
 			//if ( pMagic->bType2 == 0 || pMagic->bType2 == 3 )
-			{
-				SetByte(sendBuffer, AG_MAGIC_ATTACK_RESULT, sendIndex);
-				SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
-				SetDWORD(sendBuffer, magicid, sendIndex);
-				SetShort(sendBuffer, m_pSrcUser->m_iUserId, sendIndex);
-				SetShort(sendBuffer, pNpc->m_sNid + NPC_BAND, sendIndex);
-				SetShort(sendBuffer, data1, sendIndex);
-				SetShort(sendBuffer, result, sendIndex);
-				SetShort(sendBuffer, data3, sendIndex);
-				SetShort(sendBuffer, moral, sendIndex);
-				SetShort(sendBuffer, 0, sendIndex);
-				SetShort(sendBuffer, 0, sendIndex);
-
-				m_pMain->Send(sendBuffer, sendIndex, m_pSrcUser->m_curZone);
-			}
+			if (usesPerTargetAnimation)
+				SendPerTargetAnimation(
+					magicid, pNpc->m_sNid + NPC_BAND, data1, result, data3, moral);
 		}
 		// 타잎 4일 경우...
 		else if (magictype == 4)

--- a/src/Server/AIServer/MagicProcess.h
+++ b/src/Server/AIServer/MagicProcess.h
@@ -46,6 +46,13 @@ public:
 
 	model::Magic* IsAvailable(int magicid, int tid, uint8_t type);
 	void MagicPacket(char* pBuf);
+
+private:
+	bool UsesAreaCenteredAnimation(const model::Magic* pMagic) const;
+	bool UsesPerTargetAnimation(const model::Magic* pMagic) const;
+	void SendAreaCenteredAnimation(int magicid, int moral, int data1, int data2, int data3) const;
+	void SendPerTargetAnimation(
+		int magicid, int targetId, int data1, int result, int data3, int moral) const;
 };
 
 } // namespace AIServer

--- a/src/Server/Ebenezer/MagicProcess.cpp
+++ b/src/Server/Ebenezer/MagicProcess.cpp
@@ -62,6 +62,83 @@ CMagicProcess::~CMagicProcess()
 {
 }
 
+bool CMagicProcess::UsesAreaCenteredAnimation(const model::Magic* pMagic, int tid) const
+{
+	if (pMagic == nullptr || tid != -1)
+		return false;
+
+	// TargetEffect 2900-2999 are large ground-area FX (e.g. novas).
+	// If sent per target, the client draws the big center effect on every damaged unit.
+	return (pMagic->Moral == MORAL_AREA_ENEMY || pMagic->Moral == MORAL_AREA_ALL
+			   || pMagic->Moral == MORAL_SELF_AREA)
+		   && pMagic->FlyingEffect == 0 && pMagic->TargetEffect >= 2900
+		   && pMagic->TargetEffect < 3000;
+}
+
+bool CMagicProcess::UsesPerTargetAnimation(const model::Magic* pMagic, int tid) const
+{
+	return !UsesAreaCenteredAnimation(pMagic, tid);
+}
+
+void CMagicProcess::SendAreaCenteredAnimation(
+	int magicid, int sid, int data1, int data2, int data3, bool isNpcSource, CNpc* pMon) const
+{
+	int sendIndex = 0;
+	char sendBuffer[128] {};
+
+	SetByte(sendBuffer, WIZ_MAGIC_PROCESS, sendIndex);
+	SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
+	SetDWORD(sendBuffer, magicid, sendIndex);
+	SetShort(sendBuffer, sid, sendIndex);
+	SetShort(sendBuffer, -1, sendIndex);
+	SetShort(sendBuffer, data1, sendIndex);
+	SetShort(sendBuffer, data2, sendIndex);
+	SetShort(sendBuffer, data3, sendIndex);
+
+	if (!isNpcSource)
+	{
+		if (m_pSrcUser != nullptr)
+		{
+			m_pMain->Send_Region(sendBuffer, sendIndex, m_pSrcUser->m_pUserData->m_bZone,
+				m_pSrcUser->m_RegionX, m_pSrcUser->m_RegionZ, nullptr, false);
+		}
+	}
+	else if (pMon != nullptr)
+	{
+		m_pMain->Send_Region(sendBuffer, sendIndex, pMon->m_sCurZone, pMon->m_sRegion_X,
+			pMon->m_sRegion_Z, nullptr, false);
+	}
+}
+
+void CMagicProcess::SendPerTargetAnimation(int magicid, int sid, int targetId, int data1,
+	int result, int data3, bool isNpcSource, CNpc* pMon) const
+{
+	int sendIndex = 0;
+	char sendBuffer[128] {};
+
+	SetByte(sendBuffer, WIZ_MAGIC_PROCESS, sendIndex);
+	SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
+	SetDWORD(sendBuffer, magicid, sendIndex);
+	SetShort(sendBuffer, sid, sendIndex);
+	SetShort(sendBuffer, targetId, sendIndex);
+	SetShort(sendBuffer, data1, sendIndex);
+	SetShort(sendBuffer, result, sendIndex);
+	SetShort(sendBuffer, data3, sendIndex);
+	if (!isNpcSource)
+	{
+		if (m_pSrcUser != nullptr)
+		{
+			m_pMain->Send_Region(sendBuffer, sendIndex, m_pSrcUser->m_pUserData->m_bZone,
+				m_pSrcUser->m_RegionX, m_pSrcUser->m_RegionZ, nullptr, false);
+		}
+	}
+	else if (pMon != nullptr)
+	{
+		m_pMain->Send_Region(sendBuffer, sendIndex, pMon->m_sCurZone, pMon->m_sRegion_X,
+			pMon->m_sRegion_Z, nullptr, false);
+	}
+}
+
 void CMagicProcess::MagicPacket(char* pBuf)
 {
 	model::Magic* pTable = nullptr;
@@ -1252,7 +1329,7 @@ packet_send:
 	return result;
 }
 
-void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int /*data2*/,
+void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int data2,
 	int data3)      // Applied when a magical attack, healing, and mana restoration is done.
 {
 	int damage = 0, duration_damage = 0, sendIndex = 0,
@@ -1343,6 +1420,12 @@ void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int /
 		casted_member.reserve(1); // don't bother allocating for more than 1
 		casted_member.push_back(tid);
 	}
+
+	const bool usesAreaCenteredAnimation = UsesAreaCenteredAnimation(pMagic, tid);
+	const bool usesPerTargetAnimation    = UsesPerTargetAnimation(pMagic, tid);
+
+	if ((pMagic->Type2 == 0 || pMagic->Type2 == 3) && usesAreaCenteredAnimation)
+		SendAreaCenteredAnimation(magicid, sid, data1, data2, data3, bFlag, pMon);
 
 	// THIS IS WHERE THE FUN STARTS!!!
 	for (int userId : casted_member)
@@ -1587,30 +1670,8 @@ void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int /
 			//
 		}
 
-		if (pMagic->Type2 == 0 || pMagic->Type2 == 3)
-		{
-			SetByte(sendBuffer, WIZ_MAGIC_PROCESS, sendIndex);
-			SetByte(sendBuffer, MAGIC_EFFECTING, sendIndex);
-			SetDWORD(sendBuffer, magicid, sendIndex);
-			SetShort(sendBuffer, sid, sendIndex);
-			SetShort(sendBuffer, userId, sendIndex);
-			SetShort(sendBuffer, data1, sendIndex);
-			SetShort(sendBuffer, result, sendIndex);
-			SetShort(sendBuffer, data3, sendIndex);
-			if (!bFlag)
-			{
-				if (m_pSrcUser != nullptr)
-				{
-					m_pMain->Send_Region(sendBuffer, sendIndex, m_pSrcUser->m_pUserData->m_bZone,
-						m_pSrcUser->m_RegionX, m_pSrcUser->m_RegionZ, nullptr, false);
-				}
-			}
-			else if (pMon != nullptr)
-			{
-				m_pMain->Send_Region(sendBuffer, sendIndex, pMon->m_sCurZone, pMon->m_sRegion_X,
-					pMon->m_sRegion_Z, nullptr, false);
-			}
-		}
+		if ((pMagic->Type2 == 0 || pMagic->Type2 == 3) && usesPerTargetAnimation)
+			SendPerTargetAnimation(magicid, sid, userId, data1, result, data3, bFlag, pMon);
 
 		// Heal magic
 		if (pType->DirectType == 1 && damage > 0)

--- a/src/Server/Ebenezer/MagicProcess.h
+++ b/src/Server/Ebenezer/MagicProcess.h
@@ -23,6 +23,7 @@ enum e_ResistanceType : uint8_t
 
 class EbenezerApp;
 class CUser;
+class CNpc;
 class CMagicProcess
 {
 public:
@@ -54,6 +55,14 @@ public:
 	EbenezerApp* m_pMain  = nullptr;
 	CUser* m_pSrcUser     = nullptr;
 	uint8_t m_bMagicState = 0;
+
+private:
+	bool UsesAreaCenteredAnimation(const model::Magic* pMagic, int tid) const;
+	bool UsesPerTargetAnimation(const model::Magic* pMagic, int tid) const;
+	void SendAreaCenteredAnimation(
+		int magicid, int sid, int data1, int data2, int data3, bool isNpcSource, CNpc* pMon) const;
+	void SendPerTargetAnimation(int magicid, int sid, int targetId, int data1, int result,
+		int data3, bool isNpcSource, CNpc* pMon) const;
 };
 
 } // namespace Ebenezer


### PR DESCRIPTION
                                                                                                      
Implemented mage AoE visual fix in both server paths :
                                                                                                                                                               
  - Ebenezer/MagicProcess: player-cast Type3 AoE handling.                                                                                                     
  - AIServer/MagicProcess: NPC/AI-cast Type3 AoE handling.
                                                                                                                                                               
  Main behavior changes:                                                                                                                                        
                                                                                                                                                               
  - Skills with area-centered target FX, such as mage level 45+ AoEs/novas using TargetEffect IDs in the 2900-2999 range, now send one area-centered visual packet with targetId = -1.                                                                                                                          
  - Skills that should show per-target hit visuals, such as level 33 mage AoEs, still send visuals per damaged target.                                         
  - Damage application remains per affected target; only a new visual packet was added.                                                                       


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
Related issue : https://github.com/Open-KO/KnightOnline/issues/415
Some AoE skills apply the FX animation to each affected target (i.e. Inferno, Novas, etc) instead of apply the FX animations once at the center of the AoE.

## What is the new behaviour?
Packets affecting each target is still sent, but without visual FX.
An additional packet is sent with a visual FX at the center of the AoE. 

## Why and how did I change this?                                                                                                                                                               
The implementation adds helper private methods with explicit names:                                                                                               
  - UsesAreaCenteredAnimation                                                                                                                                  
  - SendAreaCenteredAnimation                                                                                                                                  
  - UsesPerTargetAnimation                                                                                                                                     
  - SendPerTargetAnimation                            

## Was AI used at some point for any part of this change? If so, what?
- Problem finding
- Code explaining
- Solutions proposal

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [ ] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
