### PR TITLE
plug glow fx fix

### DIFF
--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -1376,6 +1376,7 @@ inline constexpr int FXID_WARP_ELMORAD            = 10047;
 inline constexpr int FXID_REGION_POISON           = 10100;
 inline constexpr int FXID_TARGET_POINTER          = 30001;
 inline constexpr int FXID_ZONE_POINTER            = 30002;
+inline constexpr int FXID_ELIXIRSTAFF_SPECIALCASE = 40000000;
 
 enum e_SkillMagicType4 : uint8_t
 {

--- a/src/Client/WarFare/GameDef.h
+++ b/src/Client/WarFare/GameDef.h
@@ -1376,7 +1376,7 @@ inline constexpr int FXID_WARP_ELMORAD            = 10047;
 inline constexpr int FXID_REGION_POISON           = 10100;
 inline constexpr int FXID_TARGET_POINTER          = 30001;
 inline constexpr int FXID_ZONE_POINTER            = 30002;
-inline constexpr int FXID_ELIXIRSTAFF_SPECIALCASE = 40000000;
+inline constexpr int FXID_ELIXIRSTAFF_SPECIALCASE = 40000;
 
 enum e_SkillMagicType4 : uint8_t
 {

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1767,14 +1767,9 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	// plug 효과 붙여라..^^
 	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
-		uint32_t dwFXMainID = pItemExt->dwIDK0;
-		uint32_t dwFXTailID = pItemExt->dwIDK0 + 1; // fx table shows that plus 1 is correspondant tail fx
-
-		if (pItemBasic && pItemBasic->dwEffectID2 > 0) // plugs with overriden fx are stored in base table dwEffectID2. This is where raptor and glave fx's are differentiated.
-		{
-			dwFXMainID = pItemBasic->dwEffectID2;
-			dwFXTailID = pItemBasic->dwEffectID2 + 1;
-		}
+		bool hasOverride    = (pItemBasic && pItemBasic->dwEffectID2 > 0);
+		uint32_t dwFXMainID = hasOverride ? pItemBasic->dwEffectID2 : pItemExt->dwIDK0;
+		uint32_t dwFXTailID = dwFXMainID + 1;
 
 		CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
 		__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(dwFXMainID);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1768,7 +1768,7 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
 		//  We need to determine fx overrides if needed. e.g raptor and glave. This is determined by base table where dwEffectID2 > 0
-		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 / 1000 : pItemExt->dwIDK0;
+		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0 && pItemExt->byMagicOrRare == ITEM_ATTRIB_UPGRADE) ? pItemBasic->dwEffectID2 / 1000 : pItemExt->dwIDK0;
 
 		if (dwFXMainID == (FXID_ELIXIRSTAFF_SPECIALCASE))
 			dwFXMainID += (pItemExt->byDamageThuner > pItemExt->byDamageIce && pItemExt->byDamageThuner > pItemExt->byDamageFire) ? 20 : (pItemExt->byDamageIce > pItemExt->byDamageFire) ? 10 : 0;

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1765,83 +1765,32 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 	//
 	// plug 효과 붙여라..^^
-	if (pItemExt)
+	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
-		if ((pItemExt->byMagicOrRare == ITEM_ATTRIB_UNIQUE && pItemExt->byDamageFire > 0)
-			|| (pItemExt->byDamageFire >= LIMIT_FX_DAMAGE)) // 17 추가데미지 - 불
+		uint32_t dwFXMainID = pItemExt->dwIDK0;
+		uint32_t dwFXTailID = pItemExt->dwIDK0 + 1; // fx table shows that plus 1 is correspondant tail fx
+
+		if (pItemBasic && pItemBasic->dwEffectID2 > 0) // plugs with overriden fx are stored in base table dwEffectID2. This is where raptor and glave fx's are differentiated.
 		{
-			CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
-			__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(FXID_SWORD_FIRE_MAIN);
-			__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(FXID_SWORD_FIRE_TAIL);
-
-			std::string szFXMain, szFXTail;
-			if (pFXMain)
-				szFXMain = pFXMain->szFN;
-			else
-				szFXMain = "";
-			if (pFXTail)
-				szFXTail = pFXTail->szFN;
-			else
-				szFXTail = "";
-			pCPlug->InitFX(szFXMain, szFXTail, 0xffffff00);
+			dwFXMainID = pItemBasic->dwEffectID2;
+			dwFXTailID = pItemBasic->dwEffectID2 + 1;
 		}
-		else if ((pItemExt->byMagicOrRare == ITEM_ATTRIB_UNIQUE && pItemExt->byDamageIce > 0)
-				 || (pItemExt->byDamageIce >= LIMIT_FX_DAMAGE)) // 18 추가데미지 - 얼음
-		{
-			CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
-			__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(FXID_SWORD_ICE_MAIN);
-			__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(FXID_SWORD_ICE_TAIL);
 
-			std::string szFXMain, szFXTail;
-			if (pFXMain)
-				szFXMain = pFXMain->szFN;
-			else
-				szFXMain = "";
-			if (pFXTail)
-				szFXTail = pFXTail->szFN;
-			else
-				szFXTail = "";
+		CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
+		__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(dwFXMainID);
+		__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(dwFXTailID);
 
-			pCPlug->InitFX(szFXMain, szFXTail, 0xff0000ff);
-		}
-		else if ((pItemExt->byMagicOrRare == ITEM_ATTRIB_UNIQUE && pItemExt->byDamageThuner > 0)
-				 || (pItemExt->byDamageThuner >= LIMIT_FX_DAMAGE)) // 19 추가데미지 - 전격
-		{
-			CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
-			__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(FXID_SWORD_LIGHTNING_MAIN);
-			__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(FXID_SWORD_LIGHTNING_TAIL);
+		std::string szFXMain, szFXTail;
+		if (pFXMain)
+			szFXMain = pFXMain->szFN;
+		else
+			szFXMain = "";
+		if (pFXTail)
+			szFXTail = pFXTail->szFN;
+		else
+			szFXTail = "";
 
-			std::string szFXMain, szFXTail;
-			if (pFXMain)
-				szFXMain = pFXMain->szFN;
-			else
-				szFXMain = "";
-			if (pFXTail)
-				szFXTail = pFXTail->szFN;
-			else
-				szFXTail = "";
-
-			pCPlug->InitFX(szFXMain, szFXTail, 0xffffffff);
-		}
-		else if ((pItemExt->byMagicOrRare == ITEM_ATTRIB_UNIQUE && pItemExt->byDamagePoison > 0)
-				 || (pItemExt->byDamagePoison >= LIMIT_FX_DAMAGE)) // 20 추가데미지 - 독
-		{
-			CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
-			__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(FXID_SWORD_POISON_MAIN);
-			__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(FXID_SWORD_POISON_TAIL);
-
-			std::string szFXMain, szFXTail;
-			if (pFXMain)
-				szFXMain = pFXMain->szFN;
-			else
-				szFXMain = "";
-			if (pFXTail)
-				szFXTail = pFXTail->szFN;
-			else
-				szFXTail = "";
-
-			pCPlug->InitFX(szFXMain, szFXTail, 0xffff00ff);
-		}
+		pCPlug->InitFX(szFXMain, szFXTail, 0xffffffff);
 	}
 	//
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1768,8 +1768,13 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
 		//  We need to determine fx overrides if needed. e.g raptor and glave. This is determined by base table where dwEffectID2 > 0
