### PR TITLE
CGameProcMain: fix unused var warning

### DIFF
--- a/src/Client/WarFare/GameProcMain.cpp
+++ b/src/Client/WarFare/GameProcMain.cpp
@@ -2802,7 +2802,7 @@ bool CGameProcMain::MsgRecv_UserInAndRequest(Packet& pkt)
 
 		itID    = m_SetUPCID.begin();
 		itIDEnd = m_SetUPCID.end();
-		for (int i = 0; itID != itIDEnd; itID++, i++)
+		for (; itID != itIDEnd; itID++)
 		{
 			iID = *itID;
 			CAPISocket::MP_AddShort(&byBuff[0], iOffset, iID); // 자세한 정보가 필요한 아이디들..
@@ -3152,7 +3152,7 @@ bool CGameProcMain::MsgRecv_NPCInAndRequest(Packet& pkt)
 
 		itID    = m_SetNPCID.begin();
 		itIDEnd = m_SetNPCID.end();
-		for (int i = 0; itID != itIDEnd; itID++, i++)
+		for (; itID != itIDEnd; itID++)
 		{
 			iID = *itID;
 			CAPISocket::MP_AddShort(&byBuff[0], iOffset, iID); // 자세한 정보가 필요한 아이디들..


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Be clear. Assume nobody knows what you're talking about. -->

Running the project for the first time, I was following the Linux + CLion instructions, everything worked great except client build was failing due to unused var error. It was easier to fix than to figure out how to suppress. 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
