### PR TITLE
CountableItemEditDlg and caller window's now work as expected

### DIFF
--- a/src/Client/WarFare/CountableItemEditDlg.cpp
+++ b/src/Client/WarFare/CountableItemEditDlg.cpp
@@ -1,10 +1,11 @@
-﻿// CountableItemEditDlg.cpp: implementation of the CCountableItemEditDlg class.
+// CountableItemEditDlg.cpp: implementation of the CCountableItemEditDlg class.
 //
 //////////////////////////////////////////////////////////////////////
 
 #include "StdAfx.h"
 #include "text_resources.h"
 #include "CountableItemEditDlg.h"
+#include "N3UIWndBase.h"
 
 #include "GameProcedure.h"
 #include "GameProcMain.h"
@@ -174,6 +175,20 @@ bool CCountableItemEditDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 
 void CCountableItemEditDlg::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountGold, bool bWareGold)
 {
+	m_eCallerWnd         = eUW;
+	m_eCallerWndDistrict = eUD;
+	m_bWareGold          = bWareGold;
+
+	int iStackSize       = -1;
+	if (!bCountGold && CN3UIWndBase::s_sSelectedIconInfo.pItemSelect != nullptr)
+	{
+		bool bToMeOrNotToMe = (eUW == UIWND_TRANSACTION && eUD == UIWND_DISTRICT_TRADE_NPC); // that is the question...
+		if (!bToMeOrNotToMe)
+		{
+			iStackSize = CN3UIWndBase::s_sSelectedIconInfo.pItemSelect->iCount;
+		}
+	}
+
 	std::string szMsg;
 	if (bCountGold)
 		szMsg = fmt::format_text_resource(IDS_EDIT_BOX_GOLD);
@@ -189,7 +204,7 @@ void CCountableItemEditDlg::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountG
 	int iCX = 0, iCY = 0;
 
 	m_bLocked = true;
-	SetQuantity(-1);
+	SetQuantity(iStackSize);
 
 	SetVisible(true);
 
@@ -197,10 +212,6 @@ void CCountableItemEditDlg::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountG
 	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 	if (pEdit != nullptr)
 		pEdit->SetFocus();
-
-	m_eCallerWnd         = eUW;
-	m_eCallerWndDistrict = eUD;
-	m_bWareGold          = bWareGold;
 
 	switch (eUW)
 	{

--- a/src/Client/WarFare/CountableItemEditDlg.h
+++ b/src/Client/WarFare/CountableItemEditDlg.h
@@ -1,4 +1,4 @@
-﻿// CountableItemEditDlg.h: interface for the CCountableItemEditDlg class.
+// CountableItemEditDlg.h: interface for the CCountableItemEditDlg class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -40,6 +40,13 @@ public:
 
 	virtual void Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountGold, bool bWareGold = false);
 	virtual void Close();
+
+	void SetCallerInfo(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bWareGold = false)
+	{
+		m_eCallerWnd         = eUW;
+		m_eCallerWndDistrict = eUD;
+		m_bWareGold          = bWareGold;
+	}
 
 	bool IsLocked()
 	{

--- a/src/Client/WarFare/UIPerTradeDlg.cpp
+++ b/src/Client/WarFare/UIPerTradeDlg.cpp
@@ -1,4 +1,4 @@
-﻿// UIPerTradeDlg.cpp: implementation of the CUIPerTradeDlg class.
+// UIPerTradeDlg.cpp: implementation of the CUIPerTradeDlg class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -664,7 +664,16 @@ bool CUIPerTradeDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 		// 활이나 물약등 아이템인 경우..
 		s_bWaitFromServer  = false;
-		s_pCountableItemEdit->Open(UIWND_PER_TRADE, UIWND_DISTRICT_PER_TRADE_MY, false);
+		if (s_sSelectedIconInfo.pItemSelect != nullptr && s_sSelectedIconInfo.pItemSelect->iCount == 1)
+		{
+			s_pCountableItemEdit->SetCallerInfo(UIWND_PER_TRADE, UIWND_DISTRICT_PER_TRADE_MY, false);
+			s_pCountableItemEdit->SetQuantity(1);
+			ItemCountOK();
+		}
+		else
+		{
+			s_pCountableItemEdit->Open(UIWND_PER_TRADE, UIWND_DISTRICT_PER_TRADE_MY, false);
+		}
 
 		AllHighLightIconFree();
 		SetState(UI_STATE_COMMON_NONE);

--- a/src/Client/WarFare/UITransactionDlg.cpp
+++ b/src/Client/WarFare/UITransactionDlg.cpp
@@ -1,4 +1,4 @@
-﻿// UITransactionDlg.cpp: implementation of the CUITransactionDlg class.
+// UITransactionDlg.cpp: implementation of the CUITransactionDlg class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -998,7 +998,18 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					s_sRecoveryJobInfo.UIWndSourceEnd.iOrder = iDestInviOrder;
 					s_bWaitFromServer                        = false;
 
-					s_pCountableItemEdit->Open(UIWND_TRANSACTION, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					if (s_sSelectedIconInfo.pItemSelect != nullptr && s_sSelectedIconInfo.pItemSelect->iCount == 1
+						&& s_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_NPC)
+					{
+						auto eDist = s_sSelectedIconInfo.UIWndSelect.UIWndDistrict;
+						s_pCountableItemEdit->SetCallerInfo(UIWND_TRANSACTION, eDist, false);
+						s_pCountableItemEdit->SetQuantity(1);
+						ItemCountOK();
+					}
+					else
+					{
+						s_pCountableItemEdit->Open(UIWND_TRANSACTION, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					}
 					return false;
 				}
 
@@ -1112,7 +1123,18 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					|| s_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)
 				{
 					// 활이나 물약등 아이템인 경우..
-					s_pCountableItemEdit->Open(UIWND_TRANSACTION, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					if (s_sSelectedIconInfo.pItemSelect != nullptr && s_sSelectedIconInfo.pItemSelect->iCount == 1
+						&& s_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_NPC)
+					{
+						auto eDist = s_sSelectedIconInfo.UIWndSelect.UIWndDistrict;
+						s_pCountableItemEdit->SetCallerInfo(UIWND_TRANSACTION, eDist, false);
+						s_pCountableItemEdit->SetQuantity(1);
+						ItemCountOK();
+					}
+					else
+					{
+						s_pCountableItemEdit->Open(UIWND_TRANSACTION, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					}
 				}
 				else
 				{

--- a/src/Client/WarFare/UIWareHouseDlg.cpp
+++ b/src/Client/WarFare/UIWareHouseDlg.cpp
@@ -1,4 +1,4 @@
-﻿// UIWareHouseDlg.cpp: implementation of the UIWareHouseDlg class.
+// UIWareHouseDlg.cpp: implementation of the UIWareHouseDlg class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -764,7 +764,16 @@ bool CUIWareHouseDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					s_sRecoveryJobInfo.UIWndSourceEnd.iOrder = iDestiOrder;
 					s_bWaitFromServer                        = false;
 
-					s_pCountableItemEdit->Open(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					if (s_sSelectedIconInfo.pItemSelect != nullptr && s_sSelectedIconInfo.pItemSelect->iCount == 1)
+					{
+						s_pCountableItemEdit->SetCallerInfo(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+						s_pCountableItemEdit->SetQuantity(1);
+						ItemCountOK();
+					}
+					else
+					{
+						s_pCountableItemEdit->Open(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					}
 				}
 				else
 				{
@@ -942,7 +951,16 @@ bool CUIWareHouseDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 					s_bWaitFromServer = false;
 
-					s_pCountableItemEdit->Open(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					if (s_sSelectedIconInfo.pItemSelect != nullptr && s_sSelectedIconInfo.pItemSelect->iCount == 1)
+					{
+						s_pCountableItemEdit->SetCallerInfo(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+						s_pCountableItemEdit->SetQuantity(1);
+						ItemCountOK();
+					}
+					else
+					{
+						s_pCountableItemEdit->Open(UIWND_WARE_HOUSE, s_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
+					}
 					return false;
 				}
 

--- a/src/N3Base/N3UIEdit.cpp
+++ b/src/N3Base/N3UIEdit.cpp
@@ -1,4 +1,4 @@
-﻿// N3UIEdit.cpp: implementation of the CN3UIEdit class.
+// N3UIEdit.cpp: implementation of the CN3UIEdit class.
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -293,6 +293,8 @@ bool CN3UIEdit::SetFocus()
 			else
 				::SetWindowText(s_hWndEdit, "");
 		}
+
+		::SendMessage(s_hWndEdit, EM_SETSEL, 0, -1);
 	}
 
 	return true;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
**Title:** Improve Countable Item Dialog UX, auto-focus,

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Be clear. Assume nobody knows what you're talking about. -->
Previously, the `CCountableItemEditDlg` (the popup for splitting stackable items) lacked several Quality of Life features:
1. It didn't show the total stack size the player currently possessed.
2. The dialog would open unnecessarily even if the player only had exactly 1 item in the stack.
3. The input field was not automatically focused when the dialog opened, requiring the player to perform an extra mouse click just to edit the amount.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. Be clear. Assume nobody knows what you're talking about. -->
- The dialog now automatically populates and displays the item's maximum stack size.
- The dialog input field is automatically focused upon opening, allowing players to start typing the amount immediately.
- The dialog intelligently bypasses the prompt if the item count is exactly 1, executing the transaction instantly.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this. This should be more than just "this was broken". -->
The primary goal was to improve the UX for handling stackable items.

## Was AI used at some point for any part of this change? If so, what?
<!-- Please specify any and all areas where AI was used here. -->
Yes. It did the pr layout and pretty much everything else.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->
N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).