-		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 : pItemExt->dwIDK0;
+		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 / 1000 : pItemExt->dwIDK0;
 
+		if (dwFXMainID == FXID_ELIXIRSTAFF_SPECIALCASE) // 40M divide it by 1000 and then you add offset to it to get fx id.
+		{
+			dwFXMainID /= 1000;
+			dwFXMainID += (pItemExt->byDamageThuner > pItemExt->byDamageIce && pItemExt->byDamageThuner > pItemExt->byDamageFire) ? 20 : (pItemExt->byDamageIce > pItemExt->byDamageFire) ? 10 : 0;
+		}
 		__TABLE_FX* pFXMain  = s_pTbl_FXSource.Find(dwFXMainID);
 		__TABLE_FX* pFXTail  = s_pTbl_FXSource.Find(dwFXMainID + 1); // Tail always = Main + 1 fx table shows this.
 		

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1767,9 +1767,9 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	// plug 효과 붙여라..^^
 	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
-		bool hasOverride    = (pItemBasic && pItemBasic->dwEffectID2 > 0);
+		bool hasOverride    = (pItemBasic && pItemBasic->dwEffectID2 > 0); // flag that determines different fx overrides e.g raptor and glave
 		uint32_t dwFXMainID = hasOverride ? pItemBasic->dwEffectID2 : pItemExt->dwIDK0;
