### PR TITLE
Fix: CN3UIWndBase sounds should be 2D

### DIFF
--- a/src/Client/WarFare/N3UIWndBase.cpp
+++ b/src/Client/WarFare/N3UIWndBase.cpp
@@ -1,4 +1,4 @@
-﻿// N3UIWndBase.cpp: implementation of the CN3UIWndBase class.
+// N3UIWndBase.cpp: implementation of the CN3UIWndBase class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -40,11 +40,11 @@ CN3UIWndBase::CN3UIWndBase()
 
 	if (s_iRefCount == 0)
 	{
-		s_pSnd_Item_Etc    = s_SndMgr.CreateObj(ID_SOUND_ITEM_ETC_IN_INVENTORY);
-		s_pSnd_Item_Weapon = s_SndMgr.CreateObj(ID_SOUND_ITEM_WEAPON_IN_INVENTORY);
-		s_pSnd_Item_Armor  = s_SndMgr.CreateObj(ID_SOUND_ITEM_ARMOR_IN_INVENTORY);
-		s_pSnd_Gold        = s_SndMgr.CreateObj(ID_SOUND_GOLD_IN_INVENTORY);
-		s_pSnd_Repair      = s_SndMgr.CreateObj(ID_SOUND_ITEM_IN_REPAIR);
+		s_pSnd_Item_Etc    = s_SndMgr.CreateObj(ID_SOUND_ITEM_ETC_IN_INVENTORY, SNDTYPE_2D);
+		s_pSnd_Item_Weapon = s_SndMgr.CreateObj(ID_SOUND_ITEM_WEAPON_IN_INVENTORY, SNDTYPE_2D);
+		s_pSnd_Item_Armor  = s_SndMgr.CreateObj(ID_SOUND_ITEM_ARMOR_IN_INVENTORY, SNDTYPE_2D);
+		s_pSnd_Gold        = s_SndMgr.CreateObj(ID_SOUND_GOLD_IN_INVENTORY, SNDTYPE_2D);
+		s_pSnd_Repair      = s_SndMgr.CreateObj(ID_SOUND_ITEM_IN_REPAIR, SNDTYPE_2D);
 	}
 	s_iRefCount++; // 참조 카운트
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Be clear. Assume nobody knows what you're talking about. -->

UI sounds (item pickup, weapon, armor, gold, repair) in `N3UIWndBase` are initialized via `s_SndMgr.CreateObj()` without specifying a sound type. The default parameter is `SNDTYPE_3D`, which means these sounds are treated as positional 3D sounds. Since UI sounds have no 3D position in the world, they end up being silent.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. Be clear. Assume nobody knows what you're talking about. -->

UI sounds are now explicitly initialized with `SNDTYPE_2D`, so they play correctly as non-positional 2D sounds regardless of the listener's position in the world.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this. This should be more than just "this was broken". -->

I wrote SNDTYPE_2D

## Was AI used at some point for any part of this change? If so, what?
<!-- Please specify any and all areas where AI was used here. -->

Yes. I told it to enforce 2d sound types while init. And it did.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

N/A — audio fix, sounds that were previously silent now play as expected.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).