-		uint32_t dwFXTailID = dwFXMainID + 1;
+		uint32_t dwFXTailID = dwFXMainID + 1;  // fx table shows that tail is always main + 1
 
 		CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
 		__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(dwFXMainID);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1767,25 +1767,16 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 	// plug 효과 붙여라..^^
 	if (pItemExt && pItemExt->dwIDK0 > 0)
 	{
-		bool hasOverride    = (pItemBasic && pItemBasic->dwEffectID2 > 0); // flag that determines different fx overrides e.g raptor and glave
-		uint32_t dwFXMainID = hasOverride ? pItemBasic->dwEffectID2 : pItemExt->dwIDK0;
-		uint32_t dwFXTailID = dwFXMainID + 1;  // fx table shows that tail is always main + 1
+		//  We need to determine fx overrides if needed. e.g raptor and glave. This is determined by base table where dwEffectID2 > 0
+		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 : pItemExt->dwIDK0;
 
-		CN3CPlug* pCPlug    = (CN3CPlug*) pPlug;
-		__TABLE_FX* pFXMain = s_pTbl_FXSource.Find(dwFXMainID);
-		__TABLE_FX* pFXTail = s_pTbl_FXSource.Find(dwFXTailID);
+		__TABLE_FX* pFXMain  = s_pTbl_FXSource.Find(dwFXMainID);
+		__TABLE_FX* pFXTail  = s_pTbl_FXSource.Find(dwFXMainID + 1); // Tail always = Main + 1 fx table shows this.
+		
+		std::string szFXMain = pFXMain ? pFXMain->szFN : "";
+		std::string szFXTail = pFXTail ? pFXTail->szFN : "";
 
-		std::string szFXMain, szFXTail;
-		if (pFXMain)
-			szFXMain = pFXMain->szFN;
-		else
-			szFXMain = "";
-		if (pFXTail)
-			szFXTail = pFXTail->szFN;
-		else
-			szFXTail = "";
-
-		pCPlug->InitFX(szFXMain, szFXTail, 0xffffffff);
+		((CN3CPlug*) pPlug)->InitFX(szFXMain, szFXTail, 0xffffffff);
 	}
 	//
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1770,7 +1770,7 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 		//  We need to determine fx overrides if needed. e.g raptor and glave. This is determined by base table where dwEffectID2 > 0
 		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 / 1000 : pItemExt->dwIDK0;
 
-		if (dwFXMainID == (FXID_ELIXIRSTAFF_SPECIALCASE / 1000)) // 40M divide it by 1000 and then you add offset to it to get fx id.
+		if (dwFXMainID == (FXID_ELIXIRSTAFF_SPECIALCASE))
 			dwFXMainID += (pItemExt->byDamageThuner > pItemExt->byDamageIce && pItemExt->byDamageThuner > pItemExt->byDamageFire) ? 20 : (pItemExt->byDamageIce > pItemExt->byDamageFire) ? 10 : 0;
 
 		__TABLE_FX* pFXMain  = s_pTbl_FXSource.Find(dwFXMainID);

--- a/src/Client/WarFare/PlayerBase.cpp
+++ b/src/Client/WarFare/PlayerBase.cpp
@@ -1770,11 +1770,9 @@ CN3CPlugBase* CPlayerBase::PlugSet(e_PlugPosition ePos, const std::string& szFN,
 		//  We need to determine fx overrides if needed. e.g raptor and glave. This is determined by base table where dwEffectID2 > 0
 		uint32_t dwFXMainID  = (pItemBasic && pItemBasic->dwEffectID2 > 0) ? pItemBasic->dwEffectID2 / 1000 : pItemExt->dwIDK0;
 
-		if (dwFXMainID == FXID_ELIXIRSTAFF_SPECIALCASE) // 40M divide it by 1000 and then you add offset to it to get fx id.
-		{
-			dwFXMainID /= 1000;
+		if (dwFXMainID == (FXID_ELIXIRSTAFF_SPECIALCASE / 1000)) // 40M divide it by 1000 and then you add offset to it to get fx id.
 			dwFXMainID += (pItemExt->byDamageThuner > pItemExt->byDamageIce && pItemExt->byDamageThuner > pItemExt->byDamageFire) ? 20 : (pItemExt->byDamageIce > pItemExt->byDamageFire) ? 10 : 0;
-		}
+
 		__TABLE_FX* pFXMain  = s_pTbl_FXSource.Find(dwFXMainID);
 		__TABLE_FX* pFXTail  = s_pTbl_FXSource.Find(dwFXMainID + 1); // Tail always = Main + 1 fx table shows this.
 		


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
Currently, the item glow logic is hardcoded and incorrect. It indiscriminately applies a glow to items with an elemental damage value over 64. Not only this causes an issue where Type 5 items at the +7 falsely glow ( they should not be glowed at all ) but also it incorrectly applies a single, identical FX to all plugs with same elemental .

## What is the new behaviour?
The new behaviour accurately matches the original 1298 client executable's glow logic. It correctly distinguishes between different item types and applies the appropriate elemental FX based on the item's properties.

## Why and how did I change this?
The `base` and `extension` and `fx` TBL files actually provide the necessary data structure to determine how the effects should be applied. Assuming familiarity with the original 1298 client's visual effects (for instance, rare items and upgrade items are supposed to have distinct FX), I refactored the glow logic to utilize the TBL data rather than relying on the incorrect hardcoded threshold.

TailFX is always be plus 1 that of the MainFX.
Plugs that have same elemental but different fx like Raptor and Glave should be overriden which is done by base table where dwEffectID2>0
Other than that it should always follow extension table EffectID which is dwIDK0 in codebase.

## Was AI used at some point for any part of this change? If so, what?
No.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->
<img width="1021" height="795" alt="dark vane" src="https://github.com/user-attachments/assets/ba13c0d6-cd53-4671-8242-4b2a0c82a6ea" />

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